### PR TITLE
Save and load again models to simplify usage.

### DIFF
--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -384,7 +384,7 @@ class ASCreationForm(_CreateUpdateModelForm):
 @admin.register(AS)
 class ASAdmin(admin.ModelAdmin):
     inlines = [InterfaceInline, BorderRouterInline, ServiceInline, HostInline]
-    actions = ['update_keys', 'trigger_config_deployment']
+    actions = ['update_keys', 'update_core_keys', 'trigger_config_deployment']
     list_display = ('isd', 'as_id', 'label', 'is_core', 'is_ap', 'is_userAS')
     list_display_links = ('as_id', 'label')
     list_filter = ('isd', 'is_core')
@@ -474,6 +474,13 @@ class ASAdmin(admin.ModelAdmin):
         """
         for as_ in queryset.iterator():
             as_.update_keys()
+
+    def update_core_keys(self, request, queryset):
+        """
+        Updates the core keys
+        """
+        for as_ in queryset.iterator():
+            as_.update_core_keys()
 
     def trigger_config_deployment(self, request, queryset):
         """

--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -477,10 +477,9 @@ class ASAdmin(admin.ModelAdmin):
 
     def update_core_keys(self, request, queryset):
         """
-        Updates the core keys
+        Updates the core keys and update the corresponding TRCs and certificates.
         """
-        for as_ in queryset.iterator():
-            as_.update_core_keys()
+        AS.update_core_as_keys(queryset)
 
     def trigger_config_deployment(self, request, queryset):
         """

--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -260,8 +260,8 @@ class AS(models.Model):
 
     def _post_delete(self):
         """
-        Called by the pre_delete signal handler `_as_post_delete`.
-        Note: the pre_delete signal has the advantage that it is called
+        Called by the post_delete signal handler `_as_post_delete`.
+        Note: the post_delete signal has the advantage that it is called
         also for bulk deletion, while this `delete()` method is not.
         """
         if self.is_core:

--- a/scionlab/models/user_as.py
+++ b/scionlab/models/user_as.py
@@ -79,7 +79,7 @@ class UserASManager(models.Manager):
         )
 
         user_as.init_keys()
-        user_as.init_certificates()
+        user_as.generate_certificate_chain()
         user_as.save()
         user_as.init_default_services(
             public_ip=public_ip,
@@ -259,12 +259,12 @@ class UserAS(AS):
     def get_public_port(self):
         return self.interfaces.get().public_port
 
-    def set_active(self, active):
+    def update_active(self, active):
         """
         Set the UserAS to be active/inactive.
         This will trigger a deployment of the attachment point configuration.
         """
-        self.interfaces.get().link().set_active(active)
+        self.interfaces.get().link().update_active(active)
         self.attachment_point.trigger_deployment()
 
     def _get_ap_link(self):

--- a/scionlab/tests/test_certificates.py
+++ b/scionlab/tests/test_certificates.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import json
+import random
 from django.test import TestCase
-from scionlab.models.core import ISD
+from scionlab.models.core import ISD, AS
 from scionlab.tests import utils
 
 from lib.crypto.trc import TRC
@@ -23,48 +24,107 @@ from lib.crypto.certificate_chain import CertificateChain
 from lib.errors import SCIONVerificationError
 
 
-class TRCAndCoreASCertificateTests(TestCase):
-    fixtures = ['testtopo-ases']
-
-    isd19_core_ases = ['19-ffaa:0:1301', '19-ffaa:0:1302']
-
-    def test_create_empty_isd(self):
+class TRCAndCoreASCertificateTestsSimple(TestCase):
+    def test_empty_isd(self):
         isd = ISD.objects.create(isd_id=1, label='empty')
+
+        # No TRC set unless explicitly created. This ISD is invalid either way!
         isd.init_trc_and_certificates()
         self.assertEqual(isd.trc['CoreASes'], {})
         self.assertEqual(isd.trc['Signatures'], {})
         self.assertEqual(isd.trc_priv_keys, {})
 
+    def test_create_delete_create(self):
+        isd = ISD.objects.create(isd_id=1, label='one')
+
+        as1_id = 'ffaa:0:0101'
+        as1_ia = '%i-%s' % (isd.isd_id, as1_id)
+        AS.objects.create(isd, as1_id, is_core=True)
+
+        trc_v1 = _check_trc_and_certs(self, 1, {as1_ia}, expected_version=1)
+
+        AS.objects.filter(as_id=as1_id).delete()
+        isd.refresh_from_db()
+
+        trc_v2 = _check_trc_and_certs(self, 1, {}, expected_version=2, prev_trc=trc_v1)
+
+        AS.objects.create(isd, as1_id, is_core=True)
+
+        _check_trc_and_certs(self, 1, {as1_ia}, expected_version=3, prev_trc=trc_v2)
+
+    def test_random_mutations(self):
+        NUM_MUTATIONS = 66
+        random.seed(5)
+
+        isd_id = 1
+
+        def make_as_id(i):
+            return "ffaa:0:%.4x" % i
+
+        def ia(as_id):
+            return "%i-%s" % (isd_id, as_id)
+
+        ISD.objects.create(isd_id=isd_id, label='some')
+
+        prev_trc = None
+        expected_version = 1
+        expected_set = set()
+
+        for i in range(NUM_MUTATIONS):
+            if not expected_set or random.getrandbits(1):
+                # add one: i has not been used yet
+                as_id = make_as_id(i)
+                expected_set.add(as_id)
+                AS.objects.create(ISD.objects.get(isd_id=isd_id), as_id, is_core=True)
+            else:
+                as_id = random.sample(expected_set, 1)[0]
+                expected_set.remove(as_id)
+                # Let's test both ways:
+                if random.getrandbits(1):
+                    AS.objects.filter(as_id=as_id).delete()
+                else:
+                    AS.objects.get(as_id=as_id).delete()
+
+            trc = _check_trc_and_certs(self,
+                                       isd_id,
+                                       {ia(as_id) for as_id in expected_set},
+                                       expected_version=expected_version,
+                                       prev_trc=prev_trc)
+            expected_version += 1
+            prev_trc = trc
+
+
+class TRCAndCoreASCertificateTestsISD19(TestCase):
+    fixtures = ['testtopo-ases']
+
+    isd19_core_ases = ['19-ffaa:0:1301', '19-ffaa:0:1302']
+
     def test_create_initial(self):
         isd = ISD.objects.get(isd_id=19)
 
-        self._reset_trc_and_certificates(isd)
+        _reset_trc_and_certificates(isd)
         self.assertEqual(isd.trc, None)
         self.assertEqual(isd.trc_priv_keys, None)
         isd.init_trc_and_certificates()
 
-        self._check_trc(isd, self.isd19_core_ases, expected_version=1)
-        for as_ in isd.ases.iterator():
-            if as_.is_core:
-                self._check_core_cert(as_, isd.trc)
-            self._check_cert_chain(as_, isd.trc)
+        _check_trc_and_certs(self, 19, self.isd19_core_ases, expected_version=1)
 
     def test_create_update(self):
         isd = ISD.objects.get(isd_id=19)
 
-        trc_v1 = self._check_trc(isd, self.isd19_core_ases, expected_version=1)
-        self._check_core_certs(isd)
+        trc_v1 = _check_trc(self, isd, self.isd19_core_ases, expected_version=1)
+        _check_core_certs(self, isd)
 
         isd.update_trc_and_core_certificates()
-        trc_v2 = self._check_trc(isd, self.isd19_core_ases, expected_version=2)
+        trc_v2 = _check_trc(self, isd, self.isd19_core_ases, expected_version=2)
         trc_v2.verify(trc_v1)
-        self._check_core_certs(isd)
+        _check_core_certs(self, isd)
 
         # XXX: this might have to be fixed if the grace period is set up. Sleep?
         isd.update_trc_and_core_certificates()
-        trc_v3 = self._check_trc(isd, self.isd19_core_ases, expected_version=3)
+        trc_v3 = _check_trc(self, isd, self.isd19_core_ases, expected_version=3)
         trc_v3.verify(trc_v2)
-        self._check_core_certs(isd)
+        _check_core_certs(self, isd)
 
         with self.assertRaises(SCIONVerificationError):
             trc_v3.verify(trc_v1)
@@ -76,28 +136,28 @@ class TRCAndCoreASCertificateTests(TestCase):
 
         # Generate fresh cert with same keys
         original_certificate_chain = as_.certificate_chain
-        as_.update_certificate_chain()
-        self._check_cert_chain(as_, isd.trc)
+        as_.generate_certificate_chain()
+        as_.save()
+        _check_cert_chain(self, as_, isd.trc)
         self.assertEqual(as_.certificate_chain['0']['Version'],
                          original_certificate_chain['0']['Version'] + 1)
 
         # Update keys and generate cert
         as_.update_keys()
-        self._check_cert_chain(as_, isd.trc)
+        _check_cert_chain(self, as_, isd.trc)
         self.assertEqual(as_.certificate_chain['0']['Version'],
                          original_certificate_chain['0']['Version'] + 2)
 
     def test_update_core_cert(self):
         isd = ISD.objects.get(isd_id=19)
 
-        trc_v1 = self._check_trc(isd, self.isd19_core_ases, expected_version=1)
+        trc_v1 = _check_trc(self, isd, self.isd19_core_ases, expected_version=1)
 
-        as_ = isd.ases.filter(is_core=True).first()
-        as_.update_core_keys()
+        AS.update_core_as_keys(isd.ases.filter(is_core=True))
 
-        trc_v2 = self._check_trc(isd, self.isd19_core_ases, expected_version=2)
+        trc_v2 = _check_trc(self, isd, self.isd19_core_ases, expected_version=2)
         trc_v2.verify(trc_v1)
-        self._check_core_certs(isd)
+        _check_core_certs(self, isd)
 
         # Certs for non-core ASes not updated; will be updated as new TRC is disseminated
         for as_ in isd.ases.filter(is_core=False).iterator():
@@ -106,50 +166,70 @@ class TRCAndCoreASCertificateTests(TestCase):
                 trc_v1.version
             )
 
-    def _reset_trc_and_certificates(self, isd):
-        isd.trc = None
-        isd.trc_priv_keys = None
-        isd.save()
-        for as_ in isd.ases.iterator():
-            as_.certificate_chain = None
-            as_.core_certificate = None
-            as_.save()
 
-    def _check_trc(self, isd, expected_core_ases, expected_version=None):
-        """
-        Check the ISD's TRC and return it as a TRC object.
-        :param ISD isd:
-        :param [str] expected_core_ases: ISD-AS strings for all core ases
-        :param int expected_version: optional
-        :returns: TRC
-        :rtype: TRC
-        """
-        self.assertEqual(set(isd.trc['CoreASes'].keys()), set(expected_core_ases))
-        self.assertEqual(set(isd.trc_priv_keys.keys()), set(expected_core_ases))
-        for isd_as in expected_core_ases:
-            utils.check_sig_keypair(self, isd.trc['CoreASes'][isd_as]['OnlineKey'],
-                                    isd.trc_priv_keys[isd_as])
+def _reset_trc_and_certificates(isd):
+    isd.trc = None
+    isd.trc_priv_keys = None
+    isd.save()
+    for as_ in isd.ases.iterator():
+        as_.certificate_chain = None
+        as_.core_certificate = None
+        as_.save()
 
-        json_trc = json.dumps(isd.trc)  # round trip through json, just to make sure this works
-        trc = TRC.from_raw(json_trc)
-        trc.check_active()
-        if expected_version is not None:
-            self.assertEqual(trc.version, expected_version)
-        return trc
 
-    def _check_core_certs(self, isd):
-        for as_ in isd.ases.filter(is_core=True).iterator():
-            self._check_core_cert(as_, isd.trc)
-            self._check_cert_chain(as_, isd.trc)
+def _check_trc_and_certs(testcase, isd_id, expected_core_ases, expected_version, prev_trc=None):
+    isd = ISD.objects.get(isd_id=isd_id)
+    trc = _check_trc(testcase, isd, expected_core_ases, expected_version)
+    if prev_trc:
+        trc.verify(prev_trc)
 
-    def _check_core_cert(self, as_, trc):
-        self.assertIsNotNone(as_.core_certificate)
-        cert = Certificate(as_.core_certificate)
-        isd_as = as_.isd_as_str()
-        cert.verify(isd_as, TRC(trc).core_ases[isd_as]['OnlineKey'])
+    for as_ in isd.ases.iterator():
+        if as_.is_core:
+            _check_core_cert(testcase, as_, isd.trc)
+            _check_cert_chain(testcase, as_, isd.trc)
+        elif as_.certificate_chain['0']['TRCVersion'] == trc.version:
+            _check_cert_chain(testcase, as_, isd.trc)
 
-    def _check_cert_chain(self, as_, trc):
-        self.assertIsNotNone(as_.certificate_chain)
-        json_cert_chain = json.dumps(as_.certificate_chain)
-        cert_chain = CertificateChain.from_raw(json_cert_chain)
-        cert_chain.verify(as_.isd_as_str(), TRC(trc))
+    return trc
+
+
+def _check_trc(testcase, isd, expected_core_ases, expected_version):
+    """
+    Check the ISD's TRC and return it as a TRC object.
+    :param ISD isd:
+    :param [str] expected_core_ases: ISD-AS strings for all core ases
+    :param int expected_version:
+    :returns: TRC
+    :rtype: TRC
+    """
+    testcase.assertEqual(set(isd.trc['CoreASes'].keys()), set(expected_core_ases))
+    testcase.assertEqual(set(isd.trc_priv_keys.keys()), set(expected_core_ases))
+    for isd_as in expected_core_ases:
+        utils.check_sig_keypair(testcase, isd.trc['CoreASes'][isd_as]['OnlineKey'],
+                                isd.trc_priv_keys[isd_as])
+
+    json_trc = json.dumps(isd.trc)  # round trip through json, just to make sure this works
+    trc = TRC.from_raw(json_trc)
+    trc.check_active()
+    testcase.assertEqual(trc.version, expected_version)
+    return trc
+
+
+def _check_core_certs(testcase, isd):
+    for as_ in isd.ases.filter(is_core=True).iterator():
+        _check_core_cert(testcase, as_, isd.trc)
+        _check_cert_chain(testcase, as_, isd.trc)
+
+
+def _check_core_cert(testcase, as_, trc):
+    testcase.assertIsNotNone(as_.core_certificate)
+    cert = Certificate(as_.core_certificate)
+    isd_as = as_.isd_as_str()
+    cert.verify(isd_as, TRC(trc).core_ases[isd_as]['OnlineKey'])
+
+
+def _check_cert_chain(testcase, as_, trc):
+    testcase.assertIsNotNone(as_.certificate_chain)
+    json_cert_chain = json.dumps(as_.certificate_chain)
+    cert_chain = CertificateChain.from_raw(json_cert_chain)
+    cert_chain.verify(as_.isd_as_str(), TRC(trc))

--- a/scionlab/tests/test_certificates.py
+++ b/scionlab/tests/test_certificates.py
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import random
 from django.test import TestCase
 from scionlab.models.core import ISD, AS
 from scionlab.tests import utils
 
-from lib.crypto.trc import TRC
-from lib.crypto.certificate import Certificate
-from lib.crypto.certificate_chain import CertificateChain
 from lib.errors import SCIONVerificationError
 
 
@@ -41,16 +37,16 @@ class TRCAndCoreASCertificateTestsSimple(TestCase):
         as1_ia = '%i-%s' % (isd.isd_id, as1_id)
         AS.objects.create(isd, as1_id, is_core=True)
 
-        trc_v1 = _check_trc_and_certs(self, 1, {as1_ia}, expected_version=1)
+        trc_v1 = utils.check_trc_and_certs(self, 1, {as1_ia}, expected_version=1)
 
         AS.objects.filter(as_id=as1_id).delete()
         isd.refresh_from_db()
 
-        trc_v2 = _check_trc_and_certs(self, 1, {}, expected_version=2, prev_trc=trc_v1)
+        trc_v2 = utils.check_trc_and_certs(self, 1, {}, expected_version=2, prev_trc=trc_v1)
 
         AS.objects.create(isd, as1_id, is_core=True)
 
-        _check_trc_and_certs(self, 1, {as1_ia}, expected_version=3, prev_trc=trc_v2)
+        utils.check_trc_and_certs(self, 1, {as1_ia}, expected_version=3, prev_trc=trc_v2)
 
     def test_random_mutations(self):
         NUM_MUTATIONS = 66
@@ -85,11 +81,11 @@ class TRCAndCoreASCertificateTestsSimple(TestCase):
                 else:
                     AS.objects.get(as_id=as_id).delete()
 
-            trc = _check_trc_and_certs(self,
-                                       isd_id,
-                                       {ia(as_id) for as_id in expected_set},
-                                       expected_version=expected_version,
-                                       prev_trc=prev_trc)
+            trc = utils.check_trc_and_certs(self,
+                                            isd_id,
+                                            {ia(as_id) for as_id in expected_set},
+                                            expected_version=expected_version,
+                                            prev_trc=prev_trc)
             expected_version += 1
             prev_trc = trc
 
@@ -107,24 +103,24 @@ class TRCAndCoreASCertificateTestsISD19(TestCase):
         self.assertEqual(isd.trc_priv_keys, None)
         isd.init_trc_and_certificates()
 
-        _check_trc_and_certs(self, 19, self.isd19_core_ases, expected_version=1)
+        utils.check_trc_and_certs(self, 19, self.isd19_core_ases, expected_version=1)
 
     def test_create_update(self):
         isd = ISD.objects.get(isd_id=19)
 
-        trc_v1 = _check_trc(self, isd, self.isd19_core_ases, expected_version=1)
-        _check_core_certs(self, isd)
+        trc_v1 = utils.check_trc(self, isd, self.isd19_core_ases, expected_version=1)
+        utils.check_core_as_certs(self, isd)
 
         isd.update_trc_and_core_certificates()
-        trc_v2 = _check_trc(self, isd, self.isd19_core_ases, expected_version=2)
+        trc_v2 = utils.check_trc(self, isd, self.isd19_core_ases, expected_version=2)
         trc_v2.verify(trc_v1)
-        _check_core_certs(self, isd)
+        utils.check_core_as_certs(self, isd)
 
         # XXX: this might have to be fixed if the grace period is set up. Sleep?
         isd.update_trc_and_core_certificates()
-        trc_v3 = _check_trc(self, isd, self.isd19_core_ases, expected_version=3)
+        trc_v3 = utils.check_trc(self, isd, self.isd19_core_ases, expected_version=3)
         trc_v3.verify(trc_v2)
-        _check_core_certs(self, isd)
+        utils.check_core_as_certs(self, isd)
 
         with self.assertRaises(SCIONVerificationError):
             trc_v3.verify(trc_v1)
@@ -138,26 +134,26 @@ class TRCAndCoreASCertificateTestsISD19(TestCase):
         original_certificate_chain = as_.certificate_chain
         as_.generate_certificate_chain()
         as_.save()
-        _check_cert_chain(self, as_, isd.trc)
+        utils.check_cert_chain(self, as_, isd.trc)
         self.assertEqual(as_.certificate_chain['0']['Version'],
                          original_certificate_chain['0']['Version'] + 1)
 
         # Update keys and generate cert
         as_.update_keys()
-        _check_cert_chain(self, as_, isd.trc)
+        utils.check_cert_chain(self, as_, isd.trc)
         self.assertEqual(as_.certificate_chain['0']['Version'],
                          original_certificate_chain['0']['Version'] + 2)
 
     def test_update_core_cert(self):
         isd = ISD.objects.get(isd_id=19)
 
-        trc_v1 = _check_trc(self, isd, self.isd19_core_ases, expected_version=1)
+        trc_v1 = utils.check_trc(self, isd, self.isd19_core_ases, expected_version=1)
 
         AS.update_core_as_keys(isd.ases.filter(is_core=True))
 
-        trc_v2 = _check_trc(self, isd, self.isd19_core_ases, expected_version=2)
+        trc_v2 = utils.check_trc(self, isd, self.isd19_core_ases, expected_version=2)
         trc_v2.verify(trc_v1)
-        _check_core_certs(self, isd)
+        utils.check_core_as_certs(self, isd)
 
         # Certs for non-core ASes not updated; will be updated as new TRC is disseminated
         for as_ in isd.ases.filter(is_core=False).iterator():
@@ -175,61 +171,3 @@ def _reset_trc_and_certificates(isd):
         as_.certificate_chain = None
         as_.core_certificate = None
         as_.save()
-
-
-def _check_trc_and_certs(testcase, isd_id, expected_core_ases, expected_version, prev_trc=None):
-    isd = ISD.objects.get(isd_id=isd_id)
-    trc = _check_trc(testcase, isd, expected_core_ases, expected_version)
-    if prev_trc:
-        trc.verify(prev_trc)
-
-    for as_ in isd.ases.iterator():
-        if as_.is_core:
-            _check_core_cert(testcase, as_, isd.trc)
-            _check_cert_chain(testcase, as_, isd.trc)
-        elif as_.certificate_chain['0']['TRCVersion'] == trc.version:
-            _check_cert_chain(testcase, as_, isd.trc)
-
-    return trc
-
-
-def _check_trc(testcase, isd, expected_core_ases, expected_version):
-    """
-    Check the ISD's TRC and return it as a TRC object.
-    :param ISD isd:
-    :param [str] expected_core_ases: ISD-AS strings for all core ases
-    :param int expected_version:
-    :returns: TRC
-    :rtype: TRC
-    """
-    testcase.assertEqual(set(isd.trc['CoreASes'].keys()), set(expected_core_ases))
-    testcase.assertEqual(set(isd.trc_priv_keys.keys()), set(expected_core_ases))
-    for isd_as in expected_core_ases:
-        utils.check_sig_keypair(testcase, isd.trc['CoreASes'][isd_as]['OnlineKey'],
-                                isd.trc_priv_keys[isd_as])
-
-    json_trc = json.dumps(isd.trc)  # round trip through json, just to make sure this works
-    trc = TRC.from_raw(json_trc)
-    trc.check_active()
-    testcase.assertEqual(trc.version, expected_version)
-    return trc
-
-
-def _check_core_certs(testcase, isd):
-    for as_ in isd.ases.filter(is_core=True).iterator():
-        _check_core_cert(testcase, as_, isd.trc)
-        _check_cert_chain(testcase, as_, isd.trc)
-
-
-def _check_core_cert(testcase, as_, trc):
-    testcase.assertIsNotNone(as_.core_certificate)
-    cert = Certificate(as_.core_certificate)
-    isd_as = as_.isd_as_str()
-    cert.verify(isd_as, TRC(trc).core_ases[isd_as]['OnlineKey'])
-
-
-def _check_cert_chain(testcase, as_, trc):
-    testcase.assertIsNotNone(as_.certificate_chain)
-    json_cert_chain = json.dumps(as_.certificate_chain)
-    cert_chain = CertificateChain.from_raw(json_cert_chain)
-    cert_chain.verify(as_.isd_as_str(), TRC(trc))

--- a/scionlab/tests/test_models.py
+++ b/scionlab/tests/test_models.py
@@ -204,10 +204,10 @@ class DeleteASTests(TestCase):
     fixtures = ['testtopo-ases-links']
 
     def setUp(self):
-        patcher = patch('scionlab.models.core.AS._pre_delete',
-                        side_effect=AS._pre_delete,
+        patcher = patch('scionlab.models.core.AS._post_delete',
+                        side_effect=AS._post_delete,
                         autospec=True)
-        self.mock_as_pre_delete = patcher.start()
+        self.mock_as_post_delete = patcher.start()
         self.addCleanup(patcher.stop)
 
     def test_delete_single_as(self):
@@ -225,7 +225,7 @@ class DeleteASTests(TestCase):
 
         as_.delete()
 
-        self.assertEqual(self.mock_as_pre_delete.call_count, 1)
+        self.assertEqual(self.mock_as_post_delete.call_count, 1)
 
         # Check hosts have not been deleted and `needs_config_deployment`:
         for host_pk in host_pks:
@@ -247,4 +247,4 @@ class DeleteASTests(TestCase):
 
         ases.delete()
 
-        self.assertEqual(self.mock_as_pre_delete.call_count, ases_count)
+        self.assertEqual(self.mock_as_post_delete.call_count, ases_count)

--- a/scionlab/tests/test_user_as_models.py
+++ b/scionlab/tests/test_user_as_models.py
@@ -550,7 +550,7 @@ class ActivateUserASTests(TestCase):
         seed = 123
         user_as = create_random_useras(self, seed=seed)
 
-        user_as.set_active(False)
+        user_as.update_active(False)
 
         uplink = Link.objects.get(interfaceB__AS=user_as)
         self.assertFalse(uplink.active)
@@ -565,7 +565,7 @@ class ActivateUserASTests(TestCase):
         )
         mock_deploy.reset_mock()
 
-        user_as.set_active(True)
+        user_as.update_active(True)
 
         uplink = Link.objects.get(interfaceB__AS=user_as)
         self.assertTrue(uplink.active)

--- a/scionlab/views/user_as_views.py
+++ b/scionlab/views/user_as_views.py
@@ -200,7 +200,7 @@ class UserASActivateView(OwnedUserASQuerysetMixin, SingleObjectMixin, View):
     def post(self, request, *args, **kwargs):
         self.object = self.get_object()
         success_url = self.get_success_url()
-        self.object.set_active(self.active)
+        self.object.update_active(self.active)
         return HttpResponseRedirect(success_url)
 
 


### PR DESCRIPTION
Save models before calling methods relaying on the data graph.
Reload them before modifying in-mem copies.

Closes #89 
There is also a new "Update Core Keys" call in the admin.AS form.

This PR is a bug-fix and only presents one possible way to solve a more generic scenario, in which we have in memory copies of objects that are not persisted yet to the DB, yet some methods rely on the DB being fresh for proper functioning.

It would be nice to establish a set of "rules" for our app, in that we can e.g. only load once and only save once, or e.g. save() and refresh() as objects are changed (maybe using the django cache), etc. Choosing one way of working will help us reason about the data graph easily.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/90)
<!-- Reviewable:end -->
