### PR TITLE
In the APs, split the border routers.

### DIFF
--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -494,6 +494,7 @@ class ASAdmin(admin.ModelAdmin):
 
     def is_userAS(self, obj):
         """ Is the AS `obj` a user AS? """
+        # Some other places simply check for owner=None.
         return UserAS.objects.filter(as_ptr=obj).exists()
 
     # Mark the is_ap and is_userAS functions as boolean, so they show

--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -699,6 +699,13 @@ class InterfaceManager(models.Manager):
         return self.filter(link_as_interfaceA__active=True) |\
             self.filter(link_as_interfaceB__active=True)
 
+    def inactive(self):
+        """
+        return list of Interfaces from inactive links
+        """
+        return self.filter(link_as_interfaceA__active=False) |\
+            self.filter(link_as_interfaceB__active=False)
+
     def get_by_address_port(self, as_, public_ip, public_port):
         """
         Get the interface by specifying its public IP and port, unique to an AS

--- a/scionlab/tests/utils.py
+++ b/scionlab/tests/utils.py
@@ -42,7 +42,7 @@ def check_topology(testcase):
         check_as(testcase, as_)
     for link in Link.objects.iterator():
         check_link(testcase, link)
-    check_no_dangling_interfaces(testcase)
+    check_interfaces(testcase)
 
 
 def check_as(testcase, as_):
@@ -231,6 +231,14 @@ def check_no_dangling_interfaces(testcase):
             link_as_interfaceA=None,
             link_as_interfaceB=None
         ).exists())
+
+
+def check_interfaces(testcase):
+    # Check that each interface is referenced by exactly one link
+    links = Link.objects.iterator()
+    ifacesA, ifacesB = zip(*((link.interfaceA_id, link.interfaceB_id) for link in links))
+    counter = Counter(ifacesA + ifacesB)
+    testcase.assertTrue(all(counter[iface.pk] == 1 for iface in Interface.objects.iterator()))
 
 
 def check_as_keys(testcase, as_):


### PR DESCRIPTION
One BR takes care of the interfaces not talking to children ASes.
The rest of the interfaces are spread using border routers, so that
no border router has more than 10 interfaces. The number 10 is an
argument to a function and can be changed.

Just noticed that the condition to split the interfaces being "children" or not, is not enough, as there are cases where an AP has a child which is not a user AS. It is not a bug, but it should be changed eventually to avoid this child ASes to change interface when user ASes are reconfigured.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/128)
<!-- Reviewable:end -->
