### PR TITLE
 Enable multiple VPN clients in infra ASes

### DIFF
--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -576,6 +576,9 @@ class VPNUpdateForm(VPNCreationForm):
 
 @admin.register(VPN)
 class VPNAdmin(admin.ModelAdmin):
+    list_display = ('__str__', 'server', 'subnet', 'server_vpn_ip', 'num_clients')
+    list_display_links = ('__str__',)
+
     def get_form(self, request, obj=None, **kwargs):
         """
         Use different forms for VPN creation or update
@@ -586,9 +589,16 @@ class VPNAdmin(admin.ModelAdmin):
             kwargs['form'] = VPNUpdateForm
         return super().get_form(request, obj, **kwargs)
 
+    def num_clients(self, obj):
+        return obj.clients.filter(active=True).count()
+
 
 @admin.register(VPNClient)
 class VPNClientAdmin(admin.ModelAdmin):
+    list_display = ('__str__', 'vpn', 'ip', 'common_name')
+    list_display_links = ('__str__',)
+    list_filter = ('vpn', 'active')
+
     def get_form(self, request, obj=None, **kwargs):
         """
         Use custom form during AS creation

--- a/scionlab/models/vpn.py
+++ b/scionlab/models/vpn.py
@@ -21,6 +21,7 @@ from scionlab.models.core import _placeholder, Host
 from scionlab.openvpn_config import (
     generate_vpn_client_key_material,
     generate_vpn_server_key_material,
+    get_cert_common_name,
 )
 from scionlab.util.django import value_set
 
@@ -56,6 +57,9 @@ class VPN(models.Model):
     class Meta:
         verbose_name = 'VPN'
         verbose_name_plural = 'VPNs'
+
+    def __str__(self):
+        return "VPN %s, %s" % (self.server, self.subnet)
 
     def _pre_delete(self):
         """
@@ -168,12 +172,18 @@ class VPNClient(models.Model):
         verbose_name = 'VPN Client'
         verbose_name_plural = 'VPN Clients'
 
+    def __str__(self):
+        return "%s in %s" % (self.ip, self.vpn)
+
     def _pre_delete(self):
         """
         Called by the pre_delete signal handler `_vpn_client_pre_delete`.
         """
         self.host.bump_config()
         self.vpn.server.bump_config()
+
+    def common_name(self):
+        return get_cert_common_name(self.cert.encode())
 
     def init_key(self):
         key, cert = generate_vpn_client_key_material(self.host)

--- a/scionlab/models/vpn.py
+++ b/scionlab/models/vpn.py
@@ -176,7 +176,7 @@ class VPNClient(models.Model):
         self.vpn.server.bump_config()
 
     def init_key(self):
-        key, cert = generate_vpn_client_key_material(self.host.AS)
+        key, cert = generate_vpn_client_key_material(self.host)
         self.private_key = key
         self.cert = cert
 


### PR DESCRIPTION
Use the host id in the common name (which needs to be unique per VPN
server); this allows to use one VPN client per host.
We may want to make use of this soon to configure some of the VPN
tunnels used in the infrastructure ASes directly in the coordinator,
instead of having random copy-pasted config files.

Note having multiple: clients per host would require to additionally
include the VPN Client id but would also require a bunch of other
changes (e.g. file couldn't just be called `client.conf`).  We don't
currently need this.

 Make admin for VPN a bit friendlier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/132)
<!-- Reviewable:end -->
