### PR TITLE
Support SCIONLab's current SCION version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,3 +6,4 @@ django-registration
 django-widget-tweaks
 jsonfield2
 pyyaml>=4.2b1  # for fixtures and config generation; high severity vulnerability before 4.1 (CVE-2017-18342)
+toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,6 +95,8 @@ idna==2.7 \
     # via cryptography, requests
 jsonfield2==3.0.1 \
     --hash=sha256:dcc7757202218f198c9152fd68184acb2a176df8c81115ed2687ee35eaa27f41
+pycapnp==0.6.4 \
+    --hash=sha256:44e14a5ace399cf1753acb8bbce558b8c895c48fd2102d266c34eaff286824cf
 pycparser==2.19 \
     --hash=sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3 \
     # via cffi
@@ -139,6 +141,9 @@ six==1.11.0 \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
     # via cryptography, django-extensions, pynacl
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e
 urllib3==1.24 \
     --hash=sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae \
     --hash=sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59 \

--- a/scion-requirements.in
+++ b/scion-requirements.in
@@ -1,3 +1,4 @@
 # these are dependencies of the scion-python libraries that we use
 pynacl
 pygments  # accidental dependency, just for stack traces somewhere
+pycapnp

--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -335,9 +335,7 @@ class InterfaceInline(admin.TabularInline):
         if db_field.name == "border_router":
             as_ = self.get_parent_object_from_request(request)
             kwargs["queryset"] = as_.border_routers.all()
-        foo = super().formfield_for_foreignkey(db_field, request, **kwargs)
-        print(foo)
-        return foo
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
     def get_parent_object_from_request(self, request):
         """

--- a/scionlab/fixtures/testtopo-ases-links.yaml
+++ b/scionlab/fixtures/testtopo-ases-links.yaml
@@ -465,226 +465,226 @@
     mtu: 1472}
 - model: scionlab.borderrouter
   pk: 1
-  fields: {AS: 1, host: 1, internal_port: 30003, control_port: 30003}
+  fields: {AS: 1, host: 1, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 2
-  fields: {AS: 3, host: 3, internal_port: 30003, control_port: 30003}
+  fields: {AS: 3, host: 3, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 3
-  fields: {AS: 2, host: 2, internal_port: 30003, control_port: 30003}
+  fields: {AS: 2, host: 2, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 4
-  fields: {AS: 4, host: 4, internal_port: 30003, control_port: 30003}
+  fields: {AS: 4, host: 4, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 5
-  fields: {AS: 5, host: 5, internal_port: 30003, control_port: 30003}
+  fields: {AS: 5, host: 5, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 6
-  fields: {AS: 6, host: 6, internal_port: 30003, control_port: 30003}
+  fields: {AS: 6, host: 6, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 7
-  fields: {AS: 7, host: 7, internal_port: 30003, control_port: 30003}
+  fields: {AS: 7, host: 7, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 8
-  fields: {AS: 8, host: 8, internal_port: 30003, control_port: 30003}
+  fields: {AS: 8, host: 8, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 9
-  fields: {AS: 9, host: 9, internal_port: 30003, control_port: 30003}
+  fields: {AS: 9, host: 9, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 10
-  fields: {AS: 10, host: 10, internal_port: 30003, control_port: 30003}
+  fields: {AS: 10, host: 10, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 11
-  fields: {AS: 11, host: 11, internal_port: 30003, control_port: 30003}
+  fields: {AS: 11, host: 11, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 12
-  fields: {AS: 12, host: 12, internal_port: 30003, control_port: 30003}
+  fields: {AS: 12, host: 12, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 13
-  fields: {AS: 13, host: 13, internal_port: 30003, control_port: 30003}
+  fields: {AS: 13, host: 13, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 14
-  fields: {AS: 14, host: 14, internal_port: 30003, control_port: 30003}
+  fields: {AS: 14, host: 14, internal_port: 30003, control_port: 31000}
 - model: scionlab.borderrouter
   pk: 15
-  fields: {AS: 15, host: 15, internal_port: 30003, control_port: 30003}
+  fields: {AS: 15, host: 15, internal_port: 30003, control_port: 31000}
 - model: scionlab.service
   pk: 1
-  fields: {AS: 1, host: 1, port: 30000, type: ''}
+  fields: {AS: 1, host: 1, port: 30000, type: BS}
 - model: scionlab.service
   pk: 2
-  fields: {AS: 1, host: 1, port: 30001, type: ''}
+  fields: {AS: 1, host: 1, port: 30001, type: PS}
 - model: scionlab.service
   pk: 3
-  fields: {AS: 1, host: 1, port: 30002, type: ''}
+  fields: {AS: 1, host: 1, port: 30002, type: CS}
 - model: scionlab.service
   pk: 4
-  fields: {AS: 1, host: 1, port: 2181, type: ''}
+  fields: {AS: 1, host: 1, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 5
-  fields: {AS: 2, host: 2, port: 30000, type: ''}
+  fields: {AS: 2, host: 2, port: 30000, type: BS}
 - model: scionlab.service
   pk: 6
-  fields: {AS: 2, host: 2, port: 30001, type: ''}
+  fields: {AS: 2, host: 2, port: 30001, type: PS}
 - model: scionlab.service
   pk: 7
-  fields: {AS: 2, host: 2, port: 30002, type: ''}
+  fields: {AS: 2, host: 2, port: 30002, type: CS}
 - model: scionlab.service
   pk: 8
-  fields: {AS: 2, host: 2, port: 2181, type: ''}
+  fields: {AS: 2, host: 2, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 9
-  fields: {AS: 3, host: 3, port: 30000, type: ''}
+  fields: {AS: 3, host: 3, port: 30000, type: BS}
 - model: scionlab.service
   pk: 10
-  fields: {AS: 3, host: 3, port: 30001, type: ''}
+  fields: {AS: 3, host: 3, port: 30001, type: PS}
 - model: scionlab.service
   pk: 11
-  fields: {AS: 3, host: 3, port: 30002, type: ''}
+  fields: {AS: 3, host: 3, port: 30002, type: CS}
 - model: scionlab.service
   pk: 12
-  fields: {AS: 3, host: 3, port: 2181, type: ''}
+  fields: {AS: 3, host: 3, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 13
-  fields: {AS: 4, host: 4, port: 30000, type: ''}
+  fields: {AS: 4, host: 4, port: 30000, type: BS}
 - model: scionlab.service
   pk: 14
-  fields: {AS: 4, host: 4, port: 30001, type: ''}
+  fields: {AS: 4, host: 4, port: 30001, type: PS}
 - model: scionlab.service
   pk: 15
-  fields: {AS: 4, host: 4, port: 30002, type: ''}
+  fields: {AS: 4, host: 4, port: 30002, type: CS}
 - model: scionlab.service
   pk: 16
-  fields: {AS: 4, host: 4, port: 2181, type: ''}
+  fields: {AS: 4, host: 4, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 17
-  fields: {AS: 5, host: 5, port: 30000, type: ''}
+  fields: {AS: 5, host: 5, port: 30000, type: BS}
 - model: scionlab.service
   pk: 18
-  fields: {AS: 5, host: 5, port: 30001, type: ''}
+  fields: {AS: 5, host: 5, port: 30001, type: PS}
 - model: scionlab.service
   pk: 19
-  fields: {AS: 5, host: 5, port: 30002, type: ''}
+  fields: {AS: 5, host: 5, port: 30002, type: CS}
 - model: scionlab.service
   pk: 20
-  fields: {AS: 5, host: 5, port: 2181, type: ''}
+  fields: {AS: 5, host: 5, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 21
-  fields: {AS: 6, host: 6, port: 30000, type: ''}
+  fields: {AS: 6, host: 6, port: 30000, type: BS}
 - model: scionlab.service
   pk: 22
-  fields: {AS: 6, host: 6, port: 30001, type: ''}
+  fields: {AS: 6, host: 6, port: 30001, type: PS}
 - model: scionlab.service
   pk: 23
-  fields: {AS: 6, host: 6, port: 30002, type: ''}
+  fields: {AS: 6, host: 6, port: 30002, type: CS}
 - model: scionlab.service
   pk: 24
-  fields: {AS: 6, host: 6, port: 2181, type: ''}
+  fields: {AS: 6, host: 6, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 25
-  fields: {AS: 7, host: 7, port: 30000, type: ''}
+  fields: {AS: 7, host: 7, port: 30000, type: BS}
 - model: scionlab.service
   pk: 26
-  fields: {AS: 7, host: 7, port: 30001, type: ''}
+  fields: {AS: 7, host: 7, port: 30001, type: PS}
 - model: scionlab.service
   pk: 27
-  fields: {AS: 7, host: 7, port: 30002, type: ''}
+  fields: {AS: 7, host: 7, port: 30002, type: CS}
 - model: scionlab.service
   pk: 28
-  fields: {AS: 7, host: 7, port: 2181, type: ''}
+  fields: {AS: 7, host: 7, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 29
-  fields: {AS: 8, host: 8, port: 30000, type: ''}
+  fields: {AS: 8, host: 8, port: 30000, type: BS}
 - model: scionlab.service
   pk: 30
-  fields: {AS: 8, host: 8, port: 30001, type: ''}
+  fields: {AS: 8, host: 8, port: 30001, type: PS}
 - model: scionlab.service
   pk: 31
-  fields: {AS: 8, host: 8, port: 30002, type: ''}
+  fields: {AS: 8, host: 8, port: 30002, type: CS}
 - model: scionlab.service
   pk: 32
-  fields: {AS: 8, host: 8, port: 2181, type: ''}
+  fields: {AS: 8, host: 8, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 33
-  fields: {AS: 9, host: 9, port: 30000, type: ''}
+  fields: {AS: 9, host: 9, port: 30000, type: BS}
 - model: scionlab.service
   pk: 34
-  fields: {AS: 9, host: 9, port: 30001, type: ''}
+  fields: {AS: 9, host: 9, port: 30001, type: PS}
 - model: scionlab.service
   pk: 35
-  fields: {AS: 9, host: 9, port: 30002, type: ''}
+  fields: {AS: 9, host: 9, port: 30002, type: CS}
 - model: scionlab.service
   pk: 36
-  fields: {AS: 9, host: 9, port: 2181, type: ''}
+  fields: {AS: 9, host: 9, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 37
-  fields: {AS: 10, host: 10, port: 30000, type: ''}
+  fields: {AS: 10, host: 10, port: 30000, type: BS}
 - model: scionlab.service
   pk: 38
-  fields: {AS: 10, host: 10, port: 30001, type: ''}
+  fields: {AS: 10, host: 10, port: 30001, type: PS}
 - model: scionlab.service
   pk: 39
-  fields: {AS: 10, host: 10, port: 30002, type: ''}
+  fields: {AS: 10, host: 10, port: 30002, type: CS}
 - model: scionlab.service
   pk: 40
-  fields: {AS: 10, host: 10, port: 2181, type: ''}
+  fields: {AS: 10, host: 10, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 41
-  fields: {AS: 11, host: 11, port: 30000, type: ''}
+  fields: {AS: 11, host: 11, port: 30000, type: BS}
 - model: scionlab.service
   pk: 42
-  fields: {AS: 11, host: 11, port: 30001, type: ''}
+  fields: {AS: 11, host: 11, port: 30001, type: PS}
 - model: scionlab.service
   pk: 43
-  fields: {AS: 11, host: 11, port: 30002, type: ''}
+  fields: {AS: 11, host: 11, port: 30002, type: CS}
 - model: scionlab.service
   pk: 44
-  fields: {AS: 11, host: 11, port: 2181, type: ''}
+  fields: {AS: 11, host: 11, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 45
-  fields: {AS: 12, host: 12, port: 30000, type: ''}
+  fields: {AS: 12, host: 12, port: 30000, type: BS}
 - model: scionlab.service
   pk: 46
-  fields: {AS: 12, host: 12, port: 30001, type: ''}
+  fields: {AS: 12, host: 12, port: 30001, type: PS}
 - model: scionlab.service
   pk: 47
-  fields: {AS: 12, host: 12, port: 30002, type: ''}
+  fields: {AS: 12, host: 12, port: 30002, type: CS}
 - model: scionlab.service
   pk: 48
-  fields: {AS: 12, host: 12, port: 2181, type: ''}
+  fields: {AS: 12, host: 12, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 49
-  fields: {AS: 13, host: 13, port: 30000, type: ''}
+  fields: {AS: 13, host: 13, port: 30000, type: BS}
 - model: scionlab.service
   pk: 50
-  fields: {AS: 13, host: 13, port: 30001, type: ''}
+  fields: {AS: 13, host: 13, port: 30001, type: PS}
 - model: scionlab.service
   pk: 51
-  fields: {AS: 13, host: 13, port: 30002, type: ''}
+  fields: {AS: 13, host: 13, port: 30002, type: CS}
 - model: scionlab.service
   pk: 52
-  fields: {AS: 13, host: 13, port: 2181, type: ''}
+  fields: {AS: 13, host: 13, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 53
-  fields: {AS: 14, host: 14, port: 30000, type: ''}
+  fields: {AS: 14, host: 14, port: 30000, type: BS}
 - model: scionlab.service
   pk: 54
-  fields: {AS: 14, host: 14, port: 30001, type: ''}
+  fields: {AS: 14, host: 14, port: 30001, type: PS}
 - model: scionlab.service
   pk: 55
-  fields: {AS: 14, host: 14, port: 30002, type: ''}
+  fields: {AS: 14, host: 14, port: 30002, type: CS}
 - model: scionlab.service
   pk: 56
-  fields: {AS: 14, host: 14, port: 2181, type: ''}
+  fields: {AS: 14, host: 14, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 57
-  fields: {AS: 15, host: 15, port: 30000, type: ''}
+  fields: {AS: 15, host: 15, port: 30000, type: BS}
 - model: scionlab.service
   pk: 58
-  fields: {AS: 15, host: 15, port: 30001, type: ''}
+  fields: {AS: 15, host: 15, port: 30001, type: PS}
 - model: scionlab.service
   pk: 59
-  fields: {AS: 15, host: 15, port: 30002, type: ''}
+  fields: {AS: 15, host: 15, port: 30002, type: CS}
 - model: scionlab.service
   pk: 60
-  fields: {AS: 15, host: 15, port: 2181, type: ''}
+  fields: {AS: 15, host: 15, port: 2181, type: ZK}

--- a/scionlab/fixtures/testtopo-ases-links.yaml
+++ b/scionlab/fixtures/testtopo-ases-links.yaml
@@ -188,213 +188,213 @@
   pk: 1
   fields: {AS: 1, internal_ip: 127.0.0.1, public_ip: 192.0.2.11, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: 5a2W0_NrlEZzfqmk_7Pq-w==,
-    config_version: 8, config_version_deployed: 0}
+    config_version: 9, config_version_deployed: 0}
 - model: scionlab.host
   pk: 2
   fields: {AS: 2, internal_ip: 127.0.0.1, public_ip: 192.0.2.12, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: OBKlTVlvLg-AdwqYGbP8ZA==,
-    config_version: 7, config_version_deployed: 0}
+    config_version: 8, config_version_deployed: 0}
 - model: scionlab.host
   pk: 3
   fields: {AS: 3, internal_ip: 127.0.0.1, public_ip: 192.0.2.13, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: atSmFACYMbJVKD05o3JgtQ==,
-    config_version: 7, config_version_deployed: 0}
+    config_version: 8, config_version_deployed: 0}
 - model: scionlab.host
   pk: 4
   fields: {AS: 4, internal_ip: 127.0.0.1, public_ip: 192.0.2.17, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: R7D6Lhl52uxloBQFRulzzA==,
-    config_version: 6, config_version_deployed: 0}
+    config_version: 7, config_version_deployed: 0}
 - model: scionlab.host
   pk: 5
   fields: {AS: 5, internal_ip: 127.0.0.1, public_ip: 192.0.2.31, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: c8CtMx5_ZUE1pAr_8sw3nw==,
-    config_version: 9, config_version_deployed: 0}
+    config_version: 10, config_version_deployed: 0}
 - model: scionlab.host
   pk: 6
   fields: {AS: 6, internal_ip: 127.0.0.1, public_ip: 192.0.2.32, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: Js_8WmkJnHdidQwZeMcmBQ==,
-    config_version: 7, config_version_deployed: 0}
+    config_version: 8, config_version_deployed: 0}
 - model: scionlab.host
   pk: 7
   fields: {AS: 7, internal_ip: 127.0.0.1, public_ip: 192.0.2.33, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: kuA3OhfG0eLjoMeAsoZrgQ==,
-    config_version: 7, config_version_deployed: 0}
+    config_version: 8, config_version_deployed: 0}
 - model: scionlab.host
   pk: 8
   fields: {AS: 8, internal_ip: 127.0.0.1, public_ip: 192.0.2.34, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: 9UIhB_c1XFV59UpL7-D1jQ==,
-    config_version: 7, config_version_deployed: 0}
+    config_version: 8, config_version_deployed: 0}
 - model: scionlab.host
   pk: 9
   fields: {AS: 9, internal_ip: 127.0.0.1, public_ip: 192.0.2.35, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: jpuwJ8uzcu1mL8Rrbiw_9Q==,
-    config_version: 7, config_version_deployed: 0}
+    config_version: 8, config_version_deployed: 0}
 - model: scionlab.host
   pk: 10
   fields: {AS: 10, internal_ip: 127.0.0.1, public_ip: 192.0.2.41, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: Ch2eAP9F36OzSrrmOiTAkg==,
-    config_version: 8, config_version_deployed: 0}
+    config_version: 9, config_version_deployed: 0}
 - model: scionlab.host
   pk: 11
   fields: {AS: 11, internal_ip: 127.0.0.1, public_ip: 192.0.2.42, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: -n51cB4VFD0Z08MnaeLrNg==,
-    config_version: 8, config_version_deployed: 0}
+    config_version: 9, config_version_deployed: 0}
 - model: scionlab.host
   pk: 12
   fields: {AS: 12, internal_ip: 127.0.0.1, public_ip: 192.0.2.43, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: tIupSDi91OY9EIROrFM7Xw==,
-    config_version: 8, config_version_deployed: 0}
+    config_version: 9, config_version_deployed: 0}
 - model: scionlab.host
   pk: 13
   fields: {AS: 13, internal_ip: 127.0.0.1, public_ip: 192.0.2.44, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: QiOaZrQw0lHJSmLxDzUJUA==,
-    config_version: 7, config_version_deployed: 0}
+    config_version: 8, config_version_deployed: 0}
 - model: scionlab.host
   pk: 14
   fields: {AS: 14, internal_ip: 127.0.0.1, public_ip: 192.0.2.45, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: aPRjKwCAI5_eqYPXu7MlFA==,
-    config_version: 7, config_version_deployed: 0}
+    config_version: 8, config_version_deployed: 0}
 - model: scionlab.host
   pk: 15
   fields: {AS: 15, internal_ip: 127.0.0.1, public_ip: 192.0.2.46, bind_ip: null, label: null,
     managed: false, management_ip: null, ssh_port: 22, secret: rwl0ZbgeZ1h-DQVFvf4IQQ==,
-    config_version: 6, config_version_deployed: 0}
+    config_version: 7, config_version_deployed: 0}
 - model: scionlab.interface
   pk: 1
-  fields: {AS: 1, interface_id: 1, host: 1, public_ip: null, public_port: 50000, bind_ip: null,
-    bind_port: null, internal_port: 30003}
+  fields: {AS: 1, interface_id: 1, host: 1, border_router: 1, public_ip: null, public_port: 50000,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 2
-  fields: {AS: 3, interface_id: 1, host: 3, public_ip: null, public_port: 50000, bind_ip: null,
-    bind_port: null, internal_port: 30003}
+  fields: {AS: 3, interface_id: 1, host: 3, border_router: 2, public_ip: null, public_port: 50000,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 3
-  fields: {AS: 3, interface_id: 2, host: 3, public_ip: null, public_port: 50001, bind_ip: null,
-    bind_port: null, internal_port: 30004}
+  fields: {AS: 3, interface_id: 2, host: 3, border_router: 2, public_ip: null, public_port: 50001,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 4
-  fields: {AS: 2, interface_id: 1, host: 2, public_ip: null, public_port: 50000, bind_ip: null,
-    bind_port: null, internal_port: 30003}
+  fields: {AS: 2, interface_id: 1, host: 2, border_router: 3, public_ip: null, public_port: 50000,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 5
-  fields: {AS: 2, interface_id: 2, host: 2, public_ip: null, public_port: 50001, bind_ip: null,
-    bind_port: null, internal_port: 30004}
+  fields: {AS: 2, interface_id: 2, host: 2, border_router: 3, public_ip: null, public_port: 50001,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 6
-  fields: {AS: 4, interface_id: 1, host: 4, public_ip: null, public_port: 50000, bind_ip: null,
-    bind_port: null, internal_port: 30003}
+  fields: {AS: 4, interface_id: 1, host: 4, border_router: 4, public_ip: null, public_port: 50000,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 7
-  fields: {AS: 5, interface_id: 1, host: 5, public_ip: null, public_port: 50000, bind_ip: null,
-    bind_port: null, internal_port: 30003}
+  fields: {AS: 5, interface_id: 1, host: 5, border_router: 5, public_ip: null, public_port: 50000,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 8
-  fields: {AS: 6, interface_id: 1, host: 6, public_ip: null, public_port: 50000, bind_ip: null,
-    bind_port: null, internal_port: 30003}
+  fields: {AS: 6, interface_id: 1, host: 6, border_router: 6, public_ip: null, public_port: 50000,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 9
-  fields: {AS: 5, interface_id: 2, host: 5, public_ip: null, public_port: 50001, bind_ip: null,
-    bind_port: null, internal_port: 30004}
+  fields: {AS: 5, interface_id: 2, host: 5, border_router: 5, public_ip: null, public_port: 50001,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 10
-  fields: {AS: 7, interface_id: 1, host: 7, public_ip: null, public_port: 50000, bind_ip: null,
-    bind_port: null, internal_port: 30003}
+  fields: {AS: 7, interface_id: 1, host: 7, border_router: 7, public_ip: null, public_port: 50000,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 11
-  fields: {AS: 5, interface_id: 3, host: 5, public_ip: null, public_port: 50002, bind_ip: null,
-    bind_port: null, internal_port: 30005}
+  fields: {AS: 5, interface_id: 3, host: 5, border_router: 5, public_ip: null, public_port: 50002,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 12
-  fields: {AS: 8, interface_id: 1, host: 8, public_ip: null, public_port: 50000, bind_ip: null,
-    bind_port: null, internal_port: 30003}
+  fields: {AS: 8, interface_id: 1, host: 8, border_router: 8, public_ip: null, public_port: 50000,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 13
-  fields: {AS: 7, interface_id: 2, host: 7, public_ip: null, public_port: 50001, bind_ip: null,
-    bind_port: null, internal_port: 30004}
+  fields: {AS: 7, interface_id: 2, host: 7, border_router: 7, public_ip: null, public_port: 50001,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 14
-  fields: {AS: 9, interface_id: 1, host: 9, public_ip: null, public_port: 50000, bind_ip: null,
-    bind_port: null, internal_port: 30003}
+  fields: {AS: 9, interface_id: 1, host: 9, border_router: 9, public_ip: null, public_port: 50000,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 15
-  fields: {AS: 8, interface_id: 2, host: 8, public_ip: null, public_port: 50001, bind_ip: null,
-    bind_port: null, internal_port: 30004}
+  fields: {AS: 8, interface_id: 2, host: 8, border_router: 8, public_ip: null, public_port: 50001,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 16
-  fields: {AS: 9, interface_id: 2, host: 9, public_ip: null, public_port: 50001, bind_ip: null,
-    bind_port: null, internal_port: 30004}
+  fields: {AS: 9, interface_id: 2, host: 9, border_router: 9, public_ip: null, public_port: 50001,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 17
-  fields: {AS: 1, interface_id: 2, host: 1, public_ip: null, public_port: 50001, bind_ip: null,
-    bind_port: null, internal_port: 30004}
+  fields: {AS: 1, interface_id: 2, host: 1, border_router: 1, public_ip: null, public_port: 50001,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 18
-  fields: {AS: 5, interface_id: 4, host: 5, public_ip: null, public_port: 50003, bind_ip: null,
-    bind_port: null, internal_port: 30006}
+  fields: {AS: 5, interface_id: 4, host: 5, border_router: 5, public_ip: null, public_port: 50003,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 19
-  fields: {AS: 1, interface_id: 3, host: 1, public_ip: null, public_port: 50002, bind_ip: null,
-    bind_port: null, internal_port: 30005}
+  fields: {AS: 1, interface_id: 3, host: 1, border_router: 1, public_ip: null, public_port: 50002,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 20
-  fields: {AS: 6, interface_id: 2, host: 6, public_ip: null, public_port: 50001, bind_ip: null,
-    bind_port: null, internal_port: 30004}
+  fields: {AS: 6, interface_id: 2, host: 6, border_router: 6, public_ip: null, public_port: 50001,
+    bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 21
-  fields: {AS: 10, interface_id: 1, host: 10, public_ip: null, public_port: 50000,
-    bind_ip: null, bind_port: null, internal_port: 30003}
+  fields: {AS: 10, interface_id: 1, host: 10, border_router: 10, public_ip: null,
+    public_port: 50000, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 22
-  fields: {AS: 11, interface_id: 1, host: 11, public_ip: null, public_port: 50000,
-    bind_ip: null, bind_port: null, internal_port: 30003}
+  fields: {AS: 11, interface_id: 1, host: 11, border_router: 11, public_ip: null,
+    public_port: 50000, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 23
-  fields: {AS: 10, interface_id: 2, host: 10, public_ip: null, public_port: 50001,
-    bind_ip: null, bind_port: null, internal_port: 30004}
+  fields: {AS: 10, interface_id: 2, host: 10, border_router: 10, public_ip: null,
+    public_port: 50001, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 24
-  fields: {AS: 12, interface_id: 1, host: 12, public_ip: null, public_port: 50000,
-    bind_ip: null, bind_port: null, internal_port: 30003}
+  fields: {AS: 12, interface_id: 1, host: 12, border_router: 12, public_ip: null,
+    public_port: 50000, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 25
-  fields: {AS: 11, interface_id: 2, host: 11, public_ip: null, public_port: 50001,
-    bind_ip: null, bind_port: null, internal_port: 30004}
+  fields: {AS: 11, interface_id: 2, host: 11, border_router: 11, public_ip: null,
+    public_port: 50001, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 26
-  fields: {AS: 12, interface_id: 2, host: 12, public_ip: null, public_port: 50001,
-    bind_ip: null, bind_port: null, internal_port: 30004}
+  fields: {AS: 12, interface_id: 2, host: 12, border_router: 12, public_ip: null,
+    public_port: 50001, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 27
-  fields: {AS: 12, interface_id: 3, host: 12, public_ip: null, public_port: 50002,
-    bind_ip: null, bind_port: null, internal_port: 30005}
+  fields: {AS: 12, interface_id: 3, host: 12, border_router: 12, public_ip: null,
+    public_port: 50002, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 28
-  fields: {AS: 13, interface_id: 1, host: 13, public_ip: null, public_port: 50000,
-    bind_ip: null, bind_port: null, internal_port: 30003}
+  fields: {AS: 13, interface_id: 1, host: 13, border_router: 13, public_ip: null,
+    public_port: 50000, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 29
-  fields: {AS: 10, interface_id: 3, host: 10, public_ip: null, public_port: 50002,
-    bind_ip: null, bind_port: null, internal_port: 30005}
+  fields: {AS: 10, interface_id: 3, host: 10, border_router: 10, public_ip: null,
+    public_port: 50002, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 30
-  fields: {AS: 14, interface_id: 1, host: 14, public_ip: null, public_port: 50000,
-    bind_ip: null, bind_port: null, internal_port: 30003}
+  fields: {AS: 14, interface_id: 1, host: 14, border_router: 14, public_ip: null,
+    public_port: 50000, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 31
-  fields: {AS: 11, interface_id: 3, host: 11, public_ip: null, public_port: 50002,
-    bind_ip: null, bind_port: null, internal_port: 30005}
+  fields: {AS: 11, interface_id: 3, host: 11, border_router: 11, public_ip: null,
+    public_port: 50002, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 32
-  fields: {AS: 14, interface_id: 2, host: 14, public_ip: null, public_port: 50001,
-    bind_ip: null, bind_port: null, internal_port: 30004}
+  fields: {AS: 14, interface_id: 2, host: 14, border_router: 14, public_ip: null,
+    public_port: 50001, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 33
-  fields: {AS: 13, interface_id: 2, host: 13, public_ip: null, public_port: 50001,
-    bind_ip: null, bind_port: null, internal_port: 30004}
+  fields: {AS: 13, interface_id: 2, host: 13, border_router: 13, public_ip: null,
+    public_port: 50001, bind_ip: null, bind_port: null}
 - model: scionlab.interface
   pk: 34
-  fields: {AS: 15, interface_id: 1, host: 15, public_ip: null, public_port: 50000,
-    bind_ip: null, bind_port: null, internal_port: 30003}
+  fields: {AS: 15, interface_id: 1, host: 15, border_router: 15, public_ip: null,
+    public_port: 50000, bind_ip: null, bind_port: null}
 - model: scionlab.link
   pk: 1
   fields: {interfaceA: 1, interfaceB: 2, type: PROVIDER, active: true, bandwidth: 1000,
@@ -463,183 +463,228 @@
   pk: 17
   fields: {interfaceA: 33, interfaceB: 34, type: PROVIDER, active: true, bandwidth: 1000,
     mtu: 1472}
+- model: scionlab.borderrouter
+  pk: 1
+  fields: {AS: 1, host: 1, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 2
+  fields: {AS: 3, host: 3, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 3
+  fields: {AS: 2, host: 2, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 4
+  fields: {AS: 4, host: 4, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 5
+  fields: {AS: 5, host: 5, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 6
+  fields: {AS: 6, host: 6, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 7
+  fields: {AS: 7, host: 7, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 8
+  fields: {AS: 8, host: 8, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 9
+  fields: {AS: 9, host: 9, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 10
+  fields: {AS: 10, host: 10, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 11
+  fields: {AS: 11, host: 11, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 12
+  fields: {AS: 12, host: 12, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 13
+  fields: {AS: 13, host: 13, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 14
+  fields: {AS: 14, host: 14, internal_port: 30003, control_port: 30003}
+- model: scionlab.borderrouter
+  pk: 15
+  fields: {AS: 15, host: 15, internal_port: 30003, control_port: 30003}
 - model: scionlab.service
   pk: 1
-  fields: {AS: 1, host: 1, port: 30000, type: BS}
+  fields: {AS: 1, host: 1, port: 30000, type: ''}
 - model: scionlab.service
   pk: 2
-  fields: {AS: 1, host: 1, port: 30001, type: PS}
+  fields: {AS: 1, host: 1, port: 30001, type: ''}
 - model: scionlab.service
   pk: 3
-  fields: {AS: 1, host: 1, port: 30002, type: CS}
+  fields: {AS: 1, host: 1, port: 30002, type: ''}
 - model: scionlab.service
   pk: 4
-  fields: {AS: 1, host: 1, port: 2181, type: ZK}
+  fields: {AS: 1, host: 1, port: 2181, type: ''}
 - model: scionlab.service
   pk: 5
-  fields: {AS: 2, host: 2, port: 30000, type: BS}
+  fields: {AS: 2, host: 2, port: 30000, type: ''}
 - model: scionlab.service
   pk: 6
-  fields: {AS: 2, host: 2, port: 30001, type: PS}
+  fields: {AS: 2, host: 2, port: 30001, type: ''}
 - model: scionlab.service
   pk: 7
-  fields: {AS: 2, host: 2, port: 30002, type: CS}
+  fields: {AS: 2, host: 2, port: 30002, type: ''}
 - model: scionlab.service
   pk: 8
-  fields: {AS: 2, host: 2, port: 2181, type: ZK}
+  fields: {AS: 2, host: 2, port: 2181, type: ''}
 - model: scionlab.service
   pk: 9
-  fields: {AS: 3, host: 3, port: 30000, type: BS}
+  fields: {AS: 3, host: 3, port: 30000, type: ''}
 - model: scionlab.service
   pk: 10
-  fields: {AS: 3, host: 3, port: 30001, type: PS}
+  fields: {AS: 3, host: 3, port: 30001, type: ''}
 - model: scionlab.service
   pk: 11
-  fields: {AS: 3, host: 3, port: 30002, type: CS}
+  fields: {AS: 3, host: 3, port: 30002, type: ''}
 - model: scionlab.service
   pk: 12
-  fields: {AS: 3, host: 3, port: 2181, type: ZK}
+  fields: {AS: 3, host: 3, port: 2181, type: ''}
 - model: scionlab.service
   pk: 13
-  fields: {AS: 4, host: 4, port: 30000, type: BS}
+  fields: {AS: 4, host: 4, port: 30000, type: ''}
 - model: scionlab.service
   pk: 14
-  fields: {AS: 4, host: 4, port: 30001, type: PS}
+  fields: {AS: 4, host: 4, port: 30001, type: ''}
 - model: scionlab.service
   pk: 15
-  fields: {AS: 4, host: 4, port: 30002, type: CS}
+  fields: {AS: 4, host: 4, port: 30002, type: ''}
 - model: scionlab.service
   pk: 16
-  fields: {AS: 4, host: 4, port: 2181, type: ZK}
+  fields: {AS: 4, host: 4, port: 2181, type: ''}
 - model: scionlab.service
   pk: 17
-  fields: {AS: 5, host: 5, port: 30000, type: BS}
+  fields: {AS: 5, host: 5, port: 30000, type: ''}
 - model: scionlab.service
   pk: 18
-  fields: {AS: 5, host: 5, port: 30001, type: PS}
+  fields: {AS: 5, host: 5, port: 30001, type: ''}
 - model: scionlab.service
   pk: 19
-  fields: {AS: 5, host: 5, port: 30002, type: CS}
+  fields: {AS: 5, host: 5, port: 30002, type: ''}
 - model: scionlab.service
   pk: 20
-  fields: {AS: 5, host: 5, port: 2181, type: ZK}
+  fields: {AS: 5, host: 5, port: 2181, type: ''}
 - model: scionlab.service
   pk: 21
-  fields: {AS: 6, host: 6, port: 30000, type: BS}
+  fields: {AS: 6, host: 6, port: 30000, type: ''}
 - model: scionlab.service
   pk: 22
-  fields: {AS: 6, host: 6, port: 30001, type: PS}
+  fields: {AS: 6, host: 6, port: 30001, type: ''}
 - model: scionlab.service
   pk: 23
-  fields: {AS: 6, host: 6, port: 30002, type: CS}
+  fields: {AS: 6, host: 6, port: 30002, type: ''}
 - model: scionlab.service
   pk: 24
-  fields: {AS: 6, host: 6, port: 2181, type: ZK}
+  fields: {AS: 6, host: 6, port: 2181, type: ''}
 - model: scionlab.service
   pk: 25
-  fields: {AS: 7, host: 7, port: 30000, type: BS}
+  fields: {AS: 7, host: 7, port: 30000, type: ''}
 - model: scionlab.service
   pk: 26
-  fields: {AS: 7, host: 7, port: 30001, type: PS}
+  fields: {AS: 7, host: 7, port: 30001, type: ''}
 - model: scionlab.service
   pk: 27
-  fields: {AS: 7, host: 7, port: 30002, type: CS}
+  fields: {AS: 7, host: 7, port: 30002, type: ''}
 - model: scionlab.service
   pk: 28
-  fields: {AS: 7, host: 7, port: 2181, type: ZK}
+  fields: {AS: 7, host: 7, port: 2181, type: ''}
 - model: scionlab.service
   pk: 29
-  fields: {AS: 8, host: 8, port: 30000, type: BS}
+  fields: {AS: 8, host: 8, port: 30000, type: ''}
 - model: scionlab.service
   pk: 30
-  fields: {AS: 8, host: 8, port: 30001, type: PS}
+  fields: {AS: 8, host: 8, port: 30001, type: ''}
 - model: scionlab.service
   pk: 31
-  fields: {AS: 8, host: 8, port: 30002, type: CS}
+  fields: {AS: 8, host: 8, port: 30002, type: ''}
 - model: scionlab.service
   pk: 32
-  fields: {AS: 8, host: 8, port: 2181, type: ZK}
+  fields: {AS: 8, host: 8, port: 2181, type: ''}
 - model: scionlab.service
   pk: 33
-  fields: {AS: 9, host: 9, port: 30000, type: BS}
+  fields: {AS: 9, host: 9, port: 30000, type: ''}
 - model: scionlab.service
   pk: 34
-  fields: {AS: 9, host: 9, port: 30001, type: PS}
+  fields: {AS: 9, host: 9, port: 30001, type: ''}
 - model: scionlab.service
   pk: 35
-  fields: {AS: 9, host: 9, port: 30002, type: CS}
+  fields: {AS: 9, host: 9, port: 30002, type: ''}
 - model: scionlab.service
   pk: 36
-  fields: {AS: 9, host: 9, port: 2181, type: ZK}
+  fields: {AS: 9, host: 9, port: 2181, type: ''}
 - model: scionlab.service
   pk: 37
-  fields: {AS: 10, host: 10, port: 30000, type: BS}
+  fields: {AS: 10, host: 10, port: 30000, type: ''}
 - model: scionlab.service
   pk: 38
-  fields: {AS: 10, host: 10, port: 30001, type: PS}
+  fields: {AS: 10, host: 10, port: 30001, type: ''}
 - model: scionlab.service
   pk: 39
-  fields: {AS: 10, host: 10, port: 30002, type: CS}
+  fields: {AS: 10, host: 10, port: 30002, type: ''}
 - model: scionlab.service
   pk: 40
-  fields: {AS: 10, host: 10, port: 2181, type: ZK}
+  fields: {AS: 10, host: 10, port: 2181, type: ''}
 - model: scionlab.service
   pk: 41
-  fields: {AS: 11, host: 11, port: 30000, type: BS}
+  fields: {AS: 11, host: 11, port: 30000, type: ''}
 - model: scionlab.service
   pk: 42
-  fields: {AS: 11, host: 11, port: 30001, type: PS}
+  fields: {AS: 11, host: 11, port: 30001, type: ''}
 - model: scionlab.service
   pk: 43
-  fields: {AS: 11, host: 11, port: 30002, type: CS}
+  fields: {AS: 11, host: 11, port: 30002, type: ''}
 - model: scionlab.service
   pk: 44
-  fields: {AS: 11, host: 11, port: 2181, type: ZK}
+  fields: {AS: 11, host: 11, port: 2181, type: ''}
 - model: scionlab.service
   pk: 45
-  fields: {AS: 12, host: 12, port: 30000, type: BS}
+  fields: {AS: 12, host: 12, port: 30000, type: ''}
 - model: scionlab.service
   pk: 46
-  fields: {AS: 12, host: 12, port: 30001, type: PS}
+  fields: {AS: 12, host: 12, port: 30001, type: ''}
 - model: scionlab.service
   pk: 47
-  fields: {AS: 12, host: 12, port: 30002, type: CS}
+  fields: {AS: 12, host: 12, port: 30002, type: ''}
 - model: scionlab.service
   pk: 48
-  fields: {AS: 12, host: 12, port: 2181, type: ZK}
+  fields: {AS: 12, host: 12, port: 2181, type: ''}
 - model: scionlab.service
   pk: 49
-  fields: {AS: 13, host: 13, port: 30000, type: BS}
+  fields: {AS: 13, host: 13, port: 30000, type: ''}
 - model: scionlab.service
   pk: 50
-  fields: {AS: 13, host: 13, port: 30001, type: PS}
+  fields: {AS: 13, host: 13, port: 30001, type: ''}
 - model: scionlab.service
   pk: 51
-  fields: {AS: 13, host: 13, port: 30002, type: CS}
+  fields: {AS: 13, host: 13, port: 30002, type: ''}
 - model: scionlab.service
   pk: 52
-  fields: {AS: 13, host: 13, port: 2181, type: ZK}
+  fields: {AS: 13, host: 13, port: 2181, type: ''}
 - model: scionlab.service
   pk: 53
-  fields: {AS: 14, host: 14, port: 30000, type: BS}
+  fields: {AS: 14, host: 14, port: 30000, type: ''}
 - model: scionlab.service
   pk: 54
-  fields: {AS: 14, host: 14, port: 30001, type: PS}
+  fields: {AS: 14, host: 14, port: 30001, type: ''}
 - model: scionlab.service
   pk: 55
-  fields: {AS: 14, host: 14, port: 30002, type: CS}
+  fields: {AS: 14, host: 14, port: 30002, type: ''}
 - model: scionlab.service
   pk: 56
-  fields: {AS: 14, host: 14, port: 2181, type: ZK}
+  fields: {AS: 14, host: 14, port: 2181, type: ''}
 - model: scionlab.service
   pk: 57
-  fields: {AS: 15, host: 15, port: 30000, type: BS}
+  fields: {AS: 15, host: 15, port: 30000, type: ''}
 - model: scionlab.service
   pk: 58
-  fields: {AS: 15, host: 15, port: 30001, type: PS}
+  fields: {AS: 15, host: 15, port: 30001, type: ''}
 - model: scionlab.service
   pk: 59
-  fields: {AS: 15, host: 15, port: 30002, type: CS}
+  fields: {AS: 15, host: 15, port: 30002, type: ''}
 - model: scionlab.service
   pk: 60
-  fields: {AS: 15, host: 15, port: 2181, type: ZK}
+  fields: {AS: 15, host: 15, port: 2181, type: ''}

--- a/scionlab/fixtures/testtopo-ases-links.yaml
+++ b/scionlab/fixtures/testtopo-ases-links.yaml
@@ -465,226 +465,226 @@
     mtu: 1472}
 - model: scionlab.borderrouter
   pk: 1
-  fields: {AS: 1, host: 1, internal_port: 30003, control_port: 31000}
+  fields: {AS: 1, host: 1, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 2
-  fields: {AS: 3, host: 3, internal_port: 30003, control_port: 31000}
+  fields: {AS: 3, host: 3, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 3
-  fields: {AS: 2, host: 2, internal_port: 30003, control_port: 31000}
+  fields: {AS: 2, host: 2, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 4
-  fields: {AS: 4, host: 4, internal_port: 30003, control_port: 31000}
+  fields: {AS: 4, host: 4, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 5
-  fields: {AS: 5, host: 5, internal_port: 30003, control_port: 31000}
+  fields: {AS: 5, host: 5, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 6
-  fields: {AS: 6, host: 6, internal_port: 30003, control_port: 31000}
+  fields: {AS: 6, host: 6, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 7
-  fields: {AS: 7, host: 7, internal_port: 30003, control_port: 31000}
+  fields: {AS: 7, host: 7, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 8
-  fields: {AS: 8, host: 8, internal_port: 30003, control_port: 31000}
+  fields: {AS: 8, host: 8, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 9
-  fields: {AS: 9, host: 9, internal_port: 30003, control_port: 31000}
+  fields: {AS: 9, host: 9, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 10
-  fields: {AS: 10, host: 10, internal_port: 30003, control_port: 31000}
+  fields: {AS: 10, host: 10, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 11
-  fields: {AS: 11, host: 11, internal_port: 30003, control_port: 31000}
+  fields: {AS: 11, host: 11, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 12
-  fields: {AS: 12, host: 12, internal_port: 30003, control_port: 31000}
+  fields: {AS: 12, host: 12, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 13
-  fields: {AS: 13, host: 13, internal_port: 30003, control_port: 31000}
+  fields: {AS: 13, host: 13, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 14
-  fields: {AS: 14, host: 14, internal_port: 30003, control_port: 31000}
+  fields: {AS: 14, host: 14, internal_port: 31045, control_port: 30045}
 - model: scionlab.borderrouter
   pk: 15
-  fields: {AS: 15, host: 15, internal_port: 30003, control_port: 31000}
+  fields: {AS: 15, host: 15, internal_port: 31045, control_port: 30045}
 - model: scionlab.service
   pk: 1
-  fields: {AS: 1, host: 1, port: 30000, type: BS}
+  fields: {AS: 1, host: 1, port: 31041, type: BS}
 - model: scionlab.service
   pk: 2
-  fields: {AS: 1, host: 1, port: 30001, type: PS}
+  fields: {AS: 1, host: 1, port: 31043, type: PS}
 - model: scionlab.service
   pk: 3
-  fields: {AS: 1, host: 1, port: 30002, type: CS}
+  fields: {AS: 1, host: 1, port: 31042, type: CS}
 - model: scionlab.service
   pk: 4
   fields: {AS: 1, host: 1, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 5
-  fields: {AS: 2, host: 2, port: 30000, type: BS}
+  fields: {AS: 2, host: 2, port: 31041, type: BS}
 - model: scionlab.service
   pk: 6
-  fields: {AS: 2, host: 2, port: 30001, type: PS}
+  fields: {AS: 2, host: 2, port: 31043, type: PS}
 - model: scionlab.service
   pk: 7
-  fields: {AS: 2, host: 2, port: 30002, type: CS}
+  fields: {AS: 2, host: 2, port: 31042, type: CS}
 - model: scionlab.service
   pk: 8
   fields: {AS: 2, host: 2, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 9
-  fields: {AS: 3, host: 3, port: 30000, type: BS}
+  fields: {AS: 3, host: 3, port: 31041, type: BS}
 - model: scionlab.service
   pk: 10
-  fields: {AS: 3, host: 3, port: 30001, type: PS}
+  fields: {AS: 3, host: 3, port: 31043, type: PS}
 - model: scionlab.service
   pk: 11
-  fields: {AS: 3, host: 3, port: 30002, type: CS}
+  fields: {AS: 3, host: 3, port: 31042, type: CS}
 - model: scionlab.service
   pk: 12
   fields: {AS: 3, host: 3, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 13
-  fields: {AS: 4, host: 4, port: 30000, type: BS}
+  fields: {AS: 4, host: 4, port: 31041, type: BS}
 - model: scionlab.service
   pk: 14
-  fields: {AS: 4, host: 4, port: 30001, type: PS}
+  fields: {AS: 4, host: 4, port: 31043, type: PS}
 - model: scionlab.service
   pk: 15
-  fields: {AS: 4, host: 4, port: 30002, type: CS}
+  fields: {AS: 4, host: 4, port: 31042, type: CS}
 - model: scionlab.service
   pk: 16
   fields: {AS: 4, host: 4, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 17
-  fields: {AS: 5, host: 5, port: 30000, type: BS}
+  fields: {AS: 5, host: 5, port: 31041, type: BS}
 - model: scionlab.service
   pk: 18
-  fields: {AS: 5, host: 5, port: 30001, type: PS}
+  fields: {AS: 5, host: 5, port: 31043, type: PS}
 - model: scionlab.service
   pk: 19
-  fields: {AS: 5, host: 5, port: 30002, type: CS}
+  fields: {AS: 5, host: 5, port: 31042, type: CS}
 - model: scionlab.service
   pk: 20
   fields: {AS: 5, host: 5, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 21
-  fields: {AS: 6, host: 6, port: 30000, type: BS}
+  fields: {AS: 6, host: 6, port: 31041, type: BS}
 - model: scionlab.service
   pk: 22
-  fields: {AS: 6, host: 6, port: 30001, type: PS}
+  fields: {AS: 6, host: 6, port: 31043, type: PS}
 - model: scionlab.service
   pk: 23
-  fields: {AS: 6, host: 6, port: 30002, type: CS}
+  fields: {AS: 6, host: 6, port: 31042, type: CS}
 - model: scionlab.service
   pk: 24
   fields: {AS: 6, host: 6, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 25
-  fields: {AS: 7, host: 7, port: 30000, type: BS}
+  fields: {AS: 7, host: 7, port: 31041, type: BS}
 - model: scionlab.service
   pk: 26
-  fields: {AS: 7, host: 7, port: 30001, type: PS}
+  fields: {AS: 7, host: 7, port: 31043, type: PS}
 - model: scionlab.service
   pk: 27
-  fields: {AS: 7, host: 7, port: 30002, type: CS}
+  fields: {AS: 7, host: 7, port: 31042, type: CS}
 - model: scionlab.service
   pk: 28
   fields: {AS: 7, host: 7, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 29
-  fields: {AS: 8, host: 8, port: 30000, type: BS}
+  fields: {AS: 8, host: 8, port: 31041, type: BS}
 - model: scionlab.service
   pk: 30
-  fields: {AS: 8, host: 8, port: 30001, type: PS}
+  fields: {AS: 8, host: 8, port: 31043, type: PS}
 - model: scionlab.service
   pk: 31
-  fields: {AS: 8, host: 8, port: 30002, type: CS}
+  fields: {AS: 8, host: 8, port: 31042, type: CS}
 - model: scionlab.service
   pk: 32
   fields: {AS: 8, host: 8, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 33
-  fields: {AS: 9, host: 9, port: 30000, type: BS}
+  fields: {AS: 9, host: 9, port: 31041, type: BS}
 - model: scionlab.service
   pk: 34
-  fields: {AS: 9, host: 9, port: 30001, type: PS}
+  fields: {AS: 9, host: 9, port: 31043, type: PS}
 - model: scionlab.service
   pk: 35
-  fields: {AS: 9, host: 9, port: 30002, type: CS}
+  fields: {AS: 9, host: 9, port: 31042, type: CS}
 - model: scionlab.service
   pk: 36
   fields: {AS: 9, host: 9, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 37
-  fields: {AS: 10, host: 10, port: 30000, type: BS}
+  fields: {AS: 10, host: 10, port: 31041, type: BS}
 - model: scionlab.service
   pk: 38
-  fields: {AS: 10, host: 10, port: 30001, type: PS}
+  fields: {AS: 10, host: 10, port: 31043, type: PS}
 - model: scionlab.service
   pk: 39
-  fields: {AS: 10, host: 10, port: 30002, type: CS}
+  fields: {AS: 10, host: 10, port: 31042, type: CS}
 - model: scionlab.service
   pk: 40
   fields: {AS: 10, host: 10, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 41
-  fields: {AS: 11, host: 11, port: 30000, type: BS}
+  fields: {AS: 11, host: 11, port: 31041, type: BS}
 - model: scionlab.service
   pk: 42
-  fields: {AS: 11, host: 11, port: 30001, type: PS}
+  fields: {AS: 11, host: 11, port: 31043, type: PS}
 - model: scionlab.service
   pk: 43
-  fields: {AS: 11, host: 11, port: 30002, type: CS}
+  fields: {AS: 11, host: 11, port: 31042, type: CS}
 - model: scionlab.service
   pk: 44
   fields: {AS: 11, host: 11, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 45
-  fields: {AS: 12, host: 12, port: 30000, type: BS}
+  fields: {AS: 12, host: 12, port: 31041, type: BS}
 - model: scionlab.service
   pk: 46
-  fields: {AS: 12, host: 12, port: 30001, type: PS}
+  fields: {AS: 12, host: 12, port: 31043, type: PS}
 - model: scionlab.service
   pk: 47
-  fields: {AS: 12, host: 12, port: 30002, type: CS}
+  fields: {AS: 12, host: 12, port: 31042, type: CS}
 - model: scionlab.service
   pk: 48
   fields: {AS: 12, host: 12, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 49
-  fields: {AS: 13, host: 13, port: 30000, type: BS}
+  fields: {AS: 13, host: 13, port: 31041, type: BS}
 - model: scionlab.service
   pk: 50
-  fields: {AS: 13, host: 13, port: 30001, type: PS}
+  fields: {AS: 13, host: 13, port: 31043, type: PS}
 - model: scionlab.service
   pk: 51
-  fields: {AS: 13, host: 13, port: 30002, type: CS}
+  fields: {AS: 13, host: 13, port: 31042, type: CS}
 - model: scionlab.service
   pk: 52
   fields: {AS: 13, host: 13, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 53
-  fields: {AS: 14, host: 14, port: 30000, type: BS}
+  fields: {AS: 14, host: 14, port: 31041, type: BS}
 - model: scionlab.service
   pk: 54
-  fields: {AS: 14, host: 14, port: 30001, type: PS}
+  fields: {AS: 14, host: 14, port: 31043, type: PS}
 - model: scionlab.service
   pk: 55
-  fields: {AS: 14, host: 14, port: 30002, type: CS}
+  fields: {AS: 14, host: 14, port: 31042, type: CS}
 - model: scionlab.service
   pk: 56
   fields: {AS: 14, host: 14, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 57
-  fields: {AS: 15, host: 15, port: 30000, type: BS}
+  fields: {AS: 15, host: 15, port: 31041, type: BS}
 - model: scionlab.service
   pk: 58
-  fields: {AS: 15, host: 15, port: 30001, type: PS}
+  fields: {AS: 15, host: 15, port: 31043, type: PS}
 - model: scionlab.service
   pk: 59
-  fields: {AS: 15, host: 15, port: 30002, type: CS}
+  fields: {AS: 15, host: 15, port: 31042, type: CS}
 - model: scionlab.service
   pk: 60
   fields: {AS: 15, host: 15, port: 2181, type: ZK}

--- a/scionlab/fixtures/testtopo-ases.yaml
+++ b/scionlab/fixtures/testtopo-ases.yaml
@@ -261,181 +261,181 @@
     config_version: 5, config_version_deployed: 0}
 - model: scionlab.service
   pk: 1
-  fields: {AS: 1, host: 1, port: 30000, type: BS}
+  fields: {AS: 1, host: 1, port: 31041, type: BS}
 - model: scionlab.service
   pk: 2
-  fields: {AS: 1, host: 1, port: 30001, type: PS}
+  fields: {AS: 1, host: 1, port: 31043, type: PS}
 - model: scionlab.service
   pk: 3
-  fields: {AS: 1, host: 1, port: 30002, type: CS}
+  fields: {AS: 1, host: 1, port: 31042, type: CS}
 - model: scionlab.service
   pk: 4
   fields: {AS: 1, host: 1, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 5
-  fields: {AS: 2, host: 2, port: 30000, type: BS}
+  fields: {AS: 2, host: 2, port: 31041, type: BS}
 - model: scionlab.service
   pk: 6
-  fields: {AS: 2, host: 2, port: 30001, type: PS}
+  fields: {AS: 2, host: 2, port: 31043, type: PS}
 - model: scionlab.service
   pk: 7
-  fields: {AS: 2, host: 2, port: 30002, type: CS}
+  fields: {AS: 2, host: 2, port: 31042, type: CS}
 - model: scionlab.service
   pk: 8
   fields: {AS: 2, host: 2, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 9
-  fields: {AS: 3, host: 3, port: 30000, type: BS}
+  fields: {AS: 3, host: 3, port: 31041, type: BS}
 - model: scionlab.service
   pk: 10
-  fields: {AS: 3, host: 3, port: 30001, type: PS}
+  fields: {AS: 3, host: 3, port: 31043, type: PS}
 - model: scionlab.service
   pk: 11
-  fields: {AS: 3, host: 3, port: 30002, type: CS}
+  fields: {AS: 3, host: 3, port: 31042, type: CS}
 - model: scionlab.service
   pk: 12
   fields: {AS: 3, host: 3, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 13
-  fields: {AS: 4, host: 4, port: 30000, type: BS}
+  fields: {AS: 4, host: 4, port: 31041, type: BS}
 - model: scionlab.service
   pk: 14
-  fields: {AS: 4, host: 4, port: 30001, type: PS}
+  fields: {AS: 4, host: 4, port: 31043, type: PS}
 - model: scionlab.service
   pk: 15
-  fields: {AS: 4, host: 4, port: 30002, type: CS}
+  fields: {AS: 4, host: 4, port: 31042, type: CS}
 - model: scionlab.service
   pk: 16
   fields: {AS: 4, host: 4, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 17
-  fields: {AS: 5, host: 5, port: 30000, type: BS}
+  fields: {AS: 5, host: 5, port: 31041, type: BS}
 - model: scionlab.service
   pk: 18
-  fields: {AS: 5, host: 5, port: 30001, type: PS}
+  fields: {AS: 5, host: 5, port: 31043, type: PS}
 - model: scionlab.service
   pk: 19
-  fields: {AS: 5, host: 5, port: 30002, type: CS}
+  fields: {AS: 5, host: 5, port: 31042, type: CS}
 - model: scionlab.service
   pk: 20
   fields: {AS: 5, host: 5, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 21
-  fields: {AS: 6, host: 6, port: 30000, type: BS}
+  fields: {AS: 6, host: 6, port: 31041, type: BS}
 - model: scionlab.service
   pk: 22
-  fields: {AS: 6, host: 6, port: 30001, type: PS}
+  fields: {AS: 6, host: 6, port: 31043, type: PS}
 - model: scionlab.service
   pk: 23
-  fields: {AS: 6, host: 6, port: 30002, type: CS}
+  fields: {AS: 6, host: 6, port: 31042, type: CS}
 - model: scionlab.service
   pk: 24
   fields: {AS: 6, host: 6, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 25
-  fields: {AS: 7, host: 7, port: 30000, type: BS}
+  fields: {AS: 7, host: 7, port: 31041, type: BS}
 - model: scionlab.service
   pk: 26
-  fields: {AS: 7, host: 7, port: 30001, type: PS}
+  fields: {AS: 7, host: 7, port: 31043, type: PS}
 - model: scionlab.service
   pk: 27
-  fields: {AS: 7, host: 7, port: 30002, type: CS}
+  fields: {AS: 7, host: 7, port: 31042, type: CS}
 - model: scionlab.service
   pk: 28
   fields: {AS: 7, host: 7, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 29
-  fields: {AS: 8, host: 8, port: 30000, type: BS}
+  fields: {AS: 8, host: 8, port: 31041, type: BS}
 - model: scionlab.service
   pk: 30
-  fields: {AS: 8, host: 8, port: 30001, type: PS}
+  fields: {AS: 8, host: 8, port: 31043, type: PS}
 - model: scionlab.service
   pk: 31
-  fields: {AS: 8, host: 8, port: 30002, type: CS}
+  fields: {AS: 8, host: 8, port: 31042, type: CS}
 - model: scionlab.service
   pk: 32
   fields: {AS: 8, host: 8, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 33
-  fields: {AS: 9, host: 9, port: 30000, type: BS}
+  fields: {AS: 9, host: 9, port: 31041, type: BS}
 - model: scionlab.service
   pk: 34
-  fields: {AS: 9, host: 9, port: 30001, type: PS}
+  fields: {AS: 9, host: 9, port: 31043, type: PS}
 - model: scionlab.service
   pk: 35
-  fields: {AS: 9, host: 9, port: 30002, type: CS}
+  fields: {AS: 9, host: 9, port: 31042, type: CS}
 - model: scionlab.service
   pk: 36
   fields: {AS: 9, host: 9, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 37
-  fields: {AS: 10, host: 10, port: 30000, type: BS}
+  fields: {AS: 10, host: 10, port: 31041, type: BS}
 - model: scionlab.service
   pk: 38
-  fields: {AS: 10, host: 10, port: 30001, type: PS}
+  fields: {AS: 10, host: 10, port: 31043, type: PS}
 - model: scionlab.service
   pk: 39
-  fields: {AS: 10, host: 10, port: 30002, type: CS}
+  fields: {AS: 10, host: 10, port: 31042, type: CS}
 - model: scionlab.service
   pk: 40
   fields: {AS: 10, host: 10, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 41
-  fields: {AS: 11, host: 11, port: 30000, type: BS}
+  fields: {AS: 11, host: 11, port: 31041, type: BS}
 - model: scionlab.service
   pk: 42
-  fields: {AS: 11, host: 11, port: 30001, type: PS}
+  fields: {AS: 11, host: 11, port: 31043, type: PS}
 - model: scionlab.service
   pk: 43
-  fields: {AS: 11, host: 11, port: 30002, type: CS}
+  fields: {AS: 11, host: 11, port: 31042, type: CS}
 - model: scionlab.service
   pk: 44
   fields: {AS: 11, host: 11, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 45
-  fields: {AS: 12, host: 12, port: 30000, type: BS}
+  fields: {AS: 12, host: 12, port: 31041, type: BS}
 - model: scionlab.service
   pk: 46
-  fields: {AS: 12, host: 12, port: 30001, type: PS}
+  fields: {AS: 12, host: 12, port: 31043, type: PS}
 - model: scionlab.service
   pk: 47
-  fields: {AS: 12, host: 12, port: 30002, type: CS}
+  fields: {AS: 12, host: 12, port: 31042, type: CS}
 - model: scionlab.service
   pk: 48
   fields: {AS: 12, host: 12, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 49
-  fields: {AS: 13, host: 13, port: 30000, type: BS}
+  fields: {AS: 13, host: 13, port: 31041, type: BS}
 - model: scionlab.service
   pk: 50
-  fields: {AS: 13, host: 13, port: 30001, type: PS}
+  fields: {AS: 13, host: 13, port: 31043, type: PS}
 - model: scionlab.service
   pk: 51
-  fields: {AS: 13, host: 13, port: 30002, type: CS}
+  fields: {AS: 13, host: 13, port: 31042, type: CS}
 - model: scionlab.service
   pk: 52
   fields: {AS: 13, host: 13, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 53
-  fields: {AS: 14, host: 14, port: 30000, type: BS}
+  fields: {AS: 14, host: 14, port: 31041, type: BS}
 - model: scionlab.service
   pk: 54
-  fields: {AS: 14, host: 14, port: 30001, type: PS}
+  fields: {AS: 14, host: 14, port: 31043, type: PS}
 - model: scionlab.service
   pk: 55
-  fields: {AS: 14, host: 14, port: 30002, type: CS}
+  fields: {AS: 14, host: 14, port: 31042, type: CS}
 - model: scionlab.service
   pk: 56
   fields: {AS: 14, host: 14, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 57
-  fields: {AS: 15, host: 15, port: 30000, type: BS}
+  fields: {AS: 15, host: 15, port: 31041, type: BS}
 - model: scionlab.service
   pk: 58
-  fields: {AS: 15, host: 15, port: 30001, type: PS}
+  fields: {AS: 15, host: 15, port: 31043, type: PS}
 - model: scionlab.service
   pk: 59
-  fields: {AS: 15, host: 15, port: 30002, type: CS}
+  fields: {AS: 15, host: 15, port: 31042, type: CS}
 - model: scionlab.service
   pk: 60
   fields: {AS: 15, host: 15, port: 2181, type: ZK}

--- a/scionlab/fixtures/testtopo-ases.yaml
+++ b/scionlab/fixtures/testtopo-ases.yaml
@@ -261,181 +261,181 @@
     config_version: 5, config_version_deployed: 0}
 - model: scionlab.service
   pk: 1
-  fields: {AS: 1, host: 1, port: 30000, type: BS}
+  fields: {AS: 1, host: 1, port: 30000, type: ''}
 - model: scionlab.service
   pk: 2
-  fields: {AS: 1, host: 1, port: 30001, type: PS}
+  fields: {AS: 1, host: 1, port: 30001, type: ''}
 - model: scionlab.service
   pk: 3
-  fields: {AS: 1, host: 1, port: 30002, type: CS}
+  fields: {AS: 1, host: 1, port: 30002, type: ''}
 - model: scionlab.service
   pk: 4
-  fields: {AS: 1, host: 1, port: 2181, type: ZK}
+  fields: {AS: 1, host: 1, port: 2181, type: ''}
 - model: scionlab.service
   pk: 5
-  fields: {AS: 2, host: 2, port: 30000, type: BS}
+  fields: {AS: 2, host: 2, port: 30000, type: ''}
 - model: scionlab.service
   pk: 6
-  fields: {AS: 2, host: 2, port: 30001, type: PS}
+  fields: {AS: 2, host: 2, port: 30001, type: ''}
 - model: scionlab.service
   pk: 7
-  fields: {AS: 2, host: 2, port: 30002, type: CS}
+  fields: {AS: 2, host: 2, port: 30002, type: ''}
 - model: scionlab.service
   pk: 8
-  fields: {AS: 2, host: 2, port: 2181, type: ZK}
+  fields: {AS: 2, host: 2, port: 2181, type: ''}
 - model: scionlab.service
   pk: 9
-  fields: {AS: 3, host: 3, port: 30000, type: BS}
+  fields: {AS: 3, host: 3, port: 30000, type: ''}
 - model: scionlab.service
   pk: 10
-  fields: {AS: 3, host: 3, port: 30001, type: PS}
+  fields: {AS: 3, host: 3, port: 30001, type: ''}
 - model: scionlab.service
   pk: 11
-  fields: {AS: 3, host: 3, port: 30002, type: CS}
+  fields: {AS: 3, host: 3, port: 30002, type: ''}
 - model: scionlab.service
   pk: 12
-  fields: {AS: 3, host: 3, port: 2181, type: ZK}
+  fields: {AS: 3, host: 3, port: 2181, type: ''}
 - model: scionlab.service
   pk: 13
-  fields: {AS: 4, host: 4, port: 30000, type: BS}
+  fields: {AS: 4, host: 4, port: 30000, type: ''}
 - model: scionlab.service
   pk: 14
-  fields: {AS: 4, host: 4, port: 30001, type: PS}
+  fields: {AS: 4, host: 4, port: 30001, type: ''}
 - model: scionlab.service
   pk: 15
-  fields: {AS: 4, host: 4, port: 30002, type: CS}
+  fields: {AS: 4, host: 4, port: 30002, type: ''}
 - model: scionlab.service
   pk: 16
-  fields: {AS: 4, host: 4, port: 2181, type: ZK}
+  fields: {AS: 4, host: 4, port: 2181, type: ''}
 - model: scionlab.service
   pk: 17
-  fields: {AS: 5, host: 5, port: 30000, type: BS}
+  fields: {AS: 5, host: 5, port: 30000, type: ''}
 - model: scionlab.service
   pk: 18
-  fields: {AS: 5, host: 5, port: 30001, type: PS}
+  fields: {AS: 5, host: 5, port: 30001, type: ''}
 - model: scionlab.service
   pk: 19
-  fields: {AS: 5, host: 5, port: 30002, type: CS}
+  fields: {AS: 5, host: 5, port: 30002, type: ''}
 - model: scionlab.service
   pk: 20
-  fields: {AS: 5, host: 5, port: 2181, type: ZK}
+  fields: {AS: 5, host: 5, port: 2181, type: ''}
 - model: scionlab.service
   pk: 21
-  fields: {AS: 6, host: 6, port: 30000, type: BS}
+  fields: {AS: 6, host: 6, port: 30000, type: ''}
 - model: scionlab.service
   pk: 22
-  fields: {AS: 6, host: 6, port: 30001, type: PS}
+  fields: {AS: 6, host: 6, port: 30001, type: ''}
 - model: scionlab.service
   pk: 23
-  fields: {AS: 6, host: 6, port: 30002, type: CS}
+  fields: {AS: 6, host: 6, port: 30002, type: ''}
 - model: scionlab.service
   pk: 24
-  fields: {AS: 6, host: 6, port: 2181, type: ZK}
+  fields: {AS: 6, host: 6, port: 2181, type: ''}
 - model: scionlab.service
   pk: 25
-  fields: {AS: 7, host: 7, port: 30000, type: BS}
+  fields: {AS: 7, host: 7, port: 30000, type: ''}
 - model: scionlab.service
   pk: 26
-  fields: {AS: 7, host: 7, port: 30001, type: PS}
+  fields: {AS: 7, host: 7, port: 30001, type: ''}
 - model: scionlab.service
   pk: 27
-  fields: {AS: 7, host: 7, port: 30002, type: CS}
+  fields: {AS: 7, host: 7, port: 30002, type: ''}
 - model: scionlab.service
   pk: 28
-  fields: {AS: 7, host: 7, port: 2181, type: ZK}
+  fields: {AS: 7, host: 7, port: 2181, type: ''}
 - model: scionlab.service
   pk: 29
-  fields: {AS: 8, host: 8, port: 30000, type: BS}
+  fields: {AS: 8, host: 8, port: 30000, type: ''}
 - model: scionlab.service
   pk: 30
-  fields: {AS: 8, host: 8, port: 30001, type: PS}
+  fields: {AS: 8, host: 8, port: 30001, type: ''}
 - model: scionlab.service
   pk: 31
-  fields: {AS: 8, host: 8, port: 30002, type: CS}
+  fields: {AS: 8, host: 8, port: 30002, type: ''}
 - model: scionlab.service
   pk: 32
-  fields: {AS: 8, host: 8, port: 2181, type: ZK}
+  fields: {AS: 8, host: 8, port: 2181, type: ''}
 - model: scionlab.service
   pk: 33
-  fields: {AS: 9, host: 9, port: 30000, type: BS}
+  fields: {AS: 9, host: 9, port: 30000, type: ''}
 - model: scionlab.service
   pk: 34
-  fields: {AS: 9, host: 9, port: 30001, type: PS}
+  fields: {AS: 9, host: 9, port: 30001, type: ''}
 - model: scionlab.service
   pk: 35
-  fields: {AS: 9, host: 9, port: 30002, type: CS}
+  fields: {AS: 9, host: 9, port: 30002, type: ''}
 - model: scionlab.service
   pk: 36
-  fields: {AS: 9, host: 9, port: 2181, type: ZK}
+  fields: {AS: 9, host: 9, port: 2181, type: ''}
 - model: scionlab.service
   pk: 37
-  fields: {AS: 10, host: 10, port: 30000, type: BS}
+  fields: {AS: 10, host: 10, port: 30000, type: ''}
 - model: scionlab.service
   pk: 38
-  fields: {AS: 10, host: 10, port: 30001, type: PS}
+  fields: {AS: 10, host: 10, port: 30001, type: ''}
 - model: scionlab.service
   pk: 39
-  fields: {AS: 10, host: 10, port: 30002, type: CS}
+  fields: {AS: 10, host: 10, port: 30002, type: ''}
 - model: scionlab.service
   pk: 40
-  fields: {AS: 10, host: 10, port: 2181, type: ZK}
+  fields: {AS: 10, host: 10, port: 2181, type: ''}
 - model: scionlab.service
   pk: 41
-  fields: {AS: 11, host: 11, port: 30000, type: BS}
+  fields: {AS: 11, host: 11, port: 30000, type: ''}
 - model: scionlab.service
   pk: 42
-  fields: {AS: 11, host: 11, port: 30001, type: PS}
+  fields: {AS: 11, host: 11, port: 30001, type: ''}
 - model: scionlab.service
   pk: 43
-  fields: {AS: 11, host: 11, port: 30002, type: CS}
+  fields: {AS: 11, host: 11, port: 30002, type: ''}
 - model: scionlab.service
   pk: 44
-  fields: {AS: 11, host: 11, port: 2181, type: ZK}
+  fields: {AS: 11, host: 11, port: 2181, type: ''}
 - model: scionlab.service
   pk: 45
-  fields: {AS: 12, host: 12, port: 30000, type: BS}
+  fields: {AS: 12, host: 12, port: 30000, type: ''}
 - model: scionlab.service
   pk: 46
-  fields: {AS: 12, host: 12, port: 30001, type: PS}
+  fields: {AS: 12, host: 12, port: 30001, type: ''}
 - model: scionlab.service
   pk: 47
-  fields: {AS: 12, host: 12, port: 30002, type: CS}
+  fields: {AS: 12, host: 12, port: 30002, type: ''}
 - model: scionlab.service
   pk: 48
-  fields: {AS: 12, host: 12, port: 2181, type: ZK}
+  fields: {AS: 12, host: 12, port: 2181, type: ''}
 - model: scionlab.service
   pk: 49
-  fields: {AS: 13, host: 13, port: 30000, type: BS}
+  fields: {AS: 13, host: 13, port: 30000, type: ''}
 - model: scionlab.service
   pk: 50
-  fields: {AS: 13, host: 13, port: 30001, type: PS}
+  fields: {AS: 13, host: 13, port: 30001, type: ''}
 - model: scionlab.service
   pk: 51
-  fields: {AS: 13, host: 13, port: 30002, type: CS}
+  fields: {AS: 13, host: 13, port: 30002, type: ''}
 - model: scionlab.service
   pk: 52
-  fields: {AS: 13, host: 13, port: 2181, type: ZK}
+  fields: {AS: 13, host: 13, port: 2181, type: ''}
 - model: scionlab.service
   pk: 53
-  fields: {AS: 14, host: 14, port: 30000, type: BS}
+  fields: {AS: 14, host: 14, port: 30000, type: ''}
 - model: scionlab.service
   pk: 54
-  fields: {AS: 14, host: 14, port: 30001, type: PS}
+  fields: {AS: 14, host: 14, port: 30001, type: ''}
 - model: scionlab.service
   pk: 55
-  fields: {AS: 14, host: 14, port: 30002, type: CS}
+  fields: {AS: 14, host: 14, port: 30002, type: ''}
 - model: scionlab.service
   pk: 56
-  fields: {AS: 14, host: 14, port: 2181, type: ZK}
+  fields: {AS: 14, host: 14, port: 2181, type: ''}
 - model: scionlab.service
   pk: 57
-  fields: {AS: 15, host: 15, port: 30000, type: BS}
+  fields: {AS: 15, host: 15, port: 30000, type: ''}
 - model: scionlab.service
   pk: 58
-  fields: {AS: 15, host: 15, port: 30001, type: PS}
+  fields: {AS: 15, host: 15, port: 30001, type: ''}
 - model: scionlab.service
   pk: 59
-  fields: {AS: 15, host: 15, port: 30002, type: CS}
+  fields: {AS: 15, host: 15, port: 30002, type: ''}
 - model: scionlab.service
   pk: 60
-  fields: {AS: 15, host: 15, port: 2181, type: ZK}
+  fields: {AS: 15, host: 15, port: 2181, type: ''}

--- a/scionlab/fixtures/testtopo-ases.yaml
+++ b/scionlab/fixtures/testtopo-ases.yaml
@@ -261,181 +261,181 @@
     config_version: 5, config_version_deployed: 0}
 - model: scionlab.service
   pk: 1
-  fields: {AS: 1, host: 1, port: 30000, type: ''}
+  fields: {AS: 1, host: 1, port: 30000, type: BS}
 - model: scionlab.service
   pk: 2
-  fields: {AS: 1, host: 1, port: 30001, type: ''}
+  fields: {AS: 1, host: 1, port: 30001, type: PS}
 - model: scionlab.service
   pk: 3
-  fields: {AS: 1, host: 1, port: 30002, type: ''}
+  fields: {AS: 1, host: 1, port: 30002, type: CS}
 - model: scionlab.service
   pk: 4
-  fields: {AS: 1, host: 1, port: 2181, type: ''}
+  fields: {AS: 1, host: 1, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 5
-  fields: {AS: 2, host: 2, port: 30000, type: ''}
+  fields: {AS: 2, host: 2, port: 30000, type: BS}
 - model: scionlab.service
   pk: 6
-  fields: {AS: 2, host: 2, port: 30001, type: ''}
+  fields: {AS: 2, host: 2, port: 30001, type: PS}
 - model: scionlab.service
   pk: 7
-  fields: {AS: 2, host: 2, port: 30002, type: ''}
+  fields: {AS: 2, host: 2, port: 30002, type: CS}
 - model: scionlab.service
   pk: 8
-  fields: {AS: 2, host: 2, port: 2181, type: ''}
+  fields: {AS: 2, host: 2, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 9
-  fields: {AS: 3, host: 3, port: 30000, type: ''}
+  fields: {AS: 3, host: 3, port: 30000, type: BS}
 - model: scionlab.service
   pk: 10
-  fields: {AS: 3, host: 3, port: 30001, type: ''}
+  fields: {AS: 3, host: 3, port: 30001, type: PS}
 - model: scionlab.service
   pk: 11
-  fields: {AS: 3, host: 3, port: 30002, type: ''}
+  fields: {AS: 3, host: 3, port: 30002, type: CS}
 - model: scionlab.service
   pk: 12
-  fields: {AS: 3, host: 3, port: 2181, type: ''}
+  fields: {AS: 3, host: 3, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 13
-  fields: {AS: 4, host: 4, port: 30000, type: ''}
+  fields: {AS: 4, host: 4, port: 30000, type: BS}
 - model: scionlab.service
   pk: 14
-  fields: {AS: 4, host: 4, port: 30001, type: ''}
+  fields: {AS: 4, host: 4, port: 30001, type: PS}
 - model: scionlab.service
   pk: 15
-  fields: {AS: 4, host: 4, port: 30002, type: ''}
+  fields: {AS: 4, host: 4, port: 30002, type: CS}
 - model: scionlab.service
   pk: 16
-  fields: {AS: 4, host: 4, port: 2181, type: ''}
+  fields: {AS: 4, host: 4, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 17
-  fields: {AS: 5, host: 5, port: 30000, type: ''}
+  fields: {AS: 5, host: 5, port: 30000, type: BS}
 - model: scionlab.service
   pk: 18
-  fields: {AS: 5, host: 5, port: 30001, type: ''}
+  fields: {AS: 5, host: 5, port: 30001, type: PS}
 - model: scionlab.service
   pk: 19
-  fields: {AS: 5, host: 5, port: 30002, type: ''}
+  fields: {AS: 5, host: 5, port: 30002, type: CS}
 - model: scionlab.service
   pk: 20
-  fields: {AS: 5, host: 5, port: 2181, type: ''}
+  fields: {AS: 5, host: 5, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 21
-  fields: {AS: 6, host: 6, port: 30000, type: ''}
+  fields: {AS: 6, host: 6, port: 30000, type: BS}
 - model: scionlab.service
   pk: 22
-  fields: {AS: 6, host: 6, port: 30001, type: ''}
+  fields: {AS: 6, host: 6, port: 30001, type: PS}
 - model: scionlab.service
   pk: 23
-  fields: {AS: 6, host: 6, port: 30002, type: ''}
+  fields: {AS: 6, host: 6, port: 30002, type: CS}
 - model: scionlab.service
   pk: 24
-  fields: {AS: 6, host: 6, port: 2181, type: ''}
+  fields: {AS: 6, host: 6, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 25
-  fields: {AS: 7, host: 7, port: 30000, type: ''}
+  fields: {AS: 7, host: 7, port: 30000, type: BS}
 - model: scionlab.service
   pk: 26
-  fields: {AS: 7, host: 7, port: 30001, type: ''}
+  fields: {AS: 7, host: 7, port: 30001, type: PS}
 - model: scionlab.service
   pk: 27
-  fields: {AS: 7, host: 7, port: 30002, type: ''}
+  fields: {AS: 7, host: 7, port: 30002, type: CS}
 - model: scionlab.service
   pk: 28
-  fields: {AS: 7, host: 7, port: 2181, type: ''}
+  fields: {AS: 7, host: 7, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 29
-  fields: {AS: 8, host: 8, port: 30000, type: ''}
+  fields: {AS: 8, host: 8, port: 30000, type: BS}
 - model: scionlab.service
   pk: 30
-  fields: {AS: 8, host: 8, port: 30001, type: ''}
+  fields: {AS: 8, host: 8, port: 30001, type: PS}
 - model: scionlab.service
   pk: 31
-  fields: {AS: 8, host: 8, port: 30002, type: ''}
+  fields: {AS: 8, host: 8, port: 30002, type: CS}
 - model: scionlab.service
   pk: 32
-  fields: {AS: 8, host: 8, port: 2181, type: ''}
+  fields: {AS: 8, host: 8, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 33
-  fields: {AS: 9, host: 9, port: 30000, type: ''}
+  fields: {AS: 9, host: 9, port: 30000, type: BS}
 - model: scionlab.service
   pk: 34
-  fields: {AS: 9, host: 9, port: 30001, type: ''}
+  fields: {AS: 9, host: 9, port: 30001, type: PS}
 - model: scionlab.service
   pk: 35
-  fields: {AS: 9, host: 9, port: 30002, type: ''}
+  fields: {AS: 9, host: 9, port: 30002, type: CS}
 - model: scionlab.service
   pk: 36
-  fields: {AS: 9, host: 9, port: 2181, type: ''}
+  fields: {AS: 9, host: 9, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 37
-  fields: {AS: 10, host: 10, port: 30000, type: ''}
+  fields: {AS: 10, host: 10, port: 30000, type: BS}
 - model: scionlab.service
   pk: 38
-  fields: {AS: 10, host: 10, port: 30001, type: ''}
+  fields: {AS: 10, host: 10, port: 30001, type: PS}
 - model: scionlab.service
   pk: 39
-  fields: {AS: 10, host: 10, port: 30002, type: ''}
+  fields: {AS: 10, host: 10, port: 30002, type: CS}
 - model: scionlab.service
   pk: 40
-  fields: {AS: 10, host: 10, port: 2181, type: ''}
+  fields: {AS: 10, host: 10, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 41
-  fields: {AS: 11, host: 11, port: 30000, type: ''}
+  fields: {AS: 11, host: 11, port: 30000, type: BS}
 - model: scionlab.service
   pk: 42
-  fields: {AS: 11, host: 11, port: 30001, type: ''}
+  fields: {AS: 11, host: 11, port: 30001, type: PS}
 - model: scionlab.service
   pk: 43
-  fields: {AS: 11, host: 11, port: 30002, type: ''}
+  fields: {AS: 11, host: 11, port: 30002, type: CS}
 - model: scionlab.service
   pk: 44
-  fields: {AS: 11, host: 11, port: 2181, type: ''}
+  fields: {AS: 11, host: 11, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 45
-  fields: {AS: 12, host: 12, port: 30000, type: ''}
+  fields: {AS: 12, host: 12, port: 30000, type: BS}
 - model: scionlab.service
   pk: 46
-  fields: {AS: 12, host: 12, port: 30001, type: ''}
+  fields: {AS: 12, host: 12, port: 30001, type: PS}
 - model: scionlab.service
   pk: 47
-  fields: {AS: 12, host: 12, port: 30002, type: ''}
+  fields: {AS: 12, host: 12, port: 30002, type: CS}
 - model: scionlab.service
   pk: 48
-  fields: {AS: 12, host: 12, port: 2181, type: ''}
+  fields: {AS: 12, host: 12, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 49
-  fields: {AS: 13, host: 13, port: 30000, type: ''}
+  fields: {AS: 13, host: 13, port: 30000, type: BS}
 - model: scionlab.service
   pk: 50
-  fields: {AS: 13, host: 13, port: 30001, type: ''}
+  fields: {AS: 13, host: 13, port: 30001, type: PS}
 - model: scionlab.service
   pk: 51
-  fields: {AS: 13, host: 13, port: 30002, type: ''}
+  fields: {AS: 13, host: 13, port: 30002, type: CS}
 - model: scionlab.service
   pk: 52
-  fields: {AS: 13, host: 13, port: 2181, type: ''}
+  fields: {AS: 13, host: 13, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 53
-  fields: {AS: 14, host: 14, port: 30000, type: ''}
+  fields: {AS: 14, host: 14, port: 30000, type: BS}
 - model: scionlab.service
   pk: 54
-  fields: {AS: 14, host: 14, port: 30001, type: ''}
+  fields: {AS: 14, host: 14, port: 30001, type: PS}
 - model: scionlab.service
   pk: 55
-  fields: {AS: 14, host: 14, port: 30002, type: ''}
+  fields: {AS: 14, host: 14, port: 30002, type: CS}
 - model: scionlab.service
   pk: 56
-  fields: {AS: 14, host: 14, port: 2181, type: ''}
+  fields: {AS: 14, host: 14, port: 2181, type: ZK}
 - model: scionlab.service
   pk: 57
-  fields: {AS: 15, host: 15, port: 30000, type: ''}
+  fields: {AS: 15, host: 15, port: 30000, type: BS}
 - model: scionlab.service
   pk: 58
-  fields: {AS: 15, host: 15, port: 30001, type: ''}
+  fields: {AS: 15, host: 15, port: 30001, type: PS}
 - model: scionlab.service
   pk: 59
-  fields: {AS: 15, host: 15, port: 30002, type: ''}
+  fields: {AS: 15, host: 15, port: 30002, type: CS}
 - model: scionlab.service
   pk: 60
-  fields: {AS: 15, host: 15, port: 2181, type: ''}
+  fields: {AS: 15, host: 15, port: 2181, type: ZK}

--- a/scionlab/models.py
+++ b/scionlab/models.py
@@ -1090,20 +1090,10 @@ class Interface(models.Model):
         Get the link associated with this interface.
         :returns: Link
         """
-        return (
-            Link.objects.filter(interfaceA=self) |
-            Link.objects.filter(interfaceB=self)
-        ).get()
-
-    def link_relation(self):
-        if self.link().type == Link.PROVIDER:
-            # By definition, interfaceA is on the parent side
-            if self.link().interfaceA == self:
-                return "PARENT"
-            else:
-                return"CHILD"
+        if hasattr(self, 'link_as_interfaceA'):
+            return self.link_as_interfaceA
         else:
-            return self.link().type
+            return self.link_as_interfaceB
 
     def remote_interface(self):
         """

--- a/scionlab/models.py
+++ b/scionlab/models.py
@@ -14,7 +14,6 @@
 
 import base64
 import ipaddress
-
 import jsonfield
 import operator
 import os
@@ -1323,16 +1322,6 @@ class Link(models.Model):
             self.save()
             self.interfaceA.AS.hosts.bump_config()
             self.interfaceB.AS.hosts.bump_config()
-
-    def overlay(self):
-        link_overlay = "UDP/IPv6"
-        if self.interfaceA.public_ip and self.interfaceB.public_ip and \
-                isinstance(ipaddress.ip_address(self.interfaceA.public_ip),
-                           ipaddress.IPv4Address) and \
-                isinstance(ipaddress.ip_address(self.interfaceB.public_ip),
-                           ipaddress.IPv4Address):
-            link_overlay = "UDP/IPv4"
-        return link_overlay
 
     def get_interface_a(self):
         if hasattr(self, 'interfaceA'):

--- a/scionlab/models.py
+++ b/scionlab/models.py
@@ -910,12 +910,9 @@ class InterfaceManager(models.Manager):
         if public_port is None:
             public_port = portmap.get_port(effective_public_ip, DEFAULT_PUBLIC_PORT)
         if bind_port is None and effective_bind_ip is not None:
-            print('')
-            print('assigning bind_port')
             bind_port = portmap.get_port(effective_bind_ip,
                                          min=DEFAULT_PUBLIC_PORT,
                                          preferred=public_port)
-            print('bind_port', bind_port)
 
         as_.hosts.bump_config()
 

--- a/scionlab/models.py
+++ b/scionlab/models.py
@@ -1055,7 +1055,8 @@ class Interface(models.Model):
             self.host = host
             self.border_router = border_router
 
-    def _update_ports(self, public_port, bind_port, host_changed, public_ip_changed, bind_ip_changed):
+    def _update_ports(self, public_port, bind_port,
+                      host_changed, public_ip_changed, bind_ip_changed):
         """ Helper: update public port and bind port. """
 
         portmap = LazyPortMap(self.host.get_port_map)
@@ -1074,7 +1075,6 @@ class Interface(models.Model):
                 self.bind_port = portmap.get_port(self.get_bind_ip(),
                                                   min=DEFAULT_PUBLIC_PORT,
                                                   preferred=self.public_port)
-
 
     def get_public_ip(self):
         """ Get the effective public IP for this interface """
@@ -1402,13 +1402,13 @@ class BorderRouter(models.Model):
             if internal_port is not None:
                 self.internal_port = internal_port
             elif host_changed:
-                self.internal_port = portmap.get_port(host.internal_ip, DEFAULT_INTERNAL_PORT)
+                self.internal_port = portmap.get_port(self.host.internal_ip, DEFAULT_INTERNAL_PORT)
 
         if control_port is not _placeholder:
             if control_port is not None:
                 self.control_port = control_port
             elif host_changed:
-                self.control_port = portmap.get_port(host.internal_ip, DEFAULT_CONTROL_PORT)
+                self.control_port = portmap.get_port(self.host.internal_ip, DEFAULT_CONTROL_PORT)
 
 
 class ServiceManager(models.Manager):

--- a/scionlab/models.py
+++ b/scionlab/models.py
@@ -280,16 +280,6 @@ class AS(models.Model):
         """
         return self.isd_as_str().replace(":", "_")
 
-    def AS_internal_overlay(self):
-        hosts = Host.objects.filter(AS=self)
-        AS_internal_overlay = "UDP/IPv6"  # FIXME(FR4NK-W): should the AS overlay be explicit?
-        for host in hosts:
-            ip = ipaddress.ip_address(host.internal_ip)
-            if isinstance(ip, ipaddress.IPv4Address):
-                AS_internal_overlay = "UDP/IPv4"
-                break
-        return AS_internal_overlay
-
     def init_keys(self):
         """
         Initialise signing and encryption key pairs, the MasterASKey (used for

--- a/scionlab/models.py
+++ b/scionlab/models.py
@@ -853,8 +853,8 @@ class Host(models.Model):
 
     def get_port_map(self):
         """
-        Find a set of (UDP-)ports used.
-        :returns: PortMap of used UDP-ports
+        Find a set of ports used.
+        :returns: PortMap of used ports
         """
         portmap = PortMap()
         portmap.add(None, DISPATCHER_PORT)

--- a/scionlab/tests/test_admin.py
+++ b/scionlab/tests/test_admin.py
@@ -66,10 +66,8 @@ class LinkAdminFormTests(TestCase):
             mtu=2345,
             from_host=as_a.hosts.first().pk,
             from_public_port=50000,
-            from_internal_port=30000,
             to_host=as_b.hosts.first().pk,
             to_public_port=50000,
-            to_internal_port=30000,
         )
         form = LinkAdminForm(data=form_data)
         self.assertTrue(form.is_valid(), form.errors.as_data())
@@ -102,10 +100,8 @@ class LinkAdminFormTests(TestCase):
             to_host=as_b.hosts.first().pk,
             from_public_ip='192.0.2.1',
             from_public_port=50000,
-            from_internal_port=30001,
             to_public_ip='192.0.2.2',
             to_public_port=50001,
-            to_internal_port=30000,
         )
         form = LinkAdminForm(instance=link, data=form_data)
         self.assertTrue(form.is_valid(), form.errors.as_data())
@@ -117,10 +113,12 @@ class LinkAdminFormTests(TestCase):
         self.assertEqual(link.mtu, 2345)
         self.assertEqual(link.interfaceA.public_ip, '192.0.2.1')
         self.assertEqual(link.interfaceA.public_port, 50000)
-        self.assertEqual(link.interfaceA.internal_port, 30001)
         self.assertEqual(link.interfaceB.public_ip, '192.0.2.2')
         self.assertEqual(link.interfaceB.public_port, 50001)
-        self.assertEqual(link.interfaceB.internal_port, 30000)
+        #self.assertEqual(link.interfaceA.border_router.internal_port, 30000)
+        #self.assertEqual(link.interfaceA.border_router.control_port, 30001)
+        #self.assertEqual(link.interfaceB.border_router.internal_port, 30000)
+        #self.assertEqual(link.interfaceB.border_router.control_port, 30001)
 
         # Re-creating form with same data should result in no changes:
         edit_form = LinkAdminForm(instance=link, data=form_data)

--- a/scionlab/tests/test_admin.py
+++ b/scionlab/tests/test_admin.py
@@ -115,10 +115,6 @@ class LinkAdminFormTests(TestCase):
         self.assertEqual(link.interfaceA.public_port, 50000)
         self.assertEqual(link.interfaceB.public_ip, '192.0.2.2')
         self.assertEqual(link.interfaceB.public_port, 50001)
-        #self.assertEqual(link.interfaceA.border_router.internal_port, 30000)
-        #self.assertEqual(link.interfaceA.border_router.control_port, 30001)
-        #self.assertEqual(link.interfaceB.border_router.internal_port, 30000)
-        #self.assertEqual(link.interfaceB.border_router.control_port, 30001)
 
         # Re-creating form with same data should result in no changes:
         edit_form = LinkAdminForm(instance=link, data=form_data)

--- a/scionlab/tests/test_models.py
+++ b/scionlab/tests/test_models.py
@@ -14,7 +14,7 @@
 
 from unittest.mock import patch
 from django.test import TestCase
-from scionlab.models import ISD, AS, Link, Host, Interface, Service
+from scionlab.models import ISD, AS, Link, Host, Interface, BorderRouter, Service
 from scionlab.tests import utils
 
 
@@ -165,7 +165,9 @@ class LinkModificationTests(TestCase):
 
         # change the link from A-B to A-C
         as_c = self._as_c()
-        link.interfaceB.update(host=as_c.hosts.first())
+        link.interfaceB.update(
+            border_router=BorderRouter.objects.first_or_create(as_c.hosts.first())  # XXX
+        )
         self._sanity_check_link(link)
         self.assertEqual(
             list(Host.objects.needs_config_deployment()),

--- a/scionlab/tests/test_portmap.py
+++ b/scionlab/tests/test_portmap.py
@@ -1,0 +1,66 @@
+# Copyright 2018 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from unittest import TestCase
+from parameterized import parameterized
+from scionlab.util.portmap import PortMap
+
+_PARAMETERIZED_TEST_IPS = [('127.0.0.1',), (None,)]
+
+
+class PortMapTests(TestCase):
+    @parameterized.expand(_PARAMETERIZED_TEST_IPS)
+    def test_add(self, ip):
+        port = 30000
+        portmap = PortMap()
+        portmap.add(ip, port)
+        self.assertTrue(portmap.is_used(ip, port))
+        self.assertTrue(portmap.is_used(None, port))
+
+    @parameterized.expand(_PARAMETERIZED_TEST_IPS)
+    def test_empty(self, ip):
+        port = PortMap().get_port(ip, min=30000)
+        self.assertEqual(port, 30000)
+        port = PortMap().get_port(ip, min=30000, max=31000)
+        self.assertEqual(port, 30000)
+        port = PortMap().get_port(ip, min=30000, max=31000, preferred=30100)
+        self.assertEqual(port, 30100)
+        port = PortMap().get_port(ip, min=30000, max=31000, preferred=12345)  #
+        self.assertEqual(port, 12345)
+
+    @parameterized.expand(_PARAMETERIZED_TEST_IPS)
+    def test_used_after_get(self, ip):
+        min_port = 30000
+
+        portmap = PortMap()
+        self.assertTrue(portmap.is_free(ip, min_port))
+        port = portmap.get_port(ip, min_port)
+        self.assertEqual(port, min_port)
+        self.assertTrue(portmap.is_used(ip, port))
+        self.assertTrue(portmap.is_used(None, port))
+
+    @parameterized.expand(_PARAMETERIZED_TEST_IPS)
+    def test_sequential(self, ip):
+        min_port = 30000
+
+        portmap = PortMap()
+        port1 = portmap.get_port(ip, min_port)
+        port2 = portmap.get_port(ip, min_port)
+        port3 = portmap.get_port(ip, min_port, preferred=port1)  # ignored preferred
+
+        self.assertEqual([port1, port2, port3], [min_port, min_port+1, min_port+2])
+
+        with self.assertRaises(RuntimeError):
+            portmap.get_port(ip, min=min_port, max=port3)

--- a/scionlab/tests/test_user_as_views.py
+++ b/scionlab/tests/test_user_as_views.py
@@ -159,9 +159,10 @@ class UserASFormTests(TestCase):
 
         # Create a UserAS with the given data
         create_form = UserASForm(user=get_testuser(), data=form_data)
+        self.assertIsNotNone(create_form.as_table())
         self.assertTrue(create_form.is_valid(), create_form.errors)
         user_as = create_form.save()
-        self.assertIsNotNone(create_form)
+        self.assertIsNotNone(user_as)
 
         # Check that the form can be instantiated for the object just created
         # and check that the forms initial values are the same as the

--- a/scionlab/tests/utils.py
+++ b/scionlab/tests/utils.py
@@ -321,7 +321,7 @@ def _check_open_tarball(testcase, response):
     Check http-response headers and open tar ball from content.
     """
     testcase.assertTrue(re.search(r'attachment;\s*filename="[^"]*.tar.gz"',
-                        response['Content-Disposition']))
+                                  response['Content-Disposition']))
     testcase.assertEqual(response['Content-Type'], 'application/gzip')
     testcase.assertEqual(int(response['Content-Length']), len(response.content))
 
@@ -336,7 +336,7 @@ def _check_tarball_gen(testcase, tar, host):
     isd_str = 'ISD%i' % host.AS.isd.isd_id
     as_str = 'AS%s' % host.AS.as_path_str()
 
-    testcase.assertEqual([isd_str], _tar_ls(tar, 'gen'))
+    testcase.assertEqual([isd_str, 'dispatcher'], _tar_ls(tar, 'gen'))
     testcase.assertEqual([as_str], _tar_ls(tar, os.path.join('gen', isd_str)))
 
     as_gen_dir = os.path.join('gen', isd_str, as_str)

--- a/scionlab/util/archive.py
+++ b/scionlab/util/archive.py
@@ -103,7 +103,7 @@ class TarWriter(BaseArchiveWriter):
 
     def __init__(self, tar):
         """
-        :param tarfile.TarFile tar` the tar-file to write to.
+        :param tarfile.TarFile tar: the tar-file to write to.
         """
         self.tar = tar
 

--- a/scionlab/util/archive.py
+++ b/scionlab/util/archive.py
@@ -1,0 +1,79 @@
+# Copyright 2018 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import json
+import pathlib
+import tarfile
+import toml
+import yaml
+
+
+class BaseArchiveWriter:
+    def write_text(self, path, content):
+        raise NotImplementedError()
+
+    def write_json(self, path, content):
+        self.write_text(path, json.dumps(content, indent=2))
+
+    def write_toml(self, path, content):
+        self.write_text(path, toml.dumps(content))
+
+    def write_yaml(self, path, content):
+        self.write_text(path, yaml.dump(content, default_flow_style=False))
+
+    def write_config(self, path, config):
+        f = io.StringIO()
+        config.write(f)
+        self.write_text(path, f.getvalue())
+
+    def _normalize_path(self, path):
+        if isinstance(path, tuple):
+            return str(pathlib.PurePosixPath(*path))
+        else:
+            return path
+
+
+class FileArchiveWriter(BaseArchiveWriter):
+    def __init__(self, root):
+        self.root = root
+
+    def write_text(self, path, content):
+        filepath = pathlib.Path(self.root, self._normalize_path(path))
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        filepath.write_text(content)
+
+
+# Tape Archive Writer...
+class TarWriter(BaseArchiveWriter):
+    def __init__(self, tar):
+        self.tar = tar
+
+    def write_text(self, path, content):
+        path = self._normalize_path(path)
+        tar_add_textfile(self.tar, path, content)
+
+
+def tar_add_textfile(tar, path, content):
+    """
+    Helper for tarfile: add a text-file `name` with the given `content` to a tarfile `tar`.
+    :param TarFile tar: an open tarfile.TarFile
+    :param str path: name/path for the file in the tarfile
+    :param str content: file content
+    """
+    tarinfo = tarfile.TarInfo()
+    tarinfo.name = path
+    content_bytes = content.encode()
+    tarinfo.size = len(content_bytes)
+    tar.addfile(tarinfo, io.BytesIO(content_bytes))

--- a/scionlab/util/config_tar.py
+++ b/scionlab/util/config_tar.py
@@ -92,7 +92,7 @@ def _add_gen_folder(host, tar):
     # Add the gen/-folder
     gen_dir = tempfile.mkdtemp()
     generate.create_gen(host, gen_dir)
-    tar.add(gen_dir, arcname="gen")
+    tar.add(gen_dir + '/gen', arcname="gen")
     shutil.rmtree(gen_dir)
 
 

--- a/scionlab/util/generate.py
+++ b/scionlab/util/generate.py
@@ -18,14 +18,13 @@ from scionlab.models import Service, Interface
 import scionlab.util.local_config_util as generator
 
 
-def create_gen(host, host_gen_dir):
+def create_gen(host, archive):
     """
-    Generate the gen folder for the :host: in the :directory:
+    Generate the gen/ folder for the :host: in the given archive-writer
     :param host: Host object
-    :param host_gen_dir: output directory string, as an absolute path to an existing directory
+    :param scionlab.util.archive.BaseArchiveWriter archive: output archive-writer
     """
-    archive = generator.FileArchive(host_gen_dir)
-    tp, service_name_map = generate_topology_from_DB(host.AS)  # topology file
+    tp, service_name_map = _generate_topology_from_DB(host.AS)  # topology file
     _create_gen(host, archive, tp, service_name_map)
 
 
@@ -71,7 +70,7 @@ def _get_link_overlay_type_str(interface):
         return "UDP/IPv4"
 
 
-def generate_topology_from_DB(as_):
+def _generate_topology_from_DB(as_):
     """
     Generate the topology.conf from the database values
     :param AS as_: AS object

--- a/scionlab/util/generate.py
+++ b/scionlab/util/generate.py
@@ -14,8 +14,11 @@
 
 import ipaddress
 
-from scionlab.models import Service, Interface
+from scionlab.models import Service
 import scionlab.util.local_config_util as generator
+
+
+SERVICE_TYPES_CONTROL_PLANE = [Service.BS, Service.CS, Service.PS]
 
 
 def create_gen(host, archive):
@@ -24,11 +27,11 @@ def create_gen(host, archive):
     :param host: Host object
     :param scionlab.util.archive.BaseArchiveWriter archive: output archive-writer
     """
-    tp, service_name_map = _generate_topology_from_DB(host.AS)  # topology file
-    _create_gen(host, archive, tp, service_name_map)
+    topo_dict, router_names, service_names = _generate_topology_from_DB(host.AS)  # topology file
+    _create_gen(host, archive, topo_dict, router_names, service_names)
 
 
-def _create_gen(host, archive, tp, service_name_map):
+def _create_gen(host, archive, topo_dict, router_names, service_names):
     """
     Generate the gen folder for the :host: in the :directory:
     :param host: Host object
@@ -37,20 +40,147 @@ def _create_gen(host, archive, tp, service_name_map):
     :param service_name_map: map from Service object to instance name
     :return:
     """
+
     as_ = host.AS
-    for service in host.services.exclude(type=Service.ZK).iterator():
-        instance_name = service_name_map.get(service)
-        if instance_name:
-            generator.generate_instance_dir(archive, as_, service.type, tp, instance_name)
 
-    border_router_names = tp[generator.KEY_BR].keys()
-    for border_router in border_router_names:
-        generator.generate_instance_dir(archive, as_, 'BR', tp, border_router)
+    processes = []
 
-    generator.generate_sciond_config(archive, as_, tp)
-    generator.write_supervisord_group_config(archive, as_, tp)
+    for router in host.border_routers.iterator():
+        instance_name = router_names[router]
+        generator.generate_instance_dir(archive, as_, 'BR', topo_dict, instance_name)
+        processes.append(instance_name)
+
+    for service in host.services.filter(type__in=SERVICE_TYPES_CONTROL_PLANE):
+        instance_name = service_names[service]
+        generator.generate_instance_dir(archive, as_, service.type, topo_dict, instance_name)
+        processes.append(instance_name)
+
+    sciond_name = "sd%s" % as_.isd_as_path_str()
+    generator.generate_sciond_config(archive, as_, topo_dict, sciond_name)
+    processes.append(sciond_name)
+
+    generator.write_supervisord_group_config(archive, as_, processes)
 
     generator.write_dispatcher_config(archive)
+
+
+def _generate_topology_from_DB(as_):
+    """
+    Generate the topology.conf from the database values
+    :param AS as_: AS object
+    :return: topo_dict: topology dict, service_name_map: map from Service object to instance name
+    """
+    topo_dict = {}
+
+    # get overlay type inside AS from IPs used by hosts
+    address_type = _get_internal_address_type_str(as_)
+    overlay_type = "UDP/" + address_type
+
+    # AS wide entries
+    topo_dict["ISD_AS"] = as_.isd_as_str()
+    topo_dict["MTU"] = as_.mtu
+    topo_dict["Core"] = as_.is_core
+    topo_dict["Overlay"] = overlay_type
+
+    router_names = _get_router_names(as_)
+    _topo_add_routers(topo_dict, router_names, address_type)
+
+    service_names = _get_service_names(as_)
+    _topo_add_control_services(topo_dict, service_names, address_type)
+
+    _topo_add_zookeeper(topo_dict, as_)
+
+    return topo_dict, router_names, service_names
+
+
+def _topo_add_routers(topo_dict, routers, as_address_type):
+    """
+    Add entries for border routers to topology dict
+    """
+
+    topo_dict[generator.KEY_BR] = {}
+    for router, router_name in routers.items():
+        interfaces = router.interfaces.active()
+        if not interfaces:
+            continue
+
+        router_entry = _topo_add_router_entry(topo_dict, router, router_name, as_address_type)
+
+        for interface in interfaces:
+            remote_if_obj = interface.remote_interface()
+            remote_AS_obj = interface.remote_as()
+
+            link_overlay = _get_link_overlay_type_str(interface)
+
+            interface_entry = {
+                "ISD_AS": remote_AS_obj.isd_as_str(),
+                "LinkTo": str(interface.link_relation()),
+                "Bandwidth": interface.link().bandwidth,
+                "PublicOverlay": {
+                    "Addr": interface.get_public_ip(),
+                    "OverlayPort": interface.public_port
+                },
+                "MTU": interface.link().bandwidth,
+                "RemoteOverlay": {
+                    "Addr": remote_if_obj.get_public_ip(),
+                    "OverlayPort": remote_if_obj.public_port
+                },
+                "Overlay": link_overlay
+            }
+            if interface.get_bind_ip():
+                interface_entry.update({
+                    "BindOverlay": {
+                        "Addr": interface.get_bind_ip(),
+                        "OverlayPort": interface.bind_port or interface.public_port
+                    }
+                })
+            router_entry["Interfaces"][interface.interface_id] = interface_entry
+
+
+def _topo_add_router_entry(topo_dict, router, router_name, as_address_type):
+    return topo_dict[generator.KEY_BR].setdefault(router_name, {
+        "InternalAddrs": {
+            as_address_type: {
+                "PublicOverlay": {
+                    "Addr": router.host.internal_ip,
+                    "OverlayPort": router.internal_port
+                }
+            }
+        },
+        "CtrlAddr": {
+            as_address_type: {
+                "Public": {
+                    "Addr": router.host.internal_ip,
+                    "L4Port": router.control_port
+                }
+            }
+        },
+        "Interfaces": {}
+    })
+
+
+def _topo_add_control_services(topo_dict, service_names, as_address_type):
+    for service, service_name in service_names.items():
+        service_type_entry = topo_dict.setdefault(generator.TYPES_TO_KEYS[service.type], {})
+        service_type_entry[service_name] = {
+            "Addrs": {
+                as_address_type: {
+                    "Public": {
+                        "Addr": service.host.internal_ip,
+                        "L4Port": service.port
+                    }
+                }
+            }
+        }
+
+
+def _topo_add_zookeeper(topo_dict, as_):
+    for id, service in enumerate(as_.services.filter(type=Service.ZK), start=1):
+        zookeeper_dict = topo_dict.setdefault(generator.KEY_ZK, {})
+        zookeeper_dict[str(id)] = {
+            "Addr": service.host.internal_ip,
+            "L4Port": service.port
+        }
 
 
 def _get_internal_address_type_str(as_):
@@ -70,103 +200,18 @@ def _get_link_overlay_type_str(interface):
         return "UDP/IPv4"
 
 
-def _generate_topology_from_DB(as_):
-    """
-    Generate the topology.conf from the database values
-    :param AS as_: AS object
-    :return: topo_dict: topology dict, service_name_map: map from Service object to instance name
-    """
-    topo_dict = {}
-    service_name_map = {}
+def _get_router_names(as_):
+    router_names = {}
+    for id, router in enumerate(as_.border_routers.iterator(), start=1):
+        router_name = "br%s-%s" % (as_.isd_as_path_str(), id)
+        router_names[router] = router_name
+    return router_names
 
-    # get overlay type inside AS from IPs used by hosts
-    address_type = _get_internal_address_type_str(as_)
-    overlay_type = "UDP/" + address_type
 
-    # AS wide entries
-    topo_dict["ISD_AS"] = as_.isd_as_str()
-    topo_dict["MTU"] = as_.mtu
-    topo_dict["Core"] = as_.is_core
-    topo_dict["Overlay"] = overlay_type
-
-    topo_dict[generator.KEY_BR] = {}
-    interface_enumerator = Interface.get_interface_router_instance_ids(as_)
-    for router_instance_id, interface in interface_enumerator:
-        if not interface.link().active:
-            continue
-        router_instance_name = "%s%s-%s" % ("br", as_.isd_as_path_str(), router_instance_id)
-        router_instance_entry = topo_dict[generator.KEY_BR].setdefault(router_instance_name, {})
-        if router_instance_entry == {}:
-            router_instance_entry.update({
-                "InternalAddrs": {
-                    address_type: {
-                        "PublicOverlay": {
-                            "Addr": interface.host.internal_ip,
-                            "OverlayPort": interface.internal_port  # FIXME(matzf)
-                        }
-                    }
-                },
-                "CtrlAddr": {
-                    address_type: {
-                        "Public": {
-                            "Addr": interface.host.internal_ip,
-                            "L4Port": interface.internal_port + 1000  # FIXME(matzf)
-                        }
-                    }
-                },
-                "Interfaces": {}
-            })
-
-        remote_if_obj = interface.remote_interface()
-        remote_AS_obj = interface.remote_as()
-
-        link_overlay = _get_link_overlay_type_str(interface)
-
-        interface_entry = {
-            "ISD_AS": remote_AS_obj.isd_as_str(),
-            "LinkTo": str(interface.link_relation()),
-            "Bandwidth": interface.link().bandwidth,
-            "PublicOverlay": {
-                "Addr": interface.get_public_ip(),
-                "OverlayPort": interface.public_port
-            },
-            "MTU": interface.link().bandwidth,
-            "RemoteOverlay": {
-                "Addr": remote_if_obj.get_public_ip(),
-                "OverlayPort": remote_if_obj.public_port
-            },
-            "Overlay": link_overlay
-        }
-        if interface.get_bind_ip():
-            interface_entry["BindOverlay"] = {
-                "Addr": interface.get_bind_ip(),
-                "OverlayPort": interface.bind_port or interface.public_port
-            }
-        router_instance_entry["Interfaces"][interface.interface_id] = interface_entry
-
-    for stype in [Service.BS, Service.CS, Service.PS]:
-        service_enumerator = Service.get_service_type_ids(as_, stype)
-        for service_instance_id, service in service_enumerator:
-            service_instance_name = "%s%s-%s" % (service.type.lower(), as_.isd_as_path_str(),
-                                                 service_instance_id)
-            service_name_map[service] = service_instance_name
-            service_dict = topo_dict.setdefault(generator.TYPES_TO_KEYS[stype], {})
-            service_dict[service_instance_name] = {
-                "Addrs": {
-                    address_type: {
-                        "Public": {
-                            "Addr": service.host.internal_ip,
-                            "L4Port": service.port
-                        }
-                    }
-                }
-            }
-
-    for service_instance_id, service in Service.get_service_type_ids(as_, Service.ZK):
-        zookeeper_dict = topo_dict.setdefault(generator.KEY_ZK, {})
-        zookeeper_dict[str(service_instance_id)] = {
-            "Addr": service.host.internal_ip,
-            "L4Port": service.port
-        }
-
-    return topo_dict, service_name_map
+def _get_service_names(as_):
+    service_names = {}
+    for stype in SERVICE_TYPES_CONTROL_PLANE:
+        for id, service in enumerate(as_.services.filter(type=stype), start=1):
+            service_name = "%s%s-%s" % (service.type.lower(), as_.isd_as_path_str(), id)
+            service_names[service] = service_name
+    return service_names

--- a/scionlab/util/generate.py
+++ b/scionlab/util/generate.py
@@ -79,7 +79,6 @@ def _create_gen(host, gen_dir, tp, service_name_map):
 
     generator.generate_sciond_config(host.AS, tp, gen_dir)
     generator.write_dispatcher_config(gen_dir)
-    generator.write_overlay_config(gen_dir)
 
 
 def _get_internal_address_type_str(as_):

--- a/scionlab/util/generate.py
+++ b/scionlab/util/generate.py
@@ -14,7 +14,7 @@
 
 import ipaddress
 
-from scionlab.models import Service
+from scionlab.models import Service, Link
 import scionlab.util.local_config_util as generator
 
 
@@ -114,7 +114,7 @@ def _topo_add_routers(topo_dict, routers, as_address_type):
 
             interface_entry = {
                 "ISD_AS": remote_AS_obj.isd_as_str(),
-                "LinkTo": str(interface.link_relation()),
+                "LinkTo": _get_linkto_relation(interface),
                 "Bandwidth": interface.link().bandwidth,
                 "PublicOverlay": {
                     "Addr": interface.get_public_ip(),
@@ -198,6 +198,18 @@ def _get_link_overlay_type_str(interface):
         return "UDP/IPv6"
     else:
         return "UDP/IPv4"
+
+
+def _get_linkto_relation(interface):
+    link = interface.link()
+    if link.type == Link.PROVIDER:
+        # By definition, interfaceA is on the parent side
+        if link.interfaceA == interface:
+            return "CHILD"
+        else:
+            return"PARENT"
+    else:
+        return link.type
 
 
 def _get_router_names(as_):

--- a/scionlab/util/local_config_util.py
+++ b/scionlab/util/local_config_util.py
@@ -59,12 +59,14 @@ KEY_BR = 'BorderRouters'
 KEY_BS = 'BeaconService'
 KEY_CS = 'CertificateService'
 KEY_PS = 'PathService'
+KEY_ZK = 'ZookeeperService'
 
 TYPES_TO_KEYS = {
     "BR": KEY_BR,
     "BS": KEY_BS,
     "CS": KEY_CS,
     "PS": KEY_PS,
+    "ZK": KEY_ZK,
 }
 
 
@@ -120,7 +122,7 @@ def generate_instance_dir(archive, as_, stype, tp, name):
     """
     elem_dir = _elem_dir(as_, name)
 
-    prom_port = 123456  # TODO(matzf) should be obtained from model
+    prom_port = 31000 + (hash(name) % 1000)  # TODO(matzf) should be obtained from model
     prom_addr = "127.0.0.1:%i" % prom_port
     env = DEFAULT_ENV.copy()
     if stype == 'BR':
@@ -132,7 +134,7 @@ def generate_instance_dir(archive, as_, stype, tp, name):
         cmd = 'bin/path_server -config %s/psconfig.tom' % elem_dir
     else:  # beacon server
         assert stype == 'BS'
-        env.append('PYTHONPATH=python/')
+        env.append('PYTHONPATH=python/:.')
         cmd = ('python/bin/beacon_server --prom {prom} --sciond_path '
                '/run/shm/sciond/default.sock "{instance}" "{elem_dir}"'
                ).format(prom=prom_addr, instance=name, elem_dir=elem_dir)
@@ -259,14 +261,14 @@ def _write_certs_trc(archive, elem_dir, as_):
 
 
 def _write_keys(archive, elem_dir, as_):
-    archive.write_json(get_sig_key_file_path(elem_dir), as_.sig_priv_key)
-    archive.write_json(get_enc_key_file_path(elem_dir), as_.enc_priv_key)
-    archive.write_json(get_master_key_file_path(elem_dir, MASTER_KEY_0), as_.master_as_key)
-    archive.write_json(get_master_key_file_path(elem_dir, MASTER_KEY_1), as_.master_as_key)  # TODO
+    archive.write_text(get_sig_key_file_path(elem_dir), as_.sig_priv_key)
+    archive.write_text(get_enc_key_file_path(elem_dir), as_.enc_priv_key)
+    archive.write_text(get_master_key_file_path(elem_dir, MASTER_KEY_0), as_.master_as_key)
+    archive.write_text(get_master_key_file_path(elem_dir, MASTER_KEY_1), as_.master_as_key)  # TODO
     if as_.is_core:
-        archive.write_json(get_core_sig_key_file_path(elem_dir), as_.core_sig_priv_key)
-        archive.write_json(get_online_key_file_path(elem_dir), as_.core_online_priv_key)
-        archive.write_json(get_offline_key_file_path(elem_dir), as_.core_offline_priv_key)
+        archive.write_text(get_core_sig_key_file_path(elem_dir), as_.core_sig_priv_key)
+        archive.write_text(get_online_key_file_path(elem_dir), as_.core_online_priv_key)
+        archive.write_text(get_offline_key_file_path(elem_dir), as_.core_offline_priv_key)
 
 
 def _write_topo(archive, elem_dir, tp):

--- a/scionlab/util/local_config_util.py
+++ b/scionlab/util/local_config_util.py
@@ -123,12 +123,6 @@ def write_dispatcher_config(local_gen_path):
     _write_zlog_file('dispatcher', 'dispatcher', disp_folder_path)
 
 
-def write_overlay_config(local_gen_path):
-    overlay_file_path = os.path.join(local_gen_path, 'overlay')
-    if not os.path.exists(overlay_file_path):
-        write_file(overlay_file_path, 'UDP/IPv4')
-
-
 def _prep_supervisord_conf(instance_dict, executable_name, service_type, instance_name, as_):
     """
     Prepares the supervisord configuration for the infrastructure elements

--- a/scionlab/util/local_config_util.py
+++ b/scionlab/util/local_config_util.py
@@ -11,14 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-:mod:`local_config_util' --- library functions for SCION topology generator
-===========================================================================
-"""
-
-# This library file is created in order to use the functions from
-# services such as scion-coord, without having to run the whole
-# scion-web instance on that machine.
 
 # Stdlib
 import configparser
@@ -71,43 +63,6 @@ TYPES_TO_KEYS = {
 
 
 PROM_PORT_OFFSET = 1000  # TODO(matzf) move to model for port assignment
-
-
-class BaseArchive:
-    def write_text(self, path, content):
-        raise NotImplementedError()
-        # _tar_add_textfile(tar, path, content)
-        # self.files[path] = content.encode()
-
-    def write_json(self, path, content):
-        self.write_text(path, json.dumps(content, indent=2))
-
-    def write_toml(self, path, content):
-        self.write_text(path, toml.dumps(content))
-
-    def write_yaml(self, path, content):
-        self.write_text(path, yaml.dump(content, default_flow_style=False))
-
-    def write_config(self, path, config):
-        f = io.StringIO()
-        config.write(f)
-        self.write_text(path, f.getvalue())
-
-    def _normalize_path(self, path):
-        if isinstance(path, tuple):
-            return pathlib.Path(*path)
-        else:
-            return pathlib.Path(path)
-
-
-class FileArchive(BaseArchive):
-    def __init__(self, root):
-        self.root = root
-
-    def write_text(self, path, content):
-        filepath = pathlib.Path(self.root, self._normalize_path(path))
-        filepath.parent.mkdir(parents=True, exist_ok=True)
-        filepath.write_text(content)
 
 
 def generate_instance_dir(archive, as_, stype, tp, name):

--- a/scionlab/util/local_config_util.py
+++ b/scionlab/util/local_config_util.py
@@ -14,11 +14,7 @@
 
 # Stdlib
 import configparser
-import json
 import os
-import io
-import yaml
-import toml
 import pathlib
 from string import Template
 

--- a/scionlab/util/local_config_util.py
+++ b/scionlab/util/local_config_util.py
@@ -106,13 +106,12 @@ def generate_instance_dir(archive, as_, stype, tp, name):
     _write_keys(archive, elem_dir, as_)
 
 
-def generate_sciond_config(archive, as_, tp):
+def generate_sciond_config(archive, as_, tp, name):
     """
     Writes the endhost folder into the given location.
     :param AS as_: AS of the sciond instance
     :param dict tp: the topology as a dict of dicts.
     """
-    name = "sd%s" % as_.isd_as_path_str()
     elem_dir = _elem_dir(as_, "endhost")
 
     superv = _make_supervisord_conf(name,
@@ -128,19 +127,7 @@ def generate_sciond_config(archive, as_, tp):
     _write_certs_trc(archive, elem_dir, as_)
 
 
-def write_supervisord_group_config(archive, as_, tp):
-    # TODO(matzf): broken, needs to filter for processes on this host. More than one place!
-    processes = []
-    for svc_type in ["BorderRouters", "BeaconService",
-                     "CertificateService", "PathService"]:
-        if svc_type not in tp:
-            continue
-        for elem_id, elem in tp[svc_type].items():
-            processes.append(elem_id)
-
-    sd_id = "sd%s" % as_.isd_as_path_str()
-    processes.append(sd_id)
-
+def write_supervisord_group_config(archive, as_, processes):
     config = configparser.ConfigParser()
     config['group:' + "as%s" % as_.isd_as_path_str()] = {'programs': ",".join(processes)}
     archive.write_config((_isd_as_dir(as_), 'supervisord.conf'), config)

--- a/scionlab/util/portmap.py
+++ b/scionlab/util/portmap.py
@@ -1,0 +1,130 @@
+# Copyright 2018 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+MAX_PORT = 2**16-1
+
+
+class PortMap:
+    """
+    Simple helper for managing/assigning ports.
+    Keeps a set of used ports per IP.
+    The IP `None` is used for ports bound on any address (0.0.0.0 / ::).
+
+    Note: this map does not care about the type used to represent the IPs; it just assumes
+    that identical values represent identical addresses.
+    """
+
+    def __init__(self):
+        self.ports = dict()  # ports[ip] = set of used ports
+
+    def get_port(self, ip, min, max=MAX_PORT, preferred=None):
+        """
+        Get a free port for this IP address in the given range.
+        The returned port is immediately marked as used for the queried IP address.
+        :param ip: IP address or `None` for the unspecified address
+        :param int min: Start of acceptable port range
+        :param int max: Optional, end (included) of acceptable port range
+        :param int preferred: Optional, preferred port. Will be selected if free (range not checked)
+        :returns: Port
+        :raises: RuntimeError if no free port could be found
+        """
+        port = self._find_free_port(ip, min, max, preferred)
+        if port is None:
+            raise RuntimeError('No free port available in range')
+        self.add(ip, port)
+        return port
+
+    def _find_free_port(self, ip, min, max, preferred):
+        """
+        Find a free port for this IP address in the given range.
+        """
+        if preferred and self.is_free(ip, preferred):
+            return preferred
+        for port in range(min, max):
+            if self.is_free(ip, port):
+                return port
+        return None
+
+    def is_free(self, ip, port):
+        """
+        Check if the given IP/port combination is free.
+        :param ip: IP address or `None` for the unspecified address
+        :param int port: Port
+        :returns: True iff port is free
+        """
+        return not self.is_used(ip, port)
+
+    def is_used(self, ip, port):
+        """
+        check if the given ip/port combination is used.
+        :param ip: ip address or `none` for the unspecified address
+        :param int port: port
+        :returns: true iff port is used
+        """
+        if ip is not None:
+            return port in self.ports.get(ip, set()) or port in self.ports.get(None, set())
+        else:
+            return any(port in portset for portset in self.ports.values())
+
+    def add(self, ip, port):
+        """
+        add a ip/port combination to the set of used ports. this has no effect if it
+        is already present in the set of used ports.
+        :param ip: ip address or `none` for the unspecified address
+        :param int port: port
+        """
+        assert isinstance(port, int)
+        self.ports.setdefault(ip, set()).add(port)
+
+    def update(self, ip, ports):
+        """
+        Add many IP/port combination to the set of used ports. This has no effect if it
+        is already present in the set of used ports.
+        :param ip: IP address or `None` for the unspecified address
+        :param iterable ports: Ports
+        """
+        assert all(isinstance(port, int) for port in ports)
+        self.ports.setdefault(ip, set()).update(ports)
+
+
+class LazyPortMap:
+    """
+    Lazy Proxy for PortMap. Unfortuntely there doesn't seem to be a generic implementation for
+    this in the standard library (third party libraries exist).
+
+    To keep this simple and obvious, this is verbose rather than fancy.
+    """
+    def __init__(self, factory):
+        self._factory = factory
+        self.instance = None
+
+    def _wrapped(self):
+        if self.instance is None:
+            self.instance = self._factory()
+        return self.instance
+
+    def get_port(self, *args, **kwargs):
+        return self._wrapped().get_port(*args, **kwargs)
+
+    def is_free(self, *args, **kwargs):
+        return self._wrapped().is_free(*args, **kwargs)
+
+    def is_used(self, *args, **kwargs):
+        return self._wrapped().is_used(*args, **kwargs)
+
+    def add(self, *args, **kwargs):
+        return self._wrapped().add(*args, **kwargs)
+
+    def update(self, *args, **kwargs):
+        return self._wrapped().update(*args, **kwargs)


### PR DESCRIPTION
Updated the `local_config_util.py`. As various things had not been working, also includes assorted cleanup and fixes. With this version, the service in an AS seem to startup at least to the point where the certificates are missing (will investigate this further after rebasing the certificate work).

Add explicit BorderRouter object to hold configuration of internal and control address port


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/52)
<!-- Reviewable:end -->
