### PR TITLE
supervisord conf files for developers.

### DIFF
--- a/.circleci/Dockerfile-scionHost
+++ b/.circleci/Dockerfile-scionHost
@@ -17,6 +17,19 @@ COPY ./setup/reloadASConfig.sh ${SC}/reloadASConfig.sh
 RUN sudo mkdir -p /var/log/scion/
 RUN mkdir ${SC}/gen-cache
 
+# packages install binaries in /usr/bin . Supervisord expects them in $SC/bin
+RUN mkdir -p ${SC}/bin
+RUN ln -s /usr/bin/godispatcher bin/godispatcher
+RUN ln -s /usr/bin/sciond bin/sciond
+RUN ln -s /usr/bin/border bin/border
+RUN ln -s /usr/bin/beacon_srv bin/beacon_srv
+RUN ln -s /usr/bin/path_srv bin/path_srv
+RUN ln -s /usr/bin/cert_srv bin/cert_srv
+
+# Configuration in /etc/scion/gen but supervisord uses $SC/gen to reference toml files
+RUN ln -s /etc/scion/gen ${SC}/gen
+RUN rm -rf ${SC}/logs
+RUN ln -s /var/log/scion ${SC}/logs
 
 # Add environment variables for execution
 ENV PYTHONPATH ${SC}/python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,16 +141,16 @@ jobs:
             # Wait for the SCION services to start
             docker exec coreAS1301 /bin/bash -c 'cd ${SC}; until [ `./supervisor/supervisor.sh status | grep RUNNING | wc -l` -ge 6 ]; do sleep 0.1; done;'
             # Wait for beaconing to start
-            docker exec infraAS1305 /bin/bash -c 'until [ `grep "Registered beacons" -s -r /var/log/scion/ | wc -l` -ge 5 ]; do sleep 0.1; done; scmp echo -c 10 -local 19-ffaa:0:1305,[127.0.0.1] -remote 19-ffaa:0:1301,[127.0.0.1];'
+            docker exec infraAS1305 /bin/bash -c 'until [ `grep "Registered beacons" -s -r ${SC}/logs/ | wc -l` -ge 5 ]; do sleep 0.1; done; scmp echo -c 10 -local 19-ffaa:0:1305,[127.0.0.1] -remote 19-ffaa:0:1301,[127.0.0.1];'
             docker exec coreAS1301 /bin/bash -c "scmp echo -c 10 -local 19-ffaa:0:1301,[127.0.0.1] -remote 19-ffaa:0:1303,[127.0.0.1]"
-            docker exec infraAS1303 /bin/bash -c "grep -m 5 'Registered beacons' -r /var/log/scion/; scmp echo -c 10 -local 19-ffaa:0:1303,[127.0.0.1] -remote 19-ffaa:0:1301,[127.0.0.1];"
+            docker exec infraAS1303 /bin/bash -c "grep -m 5 'Registered beacons' -r ${SC}/logs/; scmp echo -c 10 -local 19-ffaa:0:1303,[127.0.0.1] -remote 19-ffaa:0:1301,[127.0.0.1];"
 
       - run:
           name: Check deploy
           command: |
             set -x
             # Recheck 1303
-            docker exec infraAS1303 /bin/bash -c "grep -m 5 'Registered beacons' -r /var/log/scion/; scmp echo -c 10 -local 19-ffaa:0:1303,[127.0.0.1] -remote 19-ffaa:0:1301,[127.0.0.1];"
+            docker exec infraAS1303 /bin/bash -c 'grep -m 5 "Registered beacons" -r ${SC}/logs/; scmp echo -c 10 -local 19-ffaa:0:1303,[127.0.0.1] -remote 19-ffaa:0:1301,[127.0.0.1];'
             # Update coordinator url config
             docker exec coord /bin/bash -c 'echo "SCIONLAB_SITE = \"http://coord:8000\"" >> ~/repo/scionlab/scionlab/settings/development.py'
             docker cp .circleci/setup/ssh_config coord:/home/circleci/repo/scionlab/run/ssh_config
@@ -179,7 +179,7 @@ jobs:
 
             # Check change was deployed and connection still works
             # i) IP was updated
-            docker exec infraAS1303 /bin/bash -c 'until [ `grep "172.31.0.111" -s -r /etc/scion/gen/ | wc -l` -ge 1 ]; do sleep 0.1; done;'
+            docker exec infraAS1303 /bin/bash -c 'until [ `grep "172.31.0.111" -s -r ${SC}/gen/ | wc -l` -ge 1 ]; do sleep 0.1; done;'
             # ii) Showpaths displays the paths
             docker exec infraAS1303 /bin/bash -c 'until showpaths -sciond /run/shm/sciond/default.sock -srcIA 19-ffaa:0:1303 -dstIA 19-ffaa:0:1301; do sleep 1; done;'
             # iii) SCMP completes without error for 10 echo requests
@@ -197,7 +197,7 @@ jobs:
             for n in 1 3; do
                 echo $AS_ID
                 # Show current TRC
-                docker exec coreAS1301 /bin/bash -c "cat /etc/scion/gen/ISD19/ASffaa_0_1301/bs19-ffaa_0_1301-1/certs/ISD19-V${TRC_version}.trc"
+                docker exec coreAS1301 /bin/bash -c "cat ${SC}/gen/ISD19/ASffaa_0_1301/bs19-ffaa_0_1301-1/certs/ISD19-V${TRC_version}.trc"
 
                 # Add core AS(es) for ISD 19
                 docker run --net circleci_as_net -d --name add_core_AS\
@@ -214,15 +214,15 @@ jobs:
                 sleep 10
 
                 # Check that TRCs were updated
-                docker exec coreAS1301 /bin/bash -c "cat /etc/scion/gen/ISD19/ASffaa_0_1301/bs19-ffaa_0_1301-1/certs/ISD19-V${TRC_version}.trc;" >> "./TRC_V${TRC_version}.json"
-                docker exec infraAS1303 /bin/bash -c "cat /etc/scion/gen/ISD19/ASffaa_0_1303/bs19-ffaa_0_1303-1/certs/ISD19-V${TRC_version}.trc;"
-                docker exec infraAS1305 /bin/bash -c "cat /etc/scion/gen/ISD19/ASffaa_0_1305/bs19-ffaa_0_1305-1/certs/ISD19-V${TRC_version}.trc;"
+                docker exec coreAS1301 /bin/bash -c "cat ${SC}/gen/ISD19/ASffaa_0_1301/bs19-ffaa_0_1301-1/certs/ISD19-V${TRC_version}.trc;" >> "./TRC_V${TRC_version}.json"
+                docker exec infraAS1303 /bin/bash -c "cat ${SC}/gen/ISD19/ASffaa_0_1303/bs19-ffaa_0_1303-1/certs/ISD19-V${TRC_version}.trc;"
+                docker exec infraAS1305 /bin/bash -c "cat ${SC}/gen/ISD19/ASffaa_0_1305/bs19-ffaa_0_1305-1/certs/ISD19-V${TRC_version}.trc;"
 
                 # Check that infra still works
                 sleep 30 # wait for paths to register, see `Check SCION connections` for an active wait
                 docker exec coreAS1301 /bin/bash -c "scmp echo -c 10 -local 19-ffaa:0:1301,[127.0.0.1] -remote 19-ffaa:0:1303,[127.0.0.1]"
-                docker exec infraAS1305 /bin/bash -c "grep -m 5 'Registered beacons' -r /var/log/scion/; scmp echo -c 10 -local 19-ffaa:0:1305,[127.0.0.1] -remote 19-ffaa:0:1301,[127.0.0.1];"
-                docker exec infraAS1303 /bin/bash -c "grep -m 5 'Registered beacons' -r /var/log/scion/; scmp echo -c 10 -local 19-ffaa:0:1303,[127.0.0.1] -remote 19-ffaa:0:1301,[127.0.0.1];"
+                docker exec infraAS1305 /bin/bash -c 'grep -m 5 "Registered beacons" -r ${SC}/logs/; scmp echo -c 10 -local 19-ffaa:0:1305,[127.0.0.1] -remote 19-ffaa:0:1301,[127.0.0.1];'
+                docker exec infraAS1303 /bin/bash -c 'grep -m 5 "Registered beacons" -r ${SC}/logs/; scmp echo -c 10 -local 19-ffaa:0:1303,[127.0.0.1] -remote 19-ffaa:0:1301,[127.0.0.1];'
             done
 
             core_countV2=$(jq '.CoreASes | length' ./TRC_V2.json)
@@ -270,7 +270,7 @@ jobs:
             done
             # Wait for client to be setup
             echo "Waiting for beaconing before starting VPN client SCMPs"
-            docker exec -e SC=${SC} userAS1 /bin/bash -c 'until [ `grep "Registered beacons" -s -r /var/log/scion/ | wc -l` -ge 5 ]; do sleep 0.1; done; scmp echo -c 10 -local 20-ffaa:1:1,[127.0.0.1] -remote 20-ffaa:0:1405,[127.0.0.1]'
+            docker exec -e SC=${SC} userAS1 /bin/bash -c 'until [ `grep "Registered beacons" -s -r ${SC}/logs/ | wc -l` -ge 5 ]; do sleep 0.1; done; scmp echo -c 10 -local 20-ffaa:1:1,[127.0.0.1] -remote 20-ffaa:0:1405,[127.0.0.1]'
             docker stop userAS1; docker rm userAS1;
 
       - run:

--- a/scionlab/defines.py
+++ b/scionlab/defines.py
@@ -47,7 +47,6 @@ DEFAULT_LINK_BANDWIDTH = 1000
 PROPAGATE_TIME_CORE = 60  # lower beaconing frequency in cores to save resources
 PROPAGATE_TIME_NONCORE = 5  # higher frequency in non-cores ASes to have quicker startup
 
-SCION_BINARY_DIR = "/usr/bin"
 SCION_CONFIG_DIR = "/etc/scion"
 SCION_LOG_DIR = "/var/log/scion"
 SCION_VAR_DIR = "/var/lib/scion"


### PR DESCRIPTION
Enable easy access to developers. They can use the generated gen for development,
just doing some changes to their system (1 time only):
- Point /var/log/scion to /home/juan/go/src/github.com/scionproto/scion/logs
- Point /etc/scion to /home/juan/go/src/github.com/scionproto/scion
- Point /var/lib/scion to /home/juan/go/src/github.com/scionproto/scion/gen-cache

scion.sh should still work after this, using the binaries in /home/juan/go/src/github.com/scionproto/scion.

Closes #177

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/179)
<!-- Reviewable:end -->
