### PR TITLE
Persist the VPN server IP in the VPN model.

### DIFF
--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -511,10 +511,8 @@ class VPNCreationForm(_CreateUpdateModelForm):
     Specialised ModelForm for VPN creation which will initialise key and cert
     """
     class Meta:
-        fields = ('server', 'server_port', 'server_vpn_ip')
-    subnet = GenericIPNetworkField()
-    # TODO: why is this order not applied?
-    field_order = ('server', 'server_port', 'subnet', 'server_vpn_ip')
+        fields = ('server', 'server_port', 'subnet', 'server_vpn_ip')
+        field_classes = {'subnet': GenericIPNetworkField}
 
     def clean(self):
         cleaned_data = super().clean()
@@ -544,8 +542,8 @@ class VPNCreationForm(_CreateUpdateModelForm):
 
 class VPNUpdateForm(VPNCreationForm):
     class Meta:
-        fields = ('server', 'server_port', 'server_vpn_ip', 'private_key', 'cert')
-    subnet = GenericIPNetworkField()
+        fields = ('server', 'server_port', 'subnet', 'server_vpn_ip', 'private_key', 'cert')
+        field_classes = {'subnet': GenericIPNetworkField}
 
     def update(self):
         self.instance.update(
@@ -560,10 +558,9 @@ class VPNUpdateForm(VPNCreationForm):
 
 @admin.register(VPN)
 class VPNAdmin(admin.ModelAdmin):
-    # form = VPNCreationForm
     def get_form(self, request, obj=None, **kwargs):
         """
-        Use different forms for AS creation or update
+        Use different forms for VPN creation or update
         """
         if not obj:
             kwargs['form'] = VPNCreationForm

--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ipaddress
 from django import urls
 from django.utils.html import format_html
 from django.core.exceptions import ValidationError
@@ -39,6 +40,7 @@ from scionlab.models.vpn import VPN, VPNClient
 from scionlab.util.http import HttpResponseAttachment
 from scionlab import config_tar
 from scionlab.tasks import deploy_host_config
+from scionlab.forms.fields import GenericIPNetworkField
 # Needs to be after import of scionlab.models.user.User
 from django.contrib.auth.admin import UserAdmin as auth_UserAdmin
 
@@ -509,7 +511,23 @@ class VPNCreationForm(_CreateUpdateModelForm):
     Specialised ModelForm for VPN creation which will initialise key and cert
     """
     class Meta:
-        fields = ('server', 'server_port', 'subnet')
+        fields = ('server', 'server_port', 'server_vpn_ip')
+    subnet = GenericIPNetworkField()
+    # TODO: why is this order not applied?
+    field_order = ('server', 'server_port', 'subnet', 'server_vpn_ip')
+
+    def clean(self):
+        cleaned_data = super().clean()
+        subnet = cleaned_data.get('subnet')
+        server_ip = cleaned_data.get('server_vpn_ip')
+        if not subnet or not server_ip:
+            return cleaned_data
+        subnet = ipaddress.ip_network(subnet)
+        server_ip = ipaddress.ip_address(server_ip)
+        if server_ip not in subnet:
+            raise ValidationError('Server VPN IP is not inside the specified subnet',
+                                  code='server_vpn_ip_not_in_subnet')
+        return cleaned_data
 
     def create(self):
         """
@@ -520,7 +538,38 @@ class VPNCreationForm(_CreateUpdateModelForm):
             server=self.cleaned_data['server'],
             server_port=self.cleaned_data['server_port'],
             subnet=self.cleaned_data['subnet'],
+            server_vpn_ip=self.cleaned_data['server_vpn_ip'],
         )
+
+
+class VPNUpdateForm(VPNCreationForm):
+    class Meta:
+        fields = ('server', 'server_port', 'server_vpn_ip', 'private_key', 'cert')
+    subnet = GenericIPNetworkField()
+
+    def update(self):
+        self.instance.update(
+            server=self.cleaned_data['server'],
+            server_port=self.cleaned_data['server_port'],
+            subnet=self.cleaned_data['subnet'],
+            server_vpn_ip=self.cleaned_data['server_vpn_ip'],
+            private_key=self.cleaned_data['private_key'],
+            cert=self.cleaned_data['cert'],
+        )
+
+
+@admin.register(VPN)
+class VPNAdmin(admin.ModelAdmin):
+    # form = VPNCreationForm
+    def get_form(self, request, obj=None, **kwargs):
+        """
+        Use different forms for AS creation or update
+        """
+        if not obj:
+            kwargs['form'] = VPNCreationForm
+        else:
+            kwargs['form'] = VPNUpdateForm
+        return super().get_form(request, obj, **kwargs)
 
 
 @admin.register(VPNClient)
@@ -548,17 +597,6 @@ class VPNClientCreationForm(_CreateUpdateModelForm):
         vpn = self.cleaned_data['vpn']
         return vpn.create_client(self.cleaned_data['host'],
                                  self.cleaned_data['active'])
-
-
-@admin.register(VPN)
-class VPNAdmin(admin.ModelAdmin):
-    def get_form(self, request, obj=None, **kwargs):
-        """
-        Use custom form during AS creation
-        """
-        if not obj:
-            kwargs['form'] = VPNCreationForm
-        return super().get_form(request, obj, **kwargs)
 
 
 class LinkAdminForm(_CreateUpdateModelForm):

--- a/scionlab/forms/fields.py
+++ b/scionlab/forms/fields.py
@@ -1,0 +1,28 @@
+# Copyright 2018 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ipaddress
+from django import forms
+from django.core.exceptions import ValidationError
+
+
+class GenericIPNetworkField(forms.Field):
+    def to_python(self, value):
+        if not value:
+            return None
+        try:
+            subnet = ipaddress.ip_network(value)
+        except ValueError:
+            raise ValidationError('Invalid network address')
+        return subnet

--- a/scionlab/forms/fields.py
+++ b/scionlab/forms/fields.py
@@ -1,4 +1,4 @@
-# Copyright 2018 ETH Zurich
+# Copyright 2019 ETH Zurich
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,10 @@ from django.core.exceptions import ValidationError
 
 
 class GenericIPNetworkField(forms.Field):
+    def __init__(self, *args, **kwargs):
+        kwargs.pop('max_length', 0)  # parent is not length aware
+        super().__init__(*args, **kwargs)
+
     def to_python(self, value):
         if not value:
             return None

--- a/scionlab/models/user_as.py
+++ b/scionlab/models/user_as.py
@@ -99,7 +99,7 @@ class UserASManager(models.Manager):
             )
             interface_ap = Interface.objects.create(
                 border_router=attachment_point.get_border_router_for_useras_interface(),
-                public_ip=attachment_point.vpn.server_vpn_ip()
+                public_ip=attachment_point.vpn.server_vpn_ip
             )
         else:
             interface_client = Interface.objects.create(
@@ -216,7 +216,7 @@ class UserAS(AS):
             )
             interface_ap.update(
                 border_router=attachment_point.get_border_router_for_useras_interface(),
-                public_ip=attachment_point.vpn.server_vpn_ip(),
+                public_ip=attachment_point.vpn.server_vpn_ip,
                 public_port=None,
             )
         else:

--- a/scionlab/models/vpn.py
+++ b/scionlab/models/vpn.py
@@ -35,6 +35,7 @@ class VPNManager(models.Manager):
         )
         vpn.init_key()
         vpn.save()
+        server.bump_config()
         return vpn
 
 
@@ -107,8 +108,9 @@ class VPN(models.Model):
                private_key=_placeholder,
                cert=_placeholder):
         """
-        Updates all/any parameter. It always saves the object even when no changes
+        Updates all/any parameter. It always saves the object and bumps config, even when no changes
         """
+        oldserver = self.server
         if server is not _placeholder:
             self.server = server
         if server_port is not _placeholder:
@@ -122,6 +124,10 @@ class VPN(models.Model):
         if cert is not _placeholder:
             self.cert = cert
         self.save()
+        if self.server:
+            self.server.bump_config()
+        if oldserver and oldserver != self.server:
+            oldserver.bump_config()
 
 
 class VPNClientManager(models.Manager):

--- a/scionlab/openvpn_config.py
+++ b/scionlab/openvpn_config.py
@@ -218,7 +218,7 @@ def generate_vpn_server_config(vpn):
         encoding=serialization.Encoding.PEM).decode()
     server_config_tmpl = pathlib.Path(SERVER_CONFIG_TEMPLATE_PATH).read_text(encoding='utf-8')
     server_vpn_as = vpn.server.AS.as_path_str()
-    server_vpn_ip = vpn.server_vpn_ip()
+    server_vpn_ip = vpn.server_vpn_ip
     server_vpn_port = vpn.server_port
     server_vpn_subnet = vpn.vpn_subnet()
 

--- a/scionlab/tests/test_user_as_models.py
+++ b/scionlab/tests/test_user_as_models.py
@@ -313,8 +313,8 @@ class CreateUserASTests(TestCase):
     fixtures = ['testuser', 'testtopo-ases-links']
 
     def setUp(self):
-        Host.objects.reset_needs_config_deployment()
         setup_vpn_attachment_point(AttachmentPoint.objects.first())
+        Host.objects.reset_needs_config_deployment()
 
     @parameterized.expand(zip(range(testtopo_num_attachment_points)))
     def test_create_public_ip(self, ap_index):
@@ -415,8 +415,8 @@ class UpdateUserASTests(TestCase):
     fixtures = ['testuser', 'testtopo-ases-links']
 
     def setUp(self):
-        Host.objects.reset_needs_config_deployment()
         setup_vpn_attachment_point(AttachmentPoint.objects.first())
+        Host.objects.reset_needs_config_deployment()
 
     def test_enable_vpn(self):
         seed = 1
@@ -622,9 +622,8 @@ class ActivateUserASTests(TestCase):
     fixtures = ['testuser', 'testtopo-ases-links']
 
     def setUp(self):
-        Host.objects.reset_needs_config_deployment()
-
         setup_vpn_attachment_point(AttachmentPoint.objects.first())
+        Host.objects.reset_needs_config_deployment()
 
     @patch('scionlab.tasks.deploy_host_config')
     def test_cycle_active(self, mock_deploy):
@@ -667,8 +666,8 @@ class DeleteUserASTests(TestCase):
     fixtures = ['testuser', 'testtopo-ases-links']
 
     def setUp(self):
-        Host.objects.reset_needs_config_deployment()
         setup_vpn_attachment_point(AttachmentPoint.objects.first())
+        Host.objects.reset_needs_config_deployment()
 
     def test_delete_single(self):
         seed = 456

--- a/scionlab/tests/test_user_as_models.py
+++ b/scionlab/tests/test_user_as_models.py
@@ -309,6 +309,37 @@ class GenerateUserASIDTests(TestCase):
         self.assertEqual(as_id_int, USER_AS_ID_BEGIN)
 
 
+class VPNServerTests(TestCase):
+    fixtures = ['testuser', 'testtopo-ases-links']
+
+    def test_create_new(self):
+        ap = AttachmentPoint.objects.first()
+        prev_version = ap.AS.hosts.first().config_version
+        setup_vpn_attachment_point(ap)
+        self.assertGreater(ap.AS.hosts.first().config_version, prev_version)
+        self.assertEqual(ap.vpn.server, ap.AS.hosts.first())
+
+    def test_update_vpn(self):
+        ap = AttachmentPoint.objects.first()
+        setup_vpn_attachment_point(ap)
+        server = ap.vpn.server
+        prev_version = server.config_version
+        ap.vpn.update(subnet='10.0.8.0/22')
+        self.assertGreater(server.config_version, prev_version)
+
+    def test_change_vpn_server(self):
+        ap = AttachmentPoint.objects.first()
+        setup_vpn_attachment_point(ap)
+        old_server = ap.vpn.server
+        old_server_prev_version = old_server.config_version
+        new_server = Host.objects.create()
+        self.assertNotEqual(new_server, old_server)
+        new_server_prev_version = new_server.config_version
+        ap.vpn.update(server=new_server)
+        self.assertGreater(old_server.config_version, old_server_prev_version)
+        self.assertGreater(new_server.config_version, new_server_prev_version)
+
+
 class CreateUserASTests(TestCase):
     fixtures = ['testuser', 'testtopo-ases-links']
 

--- a/scionlab/tests/test_user_as_models.py
+++ b/scionlab/tests/test_user_as_models.py
@@ -48,6 +48,7 @@ def setup_vpn_attachment_point(ap):
     # TODO(matzf): move to a fixture once the VPN stuff is somewhat stable
     ap.vpn = VPN.objects.create(server=ap.AS.hosts.first(),
                                 subnet='10.0.8.0/24',
+                                server_vpn_ip='10.0.8.1',
                                 server_port=4321)
     ap.save()
 
@@ -165,7 +166,7 @@ def check_useras(testcase,
         utils.check_link(testcase, link, utils.LinkDescription(
             type=Link.PROVIDER,
             from_as_id=attachment_point.AS.as_id,
-            from_public_ip=attachment_point.vpn.server_vpn_ip(),
+            from_public_ip=attachment_point.vpn.server_vpn_ip,
             from_bind_ip=None,
             from_internal_ip=DEFAULT_HOST_INTERNAL_IP,
             to_public_ip=user_as.hosts.get().vpn_clients.get(active=True).ip,

--- a/scionlab/tests/test_user_as_views.py
+++ b/scionlab/tests/test_user_as_views.py
@@ -59,6 +59,7 @@ def _setup_vpn_attachment_point():
     ap = AttachmentPoint.objects.all()[0]
     ap.vpn = VPN.objects.create(server=ap.AS.hosts.first(),
                                 subnet='10.0.8.0/24',
+                                server_vpn_ip='10.0.8.1',
                                 server_port=4321)
     ap.save()
 

--- a/scionlab/tests/test_vpn_certs.py
+++ b/scionlab/tests/test_vpn_certs.py
@@ -46,6 +46,7 @@ def _setup_vpn_attachment_point():
     ap = AttachmentPoint.objects.first()
     ap.vpn = VPN.objects.create(server=ap.AS.hosts.first(),
                                 subnet='10.0.8.0/24',
+                                server_vpn_ip='10.0.8.1',
                                 server_port=4321)
     ap.save()
 


### PR DESCRIPTION
- [x] Validate the subnet and the IP in the VPN creation/update.
- [x] Store the IP of the VPN server in the `VPN` object.
- [x] Look for the assumption that the VPN server's IP is the first one in the range, as it will not be valid anymore.
- [x] Exclude the VPN server's IP when getting a new VPN client's IP.

Closes #99 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/100)
<!-- Reviewable:end -->
