### PR TITLE
Fix order of BR and service IDs in topology.json

### DIFF
--- a/scionlab/models/user_as.py
+++ b/scionlab/models/user_as.py
@@ -388,7 +388,7 @@ class AttachmentPoint(models.Model):
         # attaching non children all to one BR:
         infra_br = BorderRouter.objects.first_or_create(host)
         brs_to_delete = list(
-            host.border_routers.exclude(pk=infra_br.pk).values_list('pk', flat=True))
+            host.border_routers.order_by('pk').exclude(pk=infra_br.pk).values_list('pk', flat=True))
         brs_to_delete.reverse()
         infra_ifaces.update(border_router=infra_br)
         # attaching children to several BRs:

--- a/scionlab/scion_config.py
+++ b/scionlab/scion_config.py
@@ -235,7 +235,7 @@ def _get_linkto_relation(interface):
 
 def _get_router_names(as_):
     router_names = {}
-    for id, router in enumerate(as_.border_routers.iterator(), start=1):
+    for id, router in enumerate(as_.border_routers.order_by('pk').iterator(), start=1):
         router_name = "br%s-%s" % (as_.isd_as_path_str(), id)
         router_names[router] = router_name
     return router_names
@@ -244,7 +244,7 @@ def _get_router_names(as_):
 def _get_service_names(as_, service_types):
     service_names = {}
     for stype in service_types:
-        for id, service in enumerate(as_.services.filter(type=stype), start=1):
+        for id, service in enumerate(as_.services.filter(type=stype).order_by('pk'), start=1):
             service_name = "%s%s-%s" % (service.type.lower(), as_.isd_as_path_str(), id)
             service_names[service] = service_name
     return service_names


### PR DESCRIPTION
Use an explicit order_by when iterating over BRs/Services, to get predictable service IDs.

This was previously missing because I had misunderstood djangos query documentation; for `first`, the order does default to pk, but for other queries there is no default order.

Note: the issue is surprisingly tricky to reproduce locally because when loading data from a fixture into a local postgres instance, it will have the rows in the "correct" `id` order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/138)
<!-- Reviewable:end -->
