### PR TITLE
Return dictionary of user ASes in json.

### DIFF
--- a/scionlab/urls.py
+++ b/scionlab/urls.py
@@ -25,7 +25,7 @@ from scionlab.views.user_as_views import (
     UserASDetailView,
     UserASGetConfigView)
 from scionlab.views.registration_view import UserRegistrationView, UserRegistrationResendView
-from scionlab.views.api import GetHostConfig, PostHostDeployedConfigVersion
+from scionlab.views.api import GetHostConfig, PostHostDeployedConfigVersion, GetUserASesList
 from scionlab.views.topology import topology_png
 
 urlpatterns = [
@@ -79,4 +79,7 @@ urlpatterns = [
     path('api/host/<slug:uid>/deployed_config_version',
          PostHostDeployedConfigVersion.as_view(),
          name='api_post_deployed_version'),
+    path('api/user/',
+         login_required(GetUserASesList.as_view()),
+         name='api_list_ases')
 ]


### PR DESCRIPTION
The view requires login. Accessible simply by requests.get(url, cookies=self.cookies) after login.

Changes with the intention to automate user AS creation, getting the configuration, etc, for the purpose of collecting statistics.

Sample client on https://gist.github.com/juagargi/2696d0dd19ad189143a494188a9285ce
