### PR TITLE
Add UserAS and AttachmentPoint to data model

### DIFF
--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -16,6 +16,8 @@ from django.contrib import admin
 from .models import (
     ISD,
     AS,
+    UserAS,
+    AttachmentPoint,
     Host,
     ManagedHost,
     Interface,
@@ -28,6 +30,8 @@ from .models import (
 admin.site.register([
     ISD,
     AS,
+    UserAS,
+    AttachmentPoint,
     Host,
     ManagedHost,
     Interface,

--- a/scionlab/models.py
+++ b/scionlab/models.py
@@ -36,17 +36,15 @@ class AS(models.Model):
         related_name='ases',
         on_delete=models.CASCADE
     )
-
-    as_id = models.CharField(max_length=15, primary_key=True)
+    as_id = models.CharField(max_length=15)
     label = models.CharField(max_length=_MAX_LEN_DEFAULT, null=True, blank=True)
 
-    # subnet = models.CharField(max_length=15) # AS internal subnet
-    # vpn = models.ForeignKey(                 # AS internal VPN
-    #     'VPN',
-    #     null=True,
-    #     related_name='ases',
-    #     on_delete=models.SET_NULL
-    # )
+    owner = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True
+    )
 
     is_core = models.BooleanField(default=False)
     # commit_hash = models.CharField(max_length=_MAX_LEN_DEFAULT, default='')
@@ -66,11 +64,6 @@ class AS(models.Model):
 
 
 class UserAS(AS):
-    owner = models.ForeignKey(
-        User,
-        on_delete=models.CASCADE
-    )
-
     # These fields are redundant for the network model
     # They are here to retain the values entered by the user
     # if she switches to VPN and back.


### PR DESCRIPTION
This should simplify finding the VPN of an attachment point, as well as storing "front end" data for user ASes.

Also, add a `active` flag to a `Link` to allow deactivating a UserAS without removing it from the database's network model (and hence, avoid having to back up the user's configuration somewhere while the AS is inactive).
![model-useras](https://user-images.githubusercontent.com/42933359/47438061-00a49b80-d7aa-11e8-8344-c4dfbf5044a5.png)

Note: `UserAS` is a subclass of `AS` so that deletion will cascade properly automatically. On the other hand, `AttachmentPoint` is not a subclass of `AS`, because that would make it annoyingly difficult to turn an AS into an attachment point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/25)
<!-- Reviewable:end -->
