### PR TITLE
Scionlab config sudo fix

### DIFF
--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -37,6 +37,7 @@ import sys
 import tarfile
 import tempfile
 import urllib.request
+import time
 from collections import namedtuple
 
 
@@ -264,8 +265,8 @@ def install_config(tar):
     try:
         tmpdir = tempfile.mkdtemp()
         tar.extractall(path=tmpdir)
-        install_scion_config(tmpdir)
         install_vpn_client_config(tmpdir)
+        install_scion_config(tmpdir)
         install_vpn_server_config(tmpdir)
     finally:
         shutil.rmtree(tmpdir)
@@ -295,6 +296,14 @@ def install_vpn_client_config(tmpdir):
     if changed:
         if exists:
             _run_as_root(['systemctl', 'restart', 'openvpn@client'])
+            # ensure the interface is up; give up after 5 tries
+            for i in range(5):
+                print('Waiting for VPN ...')
+                time.sleep(1)
+                st = subprocess.run(['systemctl', 'is-active', '--quiet', 'openvpn@client'])
+                if st.returncode == 0:
+                    print("Got VPN")
+                    break
         else:
             _run_as_root(['systemctl', 'stop', 'openvpn@client'])
 
@@ -331,7 +340,7 @@ def _install_file(srcdir, filename, dstdir):
     dstfilename = os.path.join(dstdir, filename)
     if not os.path.exists(srcfilename):
         if os.path.exists(dstfilename):
-            os.remove(dstfilename)
+            _run_as_root(['rm', dstfilename])
             return (False, True)
         return (False, False)
 

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -310,7 +310,7 @@ def install_vpn_client_config(tmpdir):
             if vpn_ready:
                 logging.debug("Got VPN")
             else:
-                logging.warn('WARNING!: VPN could be to be ready. SCION may fail to start.')
+                logging.warn('WARNING!: VPN could be unready. SCION may fail to start.')
         else:
             _run_as_root(['systemctl', 'stop', 'openvpn@client'])
 

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -58,6 +58,8 @@ ConfigInfo = namedtuple('ConfigInfo',
                          'url',
                          'version'])
 
+logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.WARNING)
+
 
 def main(argv):
     sys.tracebacklimit = -1

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -26,7 +26,6 @@ Prerequisites:
 
 import argparse
 import base64
-import filecmp
 import io
 import json
 import logging
@@ -336,16 +335,17 @@ def _install_file(srcdir, filename, dstdir):
             return (False, True)
         return (False, False)
 
-    try:
-        equal = filecmp.cmp(srcfilename, dstfilename, shallow=False)
-    except FileNotFoundError:
-        equal = False
+    with open(os.devnull, 'w') as null:
+        equal = _run_as_root(['diff', '-q', srcfilename, dstfilename],
+                             check=False,
+                             stdout=null,
+                             stderr=null) == 0
     if not equal:
         _run_as_root(['mv', srcfilename, dstfilename])
     return (True, not equal)
 
 
-def _run_as_root(args, check=True, **kwargs):
+def _run_as_root(args, **kwargs):
     """
     Convenience helper: run with sudo unless already running as root
     Note: if in the future the scion-gen/-folder is also owned by root,
@@ -354,7 +354,7 @@ def _run_as_root(args, check=True, **kwargs):
     """
     if os.getuid() != 0:
         args = ['sudo'] + args
-    subprocess.run(args, check=check)
+    return subprocess.run(args, **kwargs).returncode
 
 
 def _get_argv():

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -297,13 +297,18 @@ def install_vpn_client_config(tmpdir):
         if exists:
             _run_as_root(['systemctl', 'restart', 'openvpn@client'])
             # ensure the interface is up; give up after 5 tries
+            vpn_ready = False
             for i in range(5):
                 print('Waiting for VPN ...')
                 time.sleep(1)
                 st = subprocess.run(['systemctl', 'is-active', '--quiet', 'openvpn@client'])
                 if st.returncode == 0:
-                    print("Got VPN")
+                    vpn_ready = True
                     break
+            if vpn_ready:
+                print("Got VPN")
+            else:
+                print('WARNING!: VPN seems not to be ready. SCION may fail to start.')
         else:
             _run_as_root(['systemctl', 'stop', 'openvpn@client'])
 
@@ -354,7 +359,7 @@ def _install_file(srcdir, filename, dstdir):
     return (True, not equal)
 
 
-def _run_as_root(args, **kwargs):
+def _run_as_root(args, check=True, **kwargs):
     """
     Convenience helper: run with sudo unless already running as root
     Note: if in the future the scion-gen/-folder is also owned by root,
@@ -363,7 +368,7 @@ def _run_as_root(args, **kwargs):
     """
     if os.getuid() != 0:
         args = ['sudo'] + args
-    return subprocess.run(args, **kwargs).returncode
+    return subprocess.run(args, check=check, **kwargs).returncode
 
 
 def _get_argv():

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -299,16 +299,18 @@ def install_vpn_client_config(tmpdir):
             # ensure the interface is up; give up after 5 tries
             vpn_ready = False
             for i in range(5):
-                logging.info('Waiting for VPN ...')
+                logging.debug('Waiting for VPN ...')
                 time.sleep(1)
-                st = subprocess.run(['systemctl', 'is-active', '--quiet', 'openvpn@client'])
+                st = subprocess.run(['ip', 'address', 'show', 'dev', 'tun0'],
+                                    stdout=subprocess.DEVNULL,
+                                    stderr=subprocess.DEVNULL)
                 if st.returncode == 0:
                     vpn_ready = True
                     break
             if vpn_ready:
-                logging.info("Got VPN")
+                logging.debug("Got VPN")
             else:
-                logging.warn('WARNING!: VPN seems not to be ready. SCION may fail to start.')
+                logging.warn('WARNING!: VPN could be to be ready. SCION may fail to start.')
         else:
             _run_as_root(['systemctl', 'stop', 'openvpn@client'])
 

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -299,16 +299,16 @@ def install_vpn_client_config(tmpdir):
             # ensure the interface is up; give up after 5 tries
             vpn_ready = False
             for i in range(5):
-                print('Waiting for VPN ...')
+                logging.info('Waiting for VPN ...')
                 time.sleep(1)
                 st = subprocess.run(['systemctl', 'is-active', '--quiet', 'openvpn@client'])
                 if st.returncode == 0:
                     vpn_ready = True
                     break
             if vpn_ready:
-                print("Got VPN")
+                logging.info("Got VPN")
             else:
-                print('WARNING!: VPN seems not to be ready. SCION may fail to start.')
+                logging.warn('WARNING!: VPN seems not to be ready. SCION may fail to start.')
         else:
             _run_as_root(['systemctl', 'stop', 'openvpn@client'])
 
@@ -349,11 +349,10 @@ def _install_file(srcdir, filename, dstdir):
             return (False, True)
         return (False, False)
 
-    with open(os.devnull, 'w') as null:
-        equal = _run_as_root(['diff', '-q', srcfilename, dstfilename],
-                             check=False,
-                             stdout=null,
-                             stderr=null) == 0
+    equal = _run_as_root(['diff', '-q', srcfilename, dstfilename],
+                         check=False,
+                         stdout=subprocess.DEVNULL,
+                         stderr=subprocess.DEVNULL) == 0
     if not equal:
         _run_as_root(['mv', srcfilename, dstfilename])
     return (True, not equal)


### PR DESCRIPTION
Closes #134 

Also fixes two other issues for user ASes:
- When going from having VPN to not having, the script would fail trying to remove `/etc/openvpn/client.conf`
- When going from not VPN to VPN, the script would start SCION before having VPN, letting the BR fail to bind to the VPN interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/135)
<!-- Reviewable:end -->
