### PR TITLE
Fix race-condition in deployment task start

### DIFF
--- a/scionlab/models/user_as.py
+++ b/scionlab/models/user_as.py
@@ -339,7 +339,7 @@ class AttachmentPoint(models.Model):
     def trigger_deployment(self):
         """
         Trigger the deployment for the attachment point configuration (after the current transaction
-        is succesfully commited).
+        is successfully committed).
 
         The deployment is rate limited, max rate controlled by
         settings.DEPLOYMENT_PERIOD.


### PR DESCRIPTION
Before, the deployment task was started while the transaction was still
ongoing. The task checks at the beginning whether it should actually do
run the deployment based on the version number in the DB.
If the task starts up quickly it would abort immediatly, because the
version bump has not been commited to the DB yet.

Fixed by starting the task in transaction.on_commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/130)
<!-- Reviewable:end -->
