### PR TITLE
Fix: VM bind ip

### DIFF
--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -114,9 +114,10 @@ def _add_vagrantfiles(host, tar):
 
 def _expand_vagrantfile_template(host):
     if not host.vpn_clients.filter(active=True).exists():
+        interface = host.interfaces.get()
+        port = interface.bind_port or interface.public_port
         forwarding_string = 'config.vm.network "forwarded_port",' \
-                            ' guest: {0}, host: {0}, protocol: "udp"'. \
-            format(host.interfaces.get().public_port)
+                            ' guest: {port}, host: {port}, protocol: "udp"'.format(port=port)
     else:
         forwarding_string = ''
 

--- a/scionlab/models/user_as.py
+++ b/scionlab/models/user_as.py
@@ -33,6 +33,7 @@ from scionlab.defines import (
 from scionlab.util import as_ids
 
 _MAX_LEN_CHOICES_DEFAULT = 16
+_VAGRANT_VM_LOCAL_IP = '10.0.2.15'
 
 
 class UserASManager(models.Manager):
@@ -92,7 +93,7 @@ class UserASManager(models.Manager):
         user_as.save()
         user_as.init_default_services(
             public_ip=public_ip,
-            bind_ip=bind_ip,
+            bind_ip=_VAGRANT_VM_LOCAL_IP if installation_type == UserAS.VM else bind_ip,
         )
 
         host = user_as.hosts.get()
@@ -209,7 +210,7 @@ class UserAS(AS):
 
         host.update(
             public_ip=public_ip,
-            bind_ip=bind_ip
+            bind_ip=_VAGRANT_VM_LOCAL_IP if installation_type == UserAS.VM else bind_ip,
         )
 
         link = self._get_ap_link()

--- a/scionlab/tests/test_user_as_models.py
+++ b/scionlab/tests/test_user_as_models.py
@@ -177,6 +177,13 @@ def check_useras(testcase,
             to_internal_ip=DEFAULT_HOST_INTERNAL_IP,
         ))
     else:
+        overridden_bind_ip = bind_ip
+        if installation_type == UserAS.VM:
+            overridden_bind_ip = '10.0.2.15'
+        overridden_bind_port = bind_port
+        if overridden_bind_ip:
+            overridden_bind_port = bind_port or public_port
+
         utils.check_link(testcase, link, utils.LinkDescription(
             type=Link.PROVIDER,
             from_as_id=attachment_point.AS.as_id,
@@ -185,8 +192,8 @@ def check_useras(testcase,
             from_internal_ip=DEFAULT_HOST_INTERNAL_IP,
             to_public_ip=public_ip,
             to_public_port=public_port,
-            to_bind_ip=bind_ip,
-            to_bind_port=bind_port,
+            to_bind_ip=overridden_bind_ip,
+            to_bind_port=overridden_bind_port,
             to_internal_ip=DEFAULT_HOST_INTERNAL_IP,
         ))
 


### PR DESCRIPTION
Override bind IP for vagrant machine to `10.0.2.15`.
Expose the bind port in Vagrantfile, not public port -- this is an edge case really; if NATed port is different from public port AND VM is used then this needs to happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/123)
<!-- Reviewable:end -->
