### PR TITLE
Tests for UserAS models

### DIFF
--- a/scionlab/models.py
+++ b/scionlab/models.py
@@ -519,7 +519,9 @@ class UserAS(AS):
             )
             interface_ap.update(
                 host=attachment_point.get_host_for_useras_interface(),
-                public_ip=attachment_point.vpn.server_vpn_ip()
+                public_ip=attachment_point.vpn.server_vpn_ip(),
+                public_port=None,
+                internal_port=None
             )
         else:
             host.vpn_clients.update(active=False)   # deactivate all vpn clients
@@ -531,7 +533,9 @@ class UserAS(AS):
             )
             interface_ap.update(
                 host=attachment_point.get_host_for_useras_interface(),
-                public_ip=None
+                public_ip=None,
+                public_port=None,
+                internal_port=None
             )
 
         self.attachment_point = attachment_point

--- a/scionlab/models.py
+++ b/scionlab/models.py
@@ -269,7 +269,7 @@ class AS(models.Model):
         """
         Generate new signing and encryption key pairs.
         Bump the corresponding indicators, so that certificates will be renewed
-        and the configuration will be to all affected hosts.
+        and the configuration will updated on all affected hosts.
         """
         # TODO(matzf): in coming scion versions, the master key can be updated too.
         self._gen_keys()
@@ -280,7 +280,7 @@ class AS(models.Model):
         """
         Generate new core AS signing key pairs.
         Bump the corresponding indicators, so that certificates will be renewed
-        and the configuration will be to all affected hosts.
+        and the configuration will updated on all affected hosts.
         """
         self._gen_core_keys()
         if self.is_core:
@@ -310,6 +310,21 @@ class AS(models.Model):
             if candidate_id not in existing_ids:
                 return candidate_id
         raise RuntimeError('Interface IDs exhausted')
+
+    def _change_isd(self, isd):
+        """
+        Change the AS to be part of a different ISD.
+        Bump the corresponding indicators, so that certificates will be renewed
+        and the configuration will updated on all affected hosts.
+        Note: does *not* check/update any links etc.
+        """
+        if self.is_core:
+            raise NotImplementedError
+
+        self.isd = isd
+        self.certificates_needs_update = True
+        self.save()
+        self.hosts.bump_config()
 
     def _bump_hosts_config_core_change(self):
         # TODO(matzf): untested
@@ -504,6 +519,9 @@ class UserAS(AS):
         interface_ap = link.interfaceA
         interface_user = link.interfaceB
         assert interface_user.host == host
+
+        if self.isd != attachment_point.AS.isd:
+            self._change_isd(attachment_point.AS.isd)
 
         host.update(
             public_ip=public_ip,

--- a/scionlab/models.py
+++ b/scionlab/models.py
@@ -515,10 +515,6 @@ class UserAS(AS):
         a configuration bump for the hosts of the affected attachment point(s).
         """
         host = self.hosts.get()   # UserAS always has only one host
-        link = self._get_ap_link()
-        interface_ap = link.interfaceA
-        interface_user = link.interfaceB
-        assert interface_user.host == host
 
         if self.isd != attachment_point.AS.isd:
             self._change_isd(attachment_point.AS.isd)
@@ -528,6 +524,9 @@ class UserAS(AS):
             bind_ip=bind_ip
         )
 
+        link = self._get_ap_link()
+        interface_ap = link.interfaceA
+        interface_user = link.interfaceB
         if use_vpn:
             vpn_client = self._create_or_activate_vpn_client(attachment_point.vpn)
             interface_user.update(

--- a/scionlab/tests/test_user_as_models.py
+++ b/scionlab/tests/test_user_as_models.py
@@ -32,54 +32,7 @@ from scionlab.fixtures.testuser import get_testuser
 from scionlab.tests import utils
 
 
-def _create_and_check_useras(testcase,
-                             attachment_point,
-                             owner,
-                             use_vpn,
-                             public_ip=None,
-                             public_port=None,
-                             bind_ip=None,
-                             bind_port=None,
-                             installation_type=UserAS.DEDICATED,
-                             label='label foo'):
-    """
-    Helper function for testing. Create a UserAS and verify that things look right.
-    Set some defaults to reduce verbosity in tests.
-    """
-    hosts_pending_before = set(Host.objects.needs_config_deployment())
-
-    user_as = UserAS.objects.create(
-        owner=owner,
-        attachment_point=attachment_point,
-        installation_type=installation_type,
-        label=label,
-        use_vpn=use_vpn,
-        public_ip=public_ip,
-        public_port=public_port,
-        bind_ip=bind_ip,
-        bind_port=bind_port,
-    )
-
-    testcase.assertEqual(user_as.owner, owner)
-    testcase.assertEqual(user_as.label, label)
-    testcase.assertEqual(user_as.installation_type, installation_type)
-    testcase.assertEqual(user_as.attachment_point, attachment_point)
-    testcase.assertEqual(user_as.is_use_vpn(), use_vpn)
-    testcase.assertEqual(user_as.public_ip, public_ip)
-    testcase.assertEqual(user_as.bind_ip, bind_ip)
-    testcase.assertEqual(user_as.bind_port, bind_port)
-
-    # Check AS needs_config_deployment:
-    testcase.assertSetEqual(
-        hosts_pending_before | set(user_as.hosts.all() | attachment_point.AS.hosts.all()),
-        set(Host.objects.needs_config_deployment())
-    )
-
-    utils.check_as(testcase, user_as)
-    utils.check_as(testcase, attachment_point.AS)
-
-    return user_as
-
+testtopo_num_attachment_points = sum(1 for asdef in testtopo.ases if asdef.is_ap)
 
 # Some test data:
 test_public_ip = '192.0.2.111'
@@ -88,35 +41,7 @@ test_bind_ip = '192.168.1.2'
 test_bind_port = 6666
 
 
-def _create_test_useras(testcase, seed, **kwargs):
-    """
-
-    """
-    r = random.Random(seed)
-
-    def _randbool():
-        return r.choice([True, False])
-
-    use_vpn = kwargs.setdefault('use_vpn', _randbool())
-    candidate_APs = AttachmentPoint.objects.all()
-    if use_vpn:
-        candidate_APs = candidate_APs.filter(vpn__isnull=False)
-    kwargs.setdefault('attachment_point', r.choice(candidate_APs))
-    kwargs.setdefault('owner', get_testuser())
-    if not use_vpn or _randbool():
-        kwargs.setdefault('public_ip', '192.0.2.%i' % r.randint(10, 254))
-        public_port_range = range(DEFAULT_PUBLIC_PORT, DEFAULT_PUBLIC_PORT + 20)
-        kwargs.setdefault('public_port', r.choice(public_port_range))
-    if _randbool():
-        kwargs.setdefault('bind_ip', '192.168.1.%i' % r.randint(10, 254))
-        bind_port_range = range(DEFAULT_PUBLIC_PORT + 1000, DEFAULT_PUBLIC_PORT + 1020)
-        kwargs.setdefault('bind_port', r.choice(bind_port_range))
-    kwargs.setdefault('installation_type', r.choice((UserAS.DEDICATED, UserAS.VM)))
-
-    return _create_and_check_useras(testcase, **kwargs)
-
-
-def _setup_vpn_attachment_point():
+def setup_vpn_attachment_point():
     """ Setup VPN for the first AP """
     # TODO(matzf): move to a fixture once the VPN stuff is somewhat stable
     ap = AttachmentPoint.objects.all()[0]
@@ -126,7 +51,7 @@ def _setup_vpn_attachment_point():
     ap.save()
 
 
-def _get_provider_link(parent_as, child_as):
+def get_provider_link(parent_as, child_as):
     """
     Get the PROVIDER link from `parent_as` to `child_as`.
     :param AS parent_as: the AS on the parent side of the link
@@ -149,6 +74,166 @@ def _get_public_ip_testtopo(as_id):
     """
     asdef = next(a for a in testtopo.ases if a.as_id == as_id)
     return asdef.public_ip
+
+
+def create_and_check_useras(testcase,
+                            attachment_point,
+                            owner,
+                            use_vpn,
+                            public_port,
+                            public_ip=None,
+                            bind_ip=None,
+                            bind_port=None,
+                            installation_type=UserAS.DEDICATED,
+                            label='label foo'):
+    """
+    Helper function for testing. Create a UserAS and verify that things look right.
+    """
+    hosts_pending_before = set(Host.objects.needs_config_deployment())
+
+    user_as = UserAS.objects.create(
+        owner=owner,
+        attachment_point=attachment_point,
+        installation_type=installation_type,
+        label=label,
+        use_vpn=use_vpn,
+        public_ip=public_ip,
+        public_port=public_port,
+        bind_ip=bind_ip,
+        bind_port=bind_port,
+    )
+
+    # Check AS needs_config_deployment:
+    testcase.assertSetEqual(
+        hosts_pending_before | set(user_as.hosts.all() | attachment_point.AS.hosts.all()),
+        set(Host.objects.needs_config_deployment())
+    )
+
+    check_useras(testcase,
+                 user_as,
+                 attachment_point,
+                 owner,
+                 use_vpn,
+                 public_ip,
+                 public_port,
+                 bind_ip,
+                 bind_port,
+                 installation_type,
+                 label)
+
+    return user_as
+
+
+def check_useras(testcase,
+                 user_as,
+                 attachment_point,
+                 owner,
+                 use_vpn,
+                 public_ip,
+                 public_port,
+                 bind_ip,
+                 bind_port,
+                 installation_type,
+                 label):
+    """
+    Check the state of `user_as`. Verify that a link to the attachment point exists and
+    that it is configured according to the given parameters.
+    """
+    testcase.assertEqual(user_as.owner, owner)
+    testcase.assertEqual(user_as.label, label)
+    testcase.assertEqual(user_as.installation_type, installation_type)
+    testcase.assertEqual(user_as.attachment_point, attachment_point)
+    testcase.assertEqual(user_as.is_use_vpn(), use_vpn)
+    testcase.assertEqual(user_as.public_ip, public_ip)
+    testcase.assertEqual(user_as.get_public_port(), public_port)
+    testcase.assertEqual(user_as.bind_ip, bind_ip)
+    testcase.assertEqual(user_as.bind_port, bind_port)
+
+    utils.check_as(testcase, user_as)
+    utils.check_as(testcase, attachment_point.AS)
+
+    link = get_provider_link(attachment_point.AS, user_as)
+    if use_vpn:
+        utils.check_link(testcase, link, utils.LinkDescription(
+            type=Link.PROVIDER,
+            from_as_id=attachment_point.AS.as_id,
+            from_public_ip=attachment_point.vpn.server_vpn_ip(),
+            from_bind_ip=None,
+            from_internal_ip=DEFAULT_HOST_INTERNAL_IP,
+            to_public_ip=user_as.hosts.get().vpn_clients.get(active=True).ip,
+            to_public_port=public_port,
+            to_bind_ip=None,
+            to_bind_port=None,
+            to_internal_ip=DEFAULT_HOST_INTERNAL_IP,
+        ))
+    else:
+        utils.check_link(testcase, link, utils.LinkDescription(
+            type=Link.PROVIDER,
+            from_as_id=attachment_point.AS.as_id,
+            from_public_ip=_get_public_ip_testtopo(attachment_point.AS.as_id),
+            from_bind_ip=None,
+            from_internal_ip=DEFAULT_HOST_INTERNAL_IP,
+            to_public_ip=public_ip,
+            to_public_port=public_port,
+            to_bind_ip=bind_ip,
+            to_bind_port=bind_port,
+            to_internal_ip=DEFAULT_HOST_INTERNAL_IP,
+        ))
+
+
+def _get_random_useras_params(seed, **kwargs):
+    """
+    Generate some "random" parameters for a UserAS based on `seed`.
+    Any parameters to UserAS.objects.create can be specified to override the generated values.
+    Note: overriding parameters may affect the generated value for other parameters.
+    :returns: kwargs dict for UserAS.objects.create
+    """
+    r = random.Random(seed)
+
+    def _randbool():
+        return r.choice([True, False])
+
+    use_vpn = kwargs.setdefault('use_vpn', _randbool())
+    candidate_APs = AttachmentPoint.objects.all()
+    if use_vpn:
+        candidate_APs = candidate_APs.filter(vpn__isnull=False)
+    kwargs.setdefault('attachment_point', r.choice(candidate_APs))
+    kwargs.setdefault('owner', get_testuser())
+    if not use_vpn or _randbool():
+        kwargs.setdefault('public_ip', '192.0.2.%i' % r.randint(10, 254))
+    else:
+        kwargs.setdefault('public_ip', None)
+    public_port_range = range(DEFAULT_PUBLIC_PORT, DEFAULT_PUBLIC_PORT + 20)
+    kwargs.setdefault('public_port', r.choice(public_port_range))
+    if _randbool():
+        kwargs.setdefault('bind_ip', '192.168.1.%i' % r.randint(10, 254))
+        bind_port_range = range(DEFAULT_PUBLIC_PORT + 1000, DEFAULT_PUBLIC_PORT + 1020)
+        kwargs.setdefault('bind_port', r.choice(bind_port_range))
+    else:
+        kwargs.setdefault('bind_ip', None)
+        kwargs.setdefault('bind_port', None)
+    kwargs.setdefault('installation_type', r.choice((UserAS.DEDICATED, UserAS.VM)))
+    randstr = r.getrandbits(1024).to_bytes(1024//8, 'little').decode('utf8', 'ignore')
+    kwargs.setdefault('label', randstr)
+
+    return kwargs
+
+
+def create_random_useras(testcase, seed, **kwargs):
+    """
+    Create and check UserAS with "random" parameters based on `seed`.
+    Any parameters to UserAS.objects.create can be specified to override the generated values.
+    """
+    return create_and_check_useras(testcase,
+                                   **_get_random_useras_params(seed, **kwargs))
+
+
+def check_random_useras(testcase, user_as, seed, **kwargs):
+    """
+    Check the state of a `user_as` based on the "random" parameters generated with `seed`.
+    Any parameters to UserAS.objects.create can be specified to override the generated values.
+    """
+    check_useras(testcase, user_as, **_get_random_useras_params(seed, **kwargs))
 
 
 class GenerateUserASIDTests(TestCase):
@@ -182,88 +267,46 @@ class CreateUserASTests(TestCase):
 
     def setUp(self):
         Host.objects.reset_needs_config_deployment()
-        _setup_vpn_attachment_point()
+        setup_vpn_attachment_point()
 
-    @parameterized.expand(zip(range(2)))
+    @parameterized.expand(zip(range(testtopo_num_attachment_points)))
     def test_create_public_ip(self, ap_index):
         attachment_point = AttachmentPoint.objects.all()[ap_index]
-        user_as = _create_and_check_useras(self,
-                                           owner=get_testuser(),
-                                           attachment_point=attachment_point,
-                                           use_vpn=False,
-                                           public_ip=test_public_ip,
-                                           public_port=test_public_port)
+        create_and_check_useras(self,
+                                owner=get_testuser(),
+                                attachment_point=attachment_point,
+                                use_vpn=False,
+                                public_ip=test_public_ip,
+                                public_port=test_public_port)
 
-        link = _get_provider_link(attachment_point.AS, user_as)
-        utils.check_link(self, link, utils.LinkDescription(
-            type=Link.PROVIDER,
-            from_as_id=attachment_point.AS.as_id,
-            from_public_ip=_get_public_ip_testtopo(attachment_point.AS.as_id),
-            from_bind_ip=None,
-            from_internal_ip=DEFAULT_HOST_INTERNAL_IP,
-            to_public_ip=test_public_ip,
-            to_public_port=test_public_port,
-            to_bind_ip=None,
-            to_bind_port=None,
-            to_internal_ip=DEFAULT_HOST_INTERNAL_IP,
-        ))
-
-    @parameterized.expand(zip(range(2)))
+    @parameterized.expand(zip(range(testtopo_num_attachment_points)))
     def test_create_public_bind_ip(self, ap_index):
         attachment_point = AttachmentPoint.objects.all()[ap_index]
-        user_as = _create_and_check_useras(self,
-                                           owner=get_testuser(),
-                                           attachment_point=attachment_point,
-                                           use_vpn=False,
-                                           public_ip=test_public_ip,
-                                           public_port=test_public_port,
-                                           bind_ip=test_bind_ip,
-                                           bind_port=test_bind_port)
-
-        link = _get_provider_link(attachment_point.AS, user_as)
-        utils.check_link(self, link, utils.LinkDescription(
-            type=Link.PROVIDER,
-            from_as_id=attachment_point.AS.as_id,
-            from_public_ip=_get_public_ip_testtopo(attachment_point.AS.as_id),
-            from_bind_ip=None,
-            from_internal_ip=DEFAULT_HOST_INTERNAL_IP,
-            to_public_ip=test_public_ip,
-            to_public_port=test_public_port,
-            to_bind_ip=test_bind_ip,
-            to_bind_port=test_bind_port,
-            to_internal_ip=DEFAULT_HOST_INTERNAL_IP,
-        ))
+        create_and_check_useras(self,
+                                owner=get_testuser(),
+                                attachment_point=attachment_point,
+                                use_vpn=False,
+                                public_ip=test_public_ip,
+                                public_port=test_public_port,
+                                bind_ip=test_bind_ip,
+                                bind_port=test_bind_port)
 
     def test_create_vpn(self):
         attachment_point = AttachmentPoint.objects.get(vpn__isnull=False)
-        user_as = _create_and_check_useras(self,
-                                           owner=get_testuser(),
-                                           attachment_point=attachment_point,
-                                           use_vpn=True,
-                                           public_port=test_public_port)
-
-        link = _get_provider_link(attachment_point.AS, user_as)
-        utils.check_link(self, link, utils.LinkDescription(
-            type=Link.PROVIDER,
-            from_as_id=attachment_point.AS.as_id,
-            from_public_ip=attachment_point.vpn.server_vpn_ip(),
-            from_bind_ip=None,
-            from_internal_ip=DEFAULT_HOST_INTERNAL_IP,
-            to_public_ip=user_as.hosts.get().vpn_clients.get().ip,
-            to_public_port=test_public_port,
-            to_bind_ip=None,
-            to_bind_port=None,
-            to_internal_ip=DEFAULT_HOST_INTERNAL_IP,
-        ))
+        create_and_check_useras(self,
+                                owner=get_testuser(),
+                                attachment_point=attachment_point,
+                                use_vpn=True,
+                                public_port=test_public_port)
 
     @patch('scionlab.models.User.max_num_ases', return_value=32)
     def test_create_mixed(self, mock):
         r = random.Random()
         r.seed(5)
         for i in range(0, 32):
-            if r.choice([True, False]): # pretend to deploy sometimes
+            if r.choice([True, False]):     # pretend to deploy sometimes
                 Host.objects.reset_needs_config_deployment()
-            _create_test_useras(self, seed=i)
+            create_random_useras(self, seed=i)
 
 
 class UpdateUserASTests(TestCase):
@@ -271,7 +314,7 @@ class UpdateUserASTests(TestCase):
 
     def setUp(self):
         Host.objects.reset_needs_config_deployment()
-        _setup_vpn_attachment_point()
+        setup_vpn_attachment_point()
 
     def test_enable_vpn(self):
         pass
@@ -280,40 +323,51 @@ class UpdateUserASTests(TestCase):
         # TODO(matzf): move to view tests?
         pass
 
-    @parameterized.expand(zip(range(2)))
+    @parameterized.expand(zip(range(testtopo_num_attachment_points)))
     def test_change_ap(self, ap_index):
         attachment_point_1 = AttachmentPoint.objects.all()[ap_index]
-        user_as = _create_test_useras(self,
-                                      seed=1,
-                                      attachment_point=attachment_point_1,
-                                      use_vpn=False)
-
-        public_ip = user_as.public_ip
-        public_port = user_as.get_public_port()
-        bind_ip = user_as.bind_ip
-        bind_port = user_as.bind_port
+        user_as = create_random_useras(self,
+                                       seed=1,
+                                       attachment_point=attachment_point_1,
+                                       use_vpn=False)
 
         attachment_point_2 = AttachmentPoint.objects.all()[(ap_index + 1) %
                                                            AttachmentPoint.objects.count()]
 
         self._change_ap(user_as, attachment_point_2)
 
-        link = _get_provider_link(attachment_point_2.AS, user_as)
-        utils.check_link(self, link, utils.LinkDescription(
-            type=Link.PROVIDER,
-            from_as_id=attachment_point_2.AS.as_id,
-            from_public_ip=_get_public_ip_testtopo(attachment_point_2.AS.as_id),
-            from_bind_ip=None,
-            from_internal_ip=DEFAULT_HOST_INTERNAL_IP,
-            to_public_ip=public_ip,
-            to_public_port=public_port,
-            to_bind_ip=bind_ip,
-            to_bind_port=bind_port,
-            to_internal_ip=DEFAULT_HOST_INTERNAL_IP,
-        ))
+        check_random_useras(self,
+                            user_as,
+                            seed=1,
+                            attachment_point=attachment_point_2,
+                            use_vpn=False)
 
-    def test_cycle_ap(self):
-        pass
+    @parameterized.expand(zip(range(testtopo_num_attachment_points)))
+    def test_cycle_ap(self, ap_index):
+        attachment_point_1 = AttachmentPoint.objects.all()[ap_index]
+        user_as = create_random_useras(self,
+                                       seed=1,
+                                       attachment_point=attachment_point_1,
+                                       use_vpn=False)
+
+        attachment_point_2 = AttachmentPoint.objects.all()[(ap_index + 1) %
+                                                           AttachmentPoint.objects.count()]
+
+        self._change_ap(user_as, attachment_point_2)
+
+        check_random_useras(self,
+                            user_as,
+                            seed=1,
+                            attachment_point=attachment_point_2,
+                            use_vpn=False)
+
+        self._change_ap(user_as, attachment_point_1)
+
+        check_random_useras(self,
+                            user_as,
+                            seed=1,
+                            attachment_point=attachment_point_1,
+                            use_vpn=False)
 
     def test_cycle_ap_vpn(self):
         pass

--- a/scionlab/tests/utils.py
+++ b/scionlab/tests/utils.py
@@ -24,15 +24,25 @@ def check_topology(testcase):
     Run all sanity checks for the current state of the models in the DB.
     """
     for as_ in AS.objects.iterator():
-        check_as_services(testcase, as_)
-        check_as_keys(testcase, as_)
-        if as_.is_core:
-            check_as_core_keys(testcase, as_)
+        check_as(testcase, as_)
     for host in Host.objects.iterator():
         check_host_ports(testcase, host)
     for link in Link.objects.iterator():
         check_link(testcase, link)
 
+
+def check_as(testcase, as_):
+    # TODO: generalize (topo checks)
+    for interface in as_.interfaces.iterator():
+        link = interface.link()
+        if link.type == Link.PROVIDER and link.interfaceB == interface:
+            parent_as = link.interfaceA.AS
+            testcase.assertEqual(parent_as.isd, as_.isd)
+
+    check_as_services(testcase, as_)
+    check_as_keys(testcase, as_)
+    if as_.is_core:
+        check_as_core_keys(testcase, as_)
 
 def check_as_services(testcase, as_):
     """

--- a/scionlab/tests/utils.py
+++ b/scionlab/tests/utils.py
@@ -181,7 +181,7 @@ def _diff_link_description(link_desc, actual_link_desc):
     for field, expected in link_desc._asdict().items():
         actual = actual_link_desc._asdict()[field]
         if expected is not _dont_care and expected != actual:
-            diff[field] = dict(expcted=expected, actual=actual)
+            diff[field] = dict(expected=expected, actual=actual)
     return diff
 
 

--- a/scionlab/tests/utils.py
+++ b/scionlab/tests/utils.py
@@ -16,7 +16,7 @@ import re
 import base64
 import lib.crypto.asymcrypto
 from collections import namedtuple, Counter, OrderedDict
-from scionlab.models import AS, Host, Service, Link, MAX_PORT
+from scionlab.models import AS, Service, Link, MAX_PORT
 
 
 def check_topology(testcase):
@@ -25,8 +25,6 @@ def check_topology(testcase):
     """
     for as_ in AS.objects.iterator():
         check_as(testcase, as_)
-    for host in Host.objects.iterator():
-        check_host_ports(testcase, host)
     for link in Link.objects.iterator():
         check_link(testcase, link)
 
@@ -43,6 +41,10 @@ def check_as(testcase, as_):
     check_as_keys(testcase, as_)
     if as_.is_core:
         check_as_core_keys(testcase, as_)
+
+    for host in as_.hosts.iterator():
+        check_host_ports(testcase, host)
+
 
 def check_as_services(testcase, as_):
     """


### PR DESCRIPTION
Add more tests for UserAS models and fix a few bugs caught by new tests:

* changing to AP in different ISD was not handled
* ports were not assigned when changing the AP
* caching issue during UserAS.update