### PR TITLE
Remove postgres from compose-file, use external DB

### DIFF
--- a/deploy/django-entrypoint.sh
+++ b/deploy/django-entrypoint.sh
@@ -6,7 +6,7 @@ set -e
 /scionlab/manage.py collectstatic --noinput
 
 # Wait for DB
-appdeps.py --wait-secs 60 --port-wait db:5432
+appdeps.py --wait-secs 60 --port-wait $POSTGRES_HOST:$POSTGRES_PORT
 
 # Initialise/migrate DB
 /scionlab/manage.py migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,6 @@
 version: '3'
 
 services:
-  db:
-    image: postgres:11-alpine
-    env_file: run/scionlab.env
-    expose:
-      - "5432"
-    volumes:
-      - pgdata:/var/lib/postgresql/data/
-
   redis:
     image: redis:5-alpine
     volumes:
@@ -33,13 +25,12 @@ services:
     expose:
       - "8000"
     depends_on:
-      - db
       - huey
     volumes:
       - ./run/:/scionlab/run/
       - web-static:/scionlab/static/
 
-  proxy:
+  caddy:
     build: ./deploy/caddy
     env_file: run/scionlab.env
     depends_on:
@@ -53,6 +44,5 @@ services:
 
 volumes:
   web-static:
-  pgdata:
   redisdata:
   caddydata:

--- a/scionlab/settings/production.py
+++ b/scionlab/settings/production.py
@@ -49,11 +49,11 @@ INSTANCE_NAME = '' if _subdomain == 'www' else _subdomain
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'HOST': _getenv('POSTGRES_HOST'),
+        'PORT': _getenv('POSTGRES_PORT'),
         'NAME': _getenv('POSTGRES_DB'),
         'USER': _getenv('POSTGRES_USER'),
         'PASSWORD': _getenv('POSTGRES_PASSWORD'),
-        'HOST': 'db',
-        'PORT': '5432',
         'ATOMIC_REQUESTS': True,
     },
 }


### PR DESCRIPTION
Use external DB (from isg) instead of local instance run by
docker-compose in production settings.
Requires two new variables from scionlab.env-file, POSTGRES_HOST and POSTGRES_DB.

Still needs to be tested (either on testing instance or directly while preparing production instance).

TODO: update README, document how to use `docker-compose.override.yaml` to still use a local instance for testing purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/125)
<!-- Reviewable:end -->
