### PR TITLE
Set Vagrant provider explicitely

### DIFF
--- a/scionlab/hostfiles/Vagrantfile.tmpl
+++ b/scionlab/hostfiles/Vagrantfile.tmpl
@@ -1,5 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
 Vagrant.require_version ">= 1.8.1"
 
 Vagrant.configure(2) do |config|


### PR DESCRIPTION
Currently we rely on a default Vagrant provider set by OS or user.
As we only support VirtualBox, we need to explicitely state it in
the Vagrantfile so it runs correctly on systems with other providers.

Closes-Bug: #165

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/166)
<!-- Reviewable:end -->
