### PR TITLE
scion-configure script, config-info file 

### DIFF
--- a/scionlab/hostfiles/scionlab_config.py
+++ b/scionlab/hostfiles/scionlab_config.py
@@ -28,7 +28,10 @@ import sys
 from collections import namedtuple
 
 REQUEST_TIMEOUT_SECONDS = 10
-DEFAULT_CONFIG_INFO_PATH = os.path.expandvars('${SC}/gen/scionlab-host.json')
+
+DEFAULT_SCION_PATH = os.path.expanduser('~/go/src/github.com/scionproto/scion')
+SCION_PATH = os.path.environ('SC', DEFAULT_SCION_PATH)
+DEFAULT_CONFIG_INFO_PATH = os.path.join(SCION_PATH, 'gen/scionlab-config.json')
 DEFAULT_COORDINATOR_URL = 'https://www.scionlab.org'
 
 
@@ -45,9 +48,13 @@ def main():
         if config is _CONFIG_EMPTY:
             # stop_scion()
             pass
-        elif config is not _CONFIG_UNCHANGED:
+        elif config is _CONFIG_UNCHANGED:
+            # log debug
+            pass
+        else:
             new_config_info = unpack_config(config)
-            confirm_deployed(new_config_info)
+            if new_config_info:
+                confirm_deployed(new_config_info)
     else:
         tar = tarfile.open(args.tar, mode='r')
         unpack_config(tar)
@@ -131,10 +138,6 @@ def _load_config_info(file):
         _error_exit("Invalid scionlab config info file '%s'" % file, e)
 
 
-def unpack_config(tar):
-    pass
-
-
 def fetch_config(config_info):
     url = '{coordinator_url}/api/host/{host_id}/config'.format(
         coordinator_url=config_info.url,
@@ -192,6 +195,13 @@ def _http_post(url, params):
 def _error_exit(*args, **kwargs):
     logging.error(*args, **kwargs)
     sys.exit(1)
+
+
+def unpack_config(tar):
+    sc = SCION_PATH
+    tar.extract('scionlab-config.json', path=sc)
+    tar.extract('gen', path=sc)
+    pass
 
 
 if __name__ == '__main__':

--- a/scionlab/hostfiles/scionlab_config.py
+++ b/scionlab/hostfiles/scionlab_config.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# Copyright 2018 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+TODO(matzf) doc
+"""
+
+import argparse
+import io
+import json
+import logging
+import os
+import tarfile
+import urllib.request
+import sys
+from collections import namedtuple
+
+REQUEST_TIMEOUT_SECONDS = 10
+DEFAULT_CONFIG_INFO_PATH = os.path.expandvars('${SC}/gen/scionlab-host.json')
+DEFAULT_COORDINATOR_URL = 'https://www.scionlab.org'
+
+
+_CONFIG_EMPTY = object()
+_CONFIG_UNCHANGED = object()
+
+
+def main():
+    args = parse_command_line_args()
+
+    if not args.tar:
+        config_info = get_config_info(args)
+        config = fetch_config(config_info)
+        if config is _CONFIG_EMPTY:
+            # stop_scion()
+            pass
+        elif config is not _CONFIG_UNCHANGED:
+            new_config_info = unpack_config(config)
+            confirm_deployed(new_config_info)
+    else:
+        tar = tarfile.open(args.tar, mode='r')
+        unpack_config(tar)
+
+
+def parse_command_line_args():
+    parser = argparse.ArgumentParser(description='')  # TODO(matzf) doc
+
+    group_fetch = parser.add_argument_group('Fetch configuration options')
+    parser.add_argument('--config-info',
+                        help="Path to json file containing host-id, secret and the local version. "
+                             "(default=%s)" % DEFAULT_CONFIG_INFO_PATH)
+    group_fetch.add_argument('--host-id', help='The host ID of the ',
+                             type=int)
+    group_fetch.add_argument('--host-secret', help='The secret for this host')
+    # Either 'local-version' or 'force'
+    group_version = group_fetch.add_mutually_exclusive_group()
+    group_version.add_argument('--local-version', help='',
+                               action='store', type=int)
+    group_version.add_argument('--force', help='',
+                               action='store_true')
+    group_fetch.add_argument('--url', help='URL of the SCIONLab coordination service')
+
+    parser.add_argument('--tar')
+    return parser.parse_args()
+
+
+ConfigInfo = namedtuple('ConfigInfo',
+                        ['host_id',
+                         'host_secret',
+                         'url',
+                         'version'])
+
+
+def get_config_info(args):
+    if args.config_info:
+        return _get_config_info_from_file(args.config_info)
+    elif args.host_id or args.host_secret:
+        if not args.host_id and args.host_secret:
+            _error_exit("Either none of or --host-id and --host-secret parameters need to be set")
+        return ConfigInfo(args.host_id,
+                          args.host_secret,
+                          args.url or DEFAULT_COORDINATOR_URL,
+                          args.local_version if not args.force else None)
+    else:
+        if not os.path.exists(DEFAULT_CONFIG_INFO_PATH):
+            _error_exit("No scionlab config info file found at '%s'. Please specify the path to "
+                        "an existing config info file with --config-info, or explicitly provide "
+                        "authentication parameters for this host with --host-id and --host-secret."
+                        % DEFAULT_CONFIG_INFO_PATH)
+        return _get_config_info_from_file(DEFAULT_CONFIG_INFO_PATH)
+
+
+def _get_config_info_from_file(file, args):
+    """
+    Load config info file.
+    Overwrite url with the URL argument.
+    Overwrite the version if '--force' or '--local-version' are given.
+    """
+    config_info = _load_config_info(DEFAULT_CONFIG_INFO_PATH)
+    config_info.url = args.url or config_info.url or DEFAULT_COORDINATOR_URL
+    if args.force:
+        config_info.version = None
+    elif args.local_version:
+        config_info.version = args.local_version
+    return config_info
+
+
+def _load_config_info(file):
+    try:
+        with open(file, 'r') as f:
+            config_info_dict = json.load(f)
+    except IOError as e:
+        _error_exit("Error loading the scionlab config info file '%s'" % file, e)
+    try:
+        return ConfigInfo(config_info_dict['host_id'],
+                          config_info_dict['host_secret'],
+                          config_info_dict.get('url'),
+                          config_info_dict.get('version'))
+    except KeyError as e:
+        _error_exit("Invalid scionlab config info file '%s'" % file, e)
+
+
+def unpack_config(tar):
+    pass
+
+
+def fetch_config(config_info):
+    url = '{coordinator_url}/api/host/{host_id}/config'.format(
+        coordinator_url=config_info.url,
+        host_id=config_info.host_id
+    )
+    data = {'secret': config_info.host_secret}
+    # version may be None (if "--force" is used or if version is not in the config info file)
+    if config_info.version:
+        data['version'] = config_info.version
+
+    try:
+        conn = _http_get(url, data)
+        response_data = conn.read()
+    except urllib.error.HTTPError as e:
+        if e.code == 304:
+            return _CONFIG_EMPTY
+        elif e.code == 204:
+            return _CONFIG_UNCHANGED
+        else:
+            _error_exit("Failed to fetch configuration from SCIONLab coordinator at '%s'"
+                        % config_info.url, e)
+    return tarfile.open(mode='r:gz', fileobj=io.BytesIO(response_data))
+
+
+def confirm_deployed(config_info):
+    url = '{coordinator_url}/api/host/{host_id}/deployed_config_version'.format(
+        coordinator_url=config_info.url,
+        host_id=config_info.host_id
+    )
+    data = {'secret': config_info.host_secret, 'version': config_info.host_version}
+    _http_post(url, data)
+
+
+def _http_get(url, params):
+    """ Helper: make GET request to URL with given params
+    :returns: urlopen return
+    """
+    return urllib.request.urlopen(
+        url + '?' + urllib.parse.urlencode(params),
+        timeout=REQUEST_TIMEOUT_SECONDS
+    )
+
+
+def _http_post(url, params):
+    """ Helper: make POST request to URL with given params """
+    request = urllib.request.Request(
+        url,
+        data=urllib.parse.urlencode(params).encode('utf-8'),
+        method='POST',
+        timeout=REQUEST_TIMEOUT_SECONDS
+    )
+    return urllib.request.urlopen(request)
+
+
+def _error_exit(*args, **kwargs):
+    logging.error(*args, **kwargs)
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scionlab/hostfiles/scionlab_config.py
+++ b/scionlab/hostfiles/scionlab_config.py
@@ -18,6 +18,7 @@ TODO(matzf) doc
 """
 
 import argparse
+import base64
 import io
 import json
 import logging
@@ -48,7 +49,7 @@ ConfigInfo = namedtuple('ConfigInfo',
 
 
 def main():
-    sys.traceback = None
+    sys.tracebacklimit = -1
     args = parse_command_line_args()
 
     if not args.tar:
@@ -58,8 +59,8 @@ def main():
             # stop_scion()
             pass
         elif config is _CONFIG_UNCHANGED:
-            # log debug
-            pass
+            logging.info('Configuration unchanged (version %s). Nothing to do.',
+                         config_info.version)
         else:
             install_config(config)
             confirm_deployed(args)
@@ -69,15 +70,14 @@ def main():
 
 
 def parse_command_line_args():
-    parser = argparse.ArgumentParser(description='')  # TODO(matzf) doc
+    parser = argparse.ArgumentParser(description='Install configuration for a SCIONLab host.')
 
-    group_fetch = parser.add_argument_group('Fetch configuration options')
+    group_fetch = parser.add_argument_group('Fetch options')
     parser.add_argument('--config-info',
                         help="Path to json file containing host-id, secret and the local version. "
                              "(default=%s)" % DEFAULT_CONFIG_INFO_PATH)
-    group_fetch.add_argument('--host-id', help='The host ID of the ',
-                             type=int)
-    group_fetch.add_argument('--host-secret', help='The secret for this host')
+    group_fetch.add_argument('--host-id', help='Host identifier', type=int)
+    group_fetch.add_argument('--host-secret', help='Authentication for host')
     # Either 'local-version' or 'force'
     group_version = group_fetch.add_mutually_exclusive_group()
     group_version.add_argument('--local-version', help='',
@@ -87,6 +87,7 @@ def parse_command_line_args():
     group_fetch.add_argument('--url', help='URL of the SCIONLab coordination service')
 
     parser.add_argument('--tar')
+
     return parser.parse_args()
 
 
@@ -104,8 +105,8 @@ def get_config_info(args):
         if not os.path.exists(DEFAULT_CONFIG_INFO_PATH):
             _error_exit("No scionlab config info file found at '%s'. Please specify the path to "
                         "an existing config info file with --config-info, or explicitly provide "
-                        "authentication parameters for this host with --host-id and --host-secret."
-                        % DEFAULT_CONFIG_INFO_PATH)
+                        "authentication parameters for this host with --host-id and --host-secret.",
+                        DEFAULT_CONFIG_INFO_PATH)
         return _get_config_info_from_file(DEFAULT_CONFIG_INFO_PATH, args)
 
 
@@ -116,85 +117,132 @@ def _get_config_info_from_file(file, args):
     Overwrite the version if '--force' or '--local-version' are given.
     """
     config_info = _load_config_info(file)
-    url = args.url or config_info.url or DEFAULT_COORDINATOR_URL
-    version = config_info.version
+
+    if args.url:
+        config_info = config_info._replace(url=args.url)
+
     if args.force:
-        version = None
+        config_info = config_info._replace(version=None)
     elif args.local_version:
-        version = args.local_version
-    return config_info._replace(url=url, version=version)
+        config_info = config_info._replace(version=args.local_version)
+
+    return config_info
 
 
 def _load_config_info(file):
+    """
+    Load and parse the config info json-file.
+    :returns: ConfigInfo
+    """
     try:
         with open(file, 'r') as f:
             config_info_dict = json.load(f)
     except IOError as e:
-        _error_exit("Error loading the scionlab config info file '%s'" % file, e)
+        _error_exit("Error loading the scionlab config info file '%s': %s", file, e)
     try:
         return ConfigInfo(config_info_dict['host_id'],
                           config_info_dict['host_secret'],
-                          config_info_dict.get('url'),
+                          config_info_dict.get('url') or DEFAULT_COORDINATOR_URL,
                           config_info_dict.get('version'))
     except KeyError as e:
-        _error_exit("Invalid scionlab config info file '%s'" % file, e)
+        _error_exit("Invalid scionlab config info file '%s': %s", file, e)
 
 
 def fetch_config(config_info):
+    """
+    Request configuration tar-ball from SCIONLab coordinator.
+
+    If available from either the config file or the command line and --force is not used, the
+    request sent to the coordinator will include the currently installed version. If the current
+    version is already the latest version, the server will reply with 304 Not Modified.
+
+    :param ConfigInfo config_info: base url, host-id/secret for authentication, version (optional).
+    :returns:
+        - _CONFIG_UNCHANGED if the current version is already the latest version, or
+        - _CONFIG_EMPTY if there is currently no configuration for this host, or
+        - tarfile.tar the configuration archive
+    """
+
     url = '{coordinator_url}/api/host/{host_id}/config'.format(
-        coordinator_url=config_info.url,
+        coordinator_url=config_info.url.rstrip('/'),
         host_id=config_info.host_id
     )
-    data = {'secret': config_info.host_secret}
+
     # version may be None (if "--force" is used or if version is not in the config info file)
+    data = {}
     if config_info.version:
         data['version'] = config_info.version
 
     try:
-        conn = _http_get(url, data)
+        conn = _http_get(url, data, username=config_info.host_id, password=config_info.host_secret)
         response_data = conn.read()
     except urllib.error.HTTPError as e:
         if e.code == 304:
-            return _CONFIG_EMPTY
-        elif e.code == 204:
             return _CONFIG_UNCHANGED
+        elif e.code == 204:
+            return _CONFIG_EMPTY
         else:
-            _error_exit("Failed to fetch configuration from SCIONLab coordinator at '%s'"
-                        % config_info.url, e)
+            _error_exit("Failed to fetch configuration from SCIONLab coordinator at %s: %s",
+                        config_info.url, e)
+    except Exception as e:
+            _error_exit("Failed to fetch configuration from SCIONLab coordinator at %s: %s",
+                        config_info.url, e)
     return tarfile.open(mode='r:gz', fileobj=io.BytesIO(response_data))
 
 
 def confirm_deployed(args):
+    """
+    Inform the SCIONLab coordinator of the currently installed version of the configuration. This
+    confirms that this version has been sucessfully installed. This information is used coordinator
+    by the coordinator only in the case where it actively pushes configuration to a host. A failure
+    in this step is generally unproblematic.
+
+    :param args: commandline arguments for optional coordinator URL
+    """
     # Get newly installed config info
     config_info = _load_config_info(DEFAULT_CONFIG_INFO_PATH)
     if args.url:
         config_info = config_info._replace(url=args.url)
 
     url = '{coordinator_url}/api/host/{host_id}/deployed_config_version'.format(
-        coordinator_url=config_info.url,
+        coordinator_url=config_info.url.rstrip('/'),
         host_id=config_info.host_id
     )
-    data = {'secret': config_info.host_secret, 'version': config_info.version}
-    _http_post(url, data)
+    data = {'version': config_info.version}
+    _http_post(url, data, username=config_info.host_id, password=config_info.host_secret)
 
 
-def _http_get(url, params):
-    """ Helper: make GET request to URL with given params
-    :returns: urlopen return
-    """
+def _http_get(url, params, username, password):
+    """ Helper: make GET request to URL with given params.  """
+    query = ''
+    if params:
+        query += '?' + urllib.parse.urlencode(params)
+    request = urllib.request.Request(url + query)
+    _add_basic_auth(request, username, password)
     return urllib.request.urlopen(
-        url + '?' + urllib.parse.urlencode(params),
+        request,
         timeout=REQUEST_TIMEOUT_SECONDS
     )
 
 
-def _http_post(url, params):
+def _http_post(url, params, username, password):
     """ Helper: make POST request to URL with given params """
+
+    request = urllib.request.Request(url,
+                                     data=urllib.parse.urlencode(params).encode('utf-8'),
+                                     method='POST')
+    _add_basic_auth(request, username, password)
     return urllib.request.urlopen(
-        url,
-        data=urllib.parse.urlencode(params).encode('utf-8'),
+        request,
         timeout=REQUEST_TIMEOUT_SECONDS
     )
+
+
+def _add_basic_auth(request, username, password):
+    """ Helper: add basic authorization header to a request """
+    uname_pwd = '%s:%s' % (username, password)
+    uname_pwd_encoded = base64.b64encode(uname_pwd.encode('utf-8')).decode('ascii')
+    request.add_header("Authorization", "Basic %s" % uname_pwd_encoded)
 
 
 def _error_exit(*args, **kwargs):
@@ -205,7 +253,7 @@ def _error_exit(*args, **kwargs):
 def install_config(tar):
     sc = SCION_PATH
     if not os.path.isdir(sc):
-        _error_exit('No SCION installation found at $SC (%s).' % sc)
+        _error_exit('No SCION installation found at $SC (%s).', sc)
 
     gen_members = [f for f in tar.getmembers() if f.path == 'gen' or f.path.startswith('gen/')]
     tar.extractall(members=gen_members, path=sc)

--- a/scionlab/hostfiles/scionlab_config.py
+++ b/scionlab/hostfiles/scionlab_config.py
@@ -293,8 +293,11 @@ def install_vpn_client_config(tmpdir):
 def install_vpn_server_config(tmpdir):
     changed = _install_file(tmpdir, 'server.conf', '/etc/openvpn/')
     if changed:
-        subprocess.check_call(['sudo', 'systemctl', 'reload-or-restart', 'openvpn@client'])
+        subprocess.check_call(['sudo', 'systemctl', 'reload-or-restart', 'openvpn@server'])
     _sudo_mv(os.path.join(tmpdir, 'openvpn_ccd'), '/etc/openvpn')
+    if not os.path.exists('/etc/openvpn/dh.pem'):
+        subprocess.check_call(['sudo', 'openssl', 'dhparam', '-out', 'dh.pem', '2048'],
+                              cwd='/etc/openvpn/')
 
 
 def _mv_dir(srcdir, dirname, dstdir):

--- a/scionlab/tests/test_api.py
+++ b/scionlab/tests/test_api.py
@@ -15,6 +15,13 @@
 from django.test import TestCase
 from scionlab.models import Host
 from scionlab.tests import utils
+import base64
+
+
+def _basic_auth(username, password):
+    uname_pwd = '%s:%s' % (username, password)
+    uname_pwd_encoded = base64.b64encode(uname_pwd.encode('utf-8')).decode('ascii')
+    return {"HTTP_AUTHORIZATION": "Basic %s" % uname_pwd_encoded}
 
 
 class GetHostConfigTests(TestCase):
@@ -24,54 +31,60 @@ class GetHostConfigTests(TestCase):
         # Avoid duplication, get this info here:
         self.host = Host.objects.last()
         self.url = '/api/host/%i/config' % self.host.pk
+        self.auth_headers = _basic_auth(self.host.id, self.host.secret)
 
-    def test_bad_secret(self):
-        ret = self.client.get(self.url, {'secret': self.host.secret + '_foobar'})
-        self.assertEqual(ret.status_code, 403)
+    def test_aaa(self):
+        ret = self.client.get(self.url, **self.auth_headers)
+        self.assertEqual(ret.status_code, 200)
 
-    def test_no_secret(self):
+    def test_bad_auth(self):
+        auth_headers = _basic_auth(self.host.id, self.host.secret + "_foobar")
+        ret = self.client.get(self.url, **auth_headers)
+        self.assertEqual(ret.status_code, 401)
+
+    def test_no_auth(self):
         ret = self.client.get(self.url)
-        self.assertEqual(ret.status_code, 403)
+        self.assertEqual(ret.status_code, 401)
 
     def test_bad_request(self):
-        ret = self.client.get(self.url, {'secret': self.host.secret, 'version': 'nan'})
+        ret = self.client.get(self.url, {'version': 'nan'}, **self.auth_headers)
         self.assertEqual(ret.status_code, 400)
 
     def test_post_not_allowed(self):
-        ret = self.client.post(self.url, {'secret': self.host.secret, 'version': 1})
+        ret = self.client.post(self.url, {'version': 1}, **self.auth_headers)
         self.assertEqual(ret.status_code, 405)
 
     def test_unchanged(self):
-        request_data = {'secret': self.host.secret, 'version': self.host.config_version}
+        request_data = {'version': self.host.config_version}
 
-        ret = self.client.get(self.url, request_data)
+        ret = self.client.get(self.url, request_data, **self.auth_headers)
         self.assertEqual(ret.status_code, 304)
 
-        ret = self.client.head(self.url, request_data)
+        ret = self.client.head(self.url, request_data, **self.auth_headers)
         self.assertEqual(ret.status_code, 304)
 
     def test_changed(self):
         prev_version = self.host.config_version
         self.host.bump_config()
-        request_data = {'secret': self.host.secret, 'version': prev_version}
+        request_data = {'version': prev_version}
 
-        ret_get = self.client.get(self.url, request_data)
+        ret_get = self.client.get(self.url, request_data, **self.auth_headers)
         self.assertEqual(ret_get.status_code, 200)
         utils.check_tarball_host(self, ret_get, self.host)
 
-        ret_head = self.client.head(self.url, request_data)
+        ret_head = self.client.head(self.url, request_data, **self.auth_headers)
         self.assertEqual(ret_head.status_code, 200)
         self.assertEqual(ret_head._headers, ret_get._headers)
 
     def test_empty(self):
         prev_version = self.host.config_version
         self.host.AS.delete()  # Nothing left to do for this host
-        request_data = {'secret': self.host.secret, 'version': prev_version}
+        request_data = {'version': prev_version}
 
-        ret = self.client.get(self.url, request_data)
+        ret = self.client.get(self.url, request_data, **self.auth_headers)
         self.assertEqual(ret.status_code, 204)
 
-        ret = self.client.head(self.url, request_data)
+        ret = self.client.head(self.url, request_data, **self.auth_headers)
         self.assertEqual(ret.status_code, 204)
 
 
@@ -82,21 +95,23 @@ class PostHostConfigVersionTests(TestCase):
         # Avoid duplication, get this info here:
         self.host = Host.objects.last()
         self.url = '/api/host/%i/deployed_config_version' % self.host.pk
+        self.auth_headers = _basic_auth(self.host.id, self.host.secret)
 
-    def test_bad_secret(self):
-        ret = self.client.post(self.url, {'secret': self.host.secret + '_foobar'})
-        self.assertEqual(ret.status_code, 403)
+    def test_bad_auth(self):
+        auth_headers = _basic_auth(self.host.id, self.host.secret + "_foobar")
+        ret = self.client.post(self.url, **auth_headers)
+        self.assertEqual(ret.status_code, 401)
 
-    def test_no_secret(self):
+    def test_no_auth(self):
         ret = self.client.post(self.url)
-        self.assertEqual(ret.status_code, 403)
+        self.assertEqual(ret.status_code, 401)
 
     def test_bad_request(self):
-        ret = self.client.post(self.url, {'secret': self.host.secret, 'version': 'nan'})
+        ret = self.client.post(self.url, {'version': 'nan'}, **self.auth_headers)
         self.assertEqual(ret.status_code, 400)
 
     def test_get_not_allowed(self):
-        ret = self.client.get(self.url, {'secret': self.host.secret, 'version': 1})
+        ret = self.client.get(self.url, {'version': 1}, **self.auth_headers)
         self.assertEqual(ret.status_code, 405)
 
     def test_older_than_prev_deployed(self):
@@ -105,18 +120,21 @@ class PostHostConfigVersionTests(TestCase):
         self.host.config_version += 1
         self.host.save()
 
-        ret = self.client.post(self.url, {'secret': self.host.secret,
-                                          'version': self.host.config_version_deployed - 1})
+        ret = self.client.post(self.url,
+                               {'version': self.host.config_version_deployed - 1},
+                               **self.auth_headers)
         self.assertEqual(ret.status_code, 304)
 
     def test_newer_than_config(self):
-        ret = self.client.post(self.url, {'secret': self.host.secret,
-                                          'version': self.host.config_version + 1})
+        ret = self.client.post(self.url,
+                               {'version': self.host.config_version + 1},
+                               **self.auth_headers)
         self.assertEqual(ret.status_code, 304)
 
     def test_success(self):
-        ret = self.client.post(self.url, {'secret': self.host.secret,
-                                          'version': self.host.config_version})
+        ret = self.client.post(self.url,
+                               {'version': self.host.config_version},
+                               **self.auth_headers)
         self.assertEqual(ret.status_code, 200)
 
         self.host.refresh_from_db()

--- a/scionlab/tests/test_api.py
+++ b/scionlab/tests/test_api.py
@@ -65,3 +65,12 @@ class GetHostConfigTests(TestCase):
 
         ret = self.client.head(self.host_config_url, request_data)
         self.assertEqual(ret.status_code, 204)
+
+
+class PostHostConfigVersionTests(TestCase):
+    fixtures = ['testtopo-ases-links']
+
+    def setUp(self):
+        # Avoid duplication, get this info here:
+        self.host = Host.objects.last()
+        self.host_config_url = '/api/host/%i' % self.host.pk

--- a/scionlab/tests/test_api.py
+++ b/scionlab/tests/test_api.py
@@ -118,3 +118,6 @@ class PostHostConfigVersionTests(TestCase):
         ret = self.client.post(self.url, {'secret': self.host.secret,
                                           'version': self.host.config_version})
         self.assertEqual(ret.status_code, 200)
+
+        self.host.refresh_from_db()
+        self.assertEqual(self.host.config_version_deployed, self.host.config_version)

--- a/scionlab/tests/utils.py
+++ b/scionlab/tests/utils.py
@@ -348,7 +348,7 @@ def _check_tarball_gen(testcase, tar, host):
     isd_str = 'ISD%i' % host.AS.isd.isd_id
     as_str = 'AS%s' % host.AS.as_path_str()
 
-    testcase.assertEqual([isd_str, 'dispatcher'], _tar_ls(tar, 'gen'))
+    testcase.assertEqual([isd_str, 'dispatcher', 'scionlab-config.json'], _tar_ls(tar, 'gen'))
     testcase.assertEqual([as_str], _tar_ls(tar, os.path.join('gen', isd_str)))
 
     as_gen_dir = os.path.join('gen', isd_str, as_str)

--- a/scionlab/urls.py
+++ b/scionlab/urls.py
@@ -26,7 +26,7 @@ from scionlab.views.user_as_views import (
     UserASGetConfigView)
 # from scionlab.views.placehoder_view import PlaceholderView
 from scionlab.views.registration_view import UserRegistrationView
-from scionlab.views.api import GetHostConfig
+from scionlab.views.api import GetHostConfig, PostHostDeployedConfigVersion
 
 urlpatterns = [
     # TODO(matzf): implement actual home page
@@ -61,6 +61,7 @@ urlpatterns = [
 
     # API:
     path('api/host/<int:pk>/config', GetHostConfig.as_view()),
+    path('api/host/<int:pk>/deployed_config_version', PostHostDeployedConfigVersion.as_view()),
 
     # django-registration patterns
     path('registration/register/',

--- a/scionlab/util/config_tar.py
+++ b/scionlab/util/config_tar.py
@@ -41,8 +41,10 @@ def generate_user_as_config_tar(user_as, fileobj):
     """
     host = user_as.hosts.get()
     with closing(tarfile.open(mode='w:gz', fileobj=fileobj)) as tar:
+        _add_config_info(host, tar)
         generate.create_gen(host, TarWriter(tar))
         _add_vpn_config(host, tar)
+
         if user_as.installation_type == UserAS.VM:
             tar.add(_hostfiles_path("README_vm.md"), arcname="README.md")
             _add_vagrantfiles(host, tar)
@@ -58,6 +60,7 @@ def generate_host_config_tar(host, fileobj):
     :param fileobj: writable, file-like object for output
     """
     with closing(tarfile.open(mode='w:gz', fileobj=fileobj)) as tar:
+        _add_config_info(host, tar)
         generate.create_gen(host, TarWriter(tar))
         _add_vpn_config(host, tar)
 
@@ -121,24 +124,25 @@ def _expand_vagrantfile_template(host):
     )
 
 
-def _add_host_info(host, tar):
-    tar_add_textfile(tar, "scionlab-host.json", _generate_host_info_json(host))
+def _add_config_info(host, tar):
+    tar_add_textfile(tar, "scionlab-config.json", _generate_config_info_json(host))
 
 
-def _generate_host_info_json(host):
+def _generate_config_info_json(host):
     """
     Return a JSON-formatted string; a dict containing the authentication parameters for the host
     and the current configuration version number.
     :param Host host:
     :returns: json string
     """
-    host_info = {
-        'id': host.pk,
-        'secret': host.secret,
+    config_info = {
+        'host_id': host.pk,
+        'host_secret': host.secret,
         'version': host.config_version,
         # 'ia': host.AS.isd_as_str() # XXX: what for?
+        'url': 'locahost:8080'  # TODO(matzf): how to get this? put into settings? Or get from request and pass in?
     }
-    return json.dumps(host_info)
+    return json.dumps(config_info)
 
 
 def _hostfiles_path(filename):

--- a/scionlab/util/config_tar.py
+++ b/scionlab/util/config_tar.py
@@ -140,7 +140,8 @@ def _generate_config_info_json(host):
         'host_secret': host.secret,
         'version': host.config_version,
         # 'ia': host.AS.isd_as_str() # XXX: what for?
-        'url': 'locahost:8080'  # TODO(matzf): how to get this? put into settings? Or get from request and pass in?
+        'url': 'locahost:8080'  # TODO(matzf): how to get this?
+                                # Put into settings? Or get from request and pass in?
     }
     return json.dumps(config_info)
 

--- a/scionlab/util/config_tar.py
+++ b/scionlab/util/config_tar.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import string
 import tarfile
@@ -93,6 +94,18 @@ def _add_vagrantfiles(host, tar):
     Add the Vagrantfiles and additional required files to the tar.
     Expands the 'Vagrantfile.tmpl'-template.
     """
+    tar_add_textfile(tar, "Vagrantfile", _expand_vagrantfile_template(host))
+
+    # Add services and scripts:
+    # Note: in the future, some of these may be included in the "box".
+    service_files = ["scion.service", "scionupgrade.service",
+                     "scion-viz.service", "scionupgrade.timer"]
+    script_files = ["run.sh", "scionupgrade.sh"]
+    for f in service_files + script_files:
+        tar.add(_hostfiles_path(f), arcname=f)
+
+
+def _expand_vagrantfile_template(host):
     if not host.vpn_clients.filter(active=True).exists():
         forwarding_string = 'config.vm.network "forwarded_port",' \
                             ' guest: {0}, host: {0}, protocol: "udp"'. \
@@ -102,19 +115,30 @@ def _add_vagrantfiles(host, tar):
 
     with open(_hostfiles_path("Vagrantfile.tmpl")) as f:
         vagrant_tmpl = f.read()
-    vagrant_file_content = string.Template(vagrant_tmpl).substitute(
+    return string.Template(vagrant_tmpl).substitute(
         PortForwarding=forwarding_string,
         ASID=host.AS.as_id,
     )
-    tar_add_textfile(tar, "Vagrantfile", vagrant_file_content)
 
-    # Add services and scripts:
-    # Note: in the future, some of these may be included in the "box".
-    service_files = ["scion.service", "scionupgrade.service",
-                     "scion-viz.service", "scionupgrade.timer"]
-    script_files = ["run.sh", "scionupgrade.sh"]
-    for f in service_files + script_files:
-        tar.add(_hostfiles_path(f), arcname=f)
+
+def _add_host_info(host, tar):
+    tar_add_textfile(tar, "scionlab-host.json", _generate_host_info_json(host))
+
+
+def _generate_host_info_json(host):
+    """
+    Return a JSON-formatted string; a dict containing the authentication parameters for the host
+    and the current configuration version number.
+    :param Host host:
+    :returns: json string
+    """
+    host_info = {
+        'id': host.pk,
+        'secret': host.secret,
+        'version': host.config_version,
+        # 'ia': host.AS.isd_as_str() # XXX: what for?
+    }
+    return json.dumps(host_info)
 
 
 def _hostfiles_path(filename):

--- a/scionlab/util/config_tar.py
+++ b/scionlab/util/config_tar.py
@@ -125,7 +125,7 @@ def _expand_vagrantfile_template(host):
 
 
 def _add_config_info(host, tar):
-    tar_add_textfile(tar, "scionlab-config.json", _generate_config_info_json(host))
+    tar_add_textfile(tar, "gen/scionlab-config.json", _generate_config_info_json(host))
 
 
 def _generate_config_info_json(host):

--- a/scionlab/util/http.py
+++ b/scionlab/util/http.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
+import binascii
 from django.http import HttpResponse
 
 
@@ -23,3 +25,54 @@ class HttpResponseAttachment(HttpResponse):
     def __init__(self, filename, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)
+
+
+class HttpResponseAuthenticate(HttpResponse):
+    """
+    Response to unauthenticated requests to views requiring Basic authentication.
+    """
+    status_code = 401
+
+    def __init__(self, realm, *args, **kwargs):
+        """
+        :param str realm: User visible realm
+        """
+        super().__init__(*args, **kwargs)
+        self['WWW-Authenticate'] = 'Basic realm="%s", charset="UTF-8"' % realm
+
+
+def _parse_basic_auth(request):
+    """
+    Helper for basicauth. Extract password, username from Authorization Basic header.
+    :returns: username, password as (str, str) or (None, None) if header not present or malformed.
+    """
+    if 'HTTP_AUTHORIZATION' in request.META:
+        auth = request.META['HTTP_AUTHORIZATION'].split()
+        if len(auth) == 2 and auth[0].lower() == "basic":
+            try:
+                auth_str = base64.b64decode(auth[1], validate=True).decode()
+                uname_pwd = auth_str.split(':')
+                if len(uname_pwd) == 2:
+                    return tuple(uname_pwd)
+            except binascii.Error:
+                pass
+            except UnicodeDecodeError:
+                pass
+    return (None, None)
+
+
+def basicauth(authenticate, realm=""):
+    """
+    View decorator for basic authentication.
+    :param authenticate: function (username: str, password: str) -> bool
+    :param str realm: User visible realm
+    """
+    def view_decorator(view):
+        def wrapper(request, *args, **kwargs):
+            uname, passwd = _parse_basic_auth(request)
+            if uname and passwd and authenticate(uname, passwd):
+                return view(request, *args, **kwargs)
+            else:
+                return HttpResponseAuthenticate(realm)
+        return wrapper
+    return view_decorator

--- a/scionlab/views/api.py
+++ b/scionlab/views/api.py
@@ -28,6 +28,10 @@ from scionlab.util import config_tar
 
 
 class GetHostConfig(SingleObjectMixin, View):
+    """
+    Get the host configuration as a tar.gz file.
+    The request is authenticated via a per-Host secret field, included in the request parameters.
+    """
     model = Host
 
     def get(self, request, *args, **kwargs):
@@ -35,10 +39,10 @@ class GetHostConfig(SingleObjectMixin, View):
         err = _check_host_request(host, request.GET)
         if err:
             return err
+        version = _get_version_param(request.GET)
 
-        if 'version' in request.GET:
-            if int(request.GET['version']) >= host.config_version:
-                return HttpResponseNotModified()
+        if version and version >= host.config_version:
+            return HttpResponseNotModified()
 
         if config_tar.is_empty_config(host):
             return HttpResponse(status=204)
@@ -53,30 +57,55 @@ class GetHostConfig(SingleObjectMixin, View):
         return resp
 
 
-class PostHostConfigVersion(SingleObjectMixin, View):
+class PostHostDeployedConfigVersion(SingleObjectMixin, View):
+    """
+    Post a version to set the `config_version_deployed` of a Host object.
+    This informs the scionlab webserver that a configuration, previously obtained from
+    GetHostConfig, has been successfully installed on a host.
+    """
     model = Host
 
     def post(self, request, *args, **kwargs):
         host = self.get_object()
-        err = _check_host_request(host, request.GET)
+        err = _check_host_request(host, request.POST)
         if err:
             return err
+        version = _get_version_param(request.POST)
 
-        if 'version' not in request.POST:
+        if not version:
             return HttpResponseBadRequest()
-        version = int(request.POST['version'])
-        if version > host.config_version \
-                or version < host.deployed_config_version:
+        if version > host.config_version or version < host.config_version_deployed:
             return HttpResponseNotModified()
 
-        host.deployed_config_version = version
+        host.config_version_deployed = version
         host.save()
+        return HttpResponse()
 
 
 def _check_host_request(host, request_params):
+    """
+    Check the authentication parameters for this request.
+    Check that the version parameter is valid if set.
+    :param Host host:
+    :param dict request_params: request.GET or request.POST
+    :returns: Http error response or None
+    """
     if 'secret' not in request_params \
             or not hmac.compare_digest(request_params['secret'], host.secret):
         return HttpResponseForbidden()
     if 'version' in request_params and not request_params['version'].isnumeric():
         return HttpResponseBadRequest()
+    return None
+
+
+def _get_version_param(request_params):
+    """
+    Extract the 'version' parameter from the request if available.
+    Assumes the parameters have been checked using `_check_host_request`.
+    :param dict request_params: request.GET or request.POST
+    :returns: int or None
+    """
+    version_str = request_params.get('version')
+    if version_str:
+        return int(version_str)
     return None

--- a/scionlab/views/api.py
+++ b/scionlab/views/api.py
@@ -15,6 +15,8 @@
 import hmac
 from django.views import View
 from django.views.generic.detail import SingleObjectMixin
+from django.views.decorators.csrf import csrf_exempt
+from django.utils.decorators import method_decorator
 from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
@@ -57,6 +59,7 @@ class GetHostConfig(SingleObjectMixin, View):
         return resp
 
 
+@method_decorator(csrf_exempt, name='dispatch')
 class PostHostDeployedConfigVersion(SingleObjectMixin, View):
     """
     Post a version to set the `config_version_deployed` of a Host object.


### PR DESCRIPTION
Add python script to fetch and install configuration on scionlab nodes. To reduce dependency issues, only the python standard library is used. Currently this is largely untested; as most operations include some file manipulations etc, testing this (without mocking essentially everything) will require a sandboxed environment of some sort.

Add a `scionlab-config.json` file to the tar ball. This includes the version number and host key/secret for subsequent automatic config requests.

Add API to post the successfully installed version, so the coordinator can keep track of whether the a host needs to be updated.
Changed the API authorization method to use "basic" authentication headers instead of passing parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/55)
<!-- Reviewable:end -->
