### PR TITLE
Generate topology with Bind for services when needed

### DIFF
--- a/scionlab/scion_config.py
+++ b/scionlab/scion_config.py
@@ -181,14 +181,20 @@ def _topo_add_router_entry(topo_dict, router, router_name, as_address_type):
 def _topo_add_control_services(topo_dict, service_names, as_address_type):
     for service, service_name in service_names.items():
         service_type_entry = topo_dict.setdefault(generator.TYPES_TO_KEYS[service.type], {})
+        addrs = {
+            "Public": {
+                "Addr": service.host.internal_ip,
+                "L4Port": service.port
+            }
+        }
+        if service.host.bind_ip:
+            addrs["Bind"] = {
+                "Addr": service.host.bind_ip,
+                "L4Port": service.port,
+            }
         service_type_entry[service_name] = {
             "Addrs": {
-                as_address_type: {
-                    "Public": {
-                        "Addr": service.host.internal_ip,
-                        "L4Port": service.port
-                    }
-                }
+                as_address_type: addrs
             }
         }
 


### PR DESCRIPTION
E.g.
```
  "BeaconService": {
    "bs17-ffaa_0_1103-1": {
      "Addrs": {
        "IPv4": {
          "Public": {
            "Addr": "86.119.37.2",
            "L4Port": 31041
          },
          "Bind": {
            "Addr": "10.0.235.43",
            "L4Port": 31041
          }
        }
      }
    }
  },
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/140)
<!-- Reviewable:end -->
