### PR TITLE
Reduce beaconing frequency except on APs

### DIFF
--- a/scionlab/defines.py
+++ b/scionlab/defines.py
@@ -38,5 +38,5 @@ DEFAULT_HOST_INTERNAL_IP = "127.0.0.1"
 DEFAULT_LINK_MTU = 1500 - 20 - 8
 DEFAULT_LINK_BANDWIDTH = 1000
 
-PROPAGATE_TIME_DEFAULT = 60
-PROPAGATE_TIME_AP = 5  # higher beaconing frequency in AP for faster UserAS startup
+PROPAGATE_TIME_CORE = 60  # lower beaconing frequency in cores to save resources
+PROPAGATE_TIME_NONCORE = 5  # higher frequency in non-cores ASes to have quicker startup

--- a/scionlab/defines.py
+++ b/scionlab/defines.py
@@ -37,3 +37,6 @@ PROM_PORT_OFFSET = 1000  # e.g. PS Prometheus port = PS.Public.Port + 1000 = 320
 DEFAULT_HOST_INTERNAL_IP = "127.0.0.1"
 DEFAULT_LINK_MTU = 1500 - 20 - 8
 DEFAULT_LINK_BANDWIDTH = 1000
+
+PROPAGATE_TIME_DEFAULT = 60
+PROPAGATE_TIME_AP = 5  # higher beaconing frequency in AP for faster UserAS startup

--- a/scionlab/util/local_config_util.py
+++ b/scionlab/util/local_config_util.py
@@ -20,6 +20,10 @@ from string import Template
 
 # SCION
 from scionlab.models.core import Service
+from scionlab.defines import (
+    PROPAGATE_TIME_DEFAULT,
+    PROPAGATE_TIME_AP
+)
 from lib.crypto.asymcrypto import (
     get_core_sig_key_file_path,
     get_enc_key_file_path,
@@ -98,7 +102,7 @@ def generate_instance_dir(archive, as_, stype, tp, name, prometheus_port):
                            _build_cs_conf(name, elem_dir))
 
     _write_topo(archive, elem_dir, tp)
-    _write_as_conf_and_path_policy(archive, elem_dir)
+    _write_as_conf_and_path_policy(archive, elem_dir, as_)
     _write_certs_trc(archive, elem_dir, as_)
     _write_keys(archive, elem_dir, as_)
 
@@ -142,7 +146,7 @@ def generate_sciond_config(archive, as_, tp, name):
                        _build_sciond_conf(name, elem_dir, as_.isd_as_str()))
 
     _write_topo(archive, elem_dir, tp)
-    _write_as_conf_and_path_policy(archive, elem_dir)
+    _write_as_conf_and_path_policy(archive, elem_dir, as_)
     _write_certs_trc(archive, elem_dir, as_)
 
 
@@ -235,10 +239,15 @@ def _write_topo(archive, elem_dir, tp):
     archive.write_json((elem_dir, 'topology.json'), tp)
 
 
-def _write_as_conf_and_path_policy(archive, elem_dir):
+def _write_as_conf_and_path_policy(archive, elem_dir, as_):
+
+    propagate_time = PROPAGATE_TIME_DEFAULT
+    if hasattr(as_, 'attachment_point_info'):
+        propagate_time = PROPAGATE_TIME_AP
+
     conf = {
         'RegisterTime': 5,
-        'PropagateTime': 5,
+        'PropagateTime': propagate_time,
         'CertChainVersion': 0,
         'RegisterPath': True,
         'PathSegmentTTL': 21600,

--- a/scionlab/util/local_config_util.py
+++ b/scionlab/util/local_config_util.py
@@ -21,8 +21,8 @@ from string import Template
 # SCION
 from scionlab.models.core import Service
 from scionlab.defines import (
-    PROPAGATE_TIME_DEFAULT,
-    PROPAGATE_TIME_AP
+    PROPAGATE_TIME_CORE,
+    PROPAGATE_TIME_NONCORE,
 )
 from lib.crypto.asymcrypto import (
     get_core_sig_key_file_path,
@@ -241,9 +241,10 @@ def _write_topo(archive, elem_dir, tp):
 
 def _write_as_conf_and_path_policy(archive, elem_dir, as_):
 
-    propagate_time = PROPAGATE_TIME_DEFAULT
-    if hasattr(as_, 'attachment_point_info'):
-        propagate_time = PROPAGATE_TIME_AP
+    if as_.is_core:
+        propagate_time = PROPAGATE_TIME_CORE
+    else:
+        propagate_time = PROPAGATE_TIME_NONCORE
 
     conf = {
         'RegisterTime': 5,


### PR DESCRIPTION
Use 60s beaconing interval on all nodes except APs to reduce CPU load
incurred by the (core-AS) beaconing.

Keep frequency high on APs to allow quick startup for UserASes.

Questions:
- should we rather make the distinction core/non-core?
- also change `RegisterTime`?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/152)
<!-- Reviewable:end -->
