### PR TITLE
Admin: Show More Useful Information

### DIFF
--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -173,8 +173,9 @@ class ISDAdmin(admin.ModelAdmin):
 
 class HostAdminForm(_CreateUpdateModelForm):
     class Meta:
-        fields = ('AS', 'internal_ip', 'public_ip', 'bind_ip', 'label', 'managed', 'ssh_host',
-                  'secret')
+        fields = ('AS', 'internal_ip', 'public_ip', 'bind_ip', 'label', 'managed', 'ssh_host')
+
+    secret = forms.CharField(required=False, widget=forms.TextInput(attrs={'size': '32'}))
 
     def create(self):
         return Host.objects.create(
@@ -216,6 +217,16 @@ class HostAdminMixin:
         return format_html('<a class="viewlink" href="%s"></a>' % url)
 
     get_config_link.short_description = 'Config'
+
+    def get_scionlab_config_cmd(self, obj):
+        return ('scionlab-config'
+                ' --host-id {host_id}'
+                ' --host-secret {host_secret}'.format(
+                    host_id=obj.uid,
+                    host_secret=obj.secret)
+                )
+
+    get_scionlab_config_cmd.short_description = 'Commandline'
 
 
 class HostInline(HostAdminMixin, admin.TabularInline):
@@ -730,11 +741,11 @@ class LinkAdmin(admin.ModelAdmin):
 @admin.register(Host)
 class HostAdmin(HostAdminMixin, admin.ModelAdmin):
     form = HostAdminForm
-    readonly_fields = ['uid']
+    readonly_fields = ['uid', 'get_scionlab_config_cmd']
     actions = ['trigger_config_deployment']
     list_display = ('__str__', 'AS',
                     'internal_ip', 'public_ip', 'bind_ip', 'managed', 'ssh_host',
-                    'latest_config_deployed', 'get_config_link')
+                    'latest_config_deployed', 'get_scionlab_config_cmd', 'get_config_link')
     list_filter = ('AS__isd', 'AS', )
     ordering = ['AS']
 

--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -1126,6 +1126,13 @@ class BorderRouter(models.Model):
 
     objects = BorderRouterManager()
 
+    def __str__(self):
+        return "br-%s-%i" % (self.AS.isd_as_path_str(), self._br_idx())
+
+    def _br_idx(self):
+        # slow!
+        return self.AS.border_routers.filter(pk__lt=self.pk).count() + 1
+
     def update(self, host=_placeholder, internal_port=_placeholder, control_port=_placeholder):
         """
         Update the given fields
@@ -1229,10 +1236,12 @@ class Service(models.Model):
 
     objects = ServiceManager()
 
-    def port(self):
-        if self.type not in self.SERVICE_PORTS:
-            raise KeyError('Unknown type %s' % self.type)
-        return self.SERVICE_PORTS[self.type]
+    def __str__(self):
+        return "%s-%s-%i" % (self.type.lower(), self.AS.isd_as_path_str(), self._service_idx())
+
+    def _service_idx(self):
+        # slow!
+        return self.AS.services.filter(type=self.type, pk__lt=self.pk).count() + 1
 
     def _pre_delete(self):
         """
@@ -1241,6 +1250,11 @@ class Service(models.Model):
         also for bulk deletion, while this `delete()` method is not.
         """
         Service._bump_affected(self.host, self.type)
+
+    def port(self):
+        if self.type not in self.SERVICE_PORTS:
+            raise KeyError('Unknown type %s' % self.type)
+        return self.SERVICE_PORTS[self.type]
 
     def update(self, host=_placeholder):
         """


### PR DESCRIPTION
* Informative string representation for Services and BorderRouters
* Show `secret` in HostAdmin (editable)
* Show `scionlab-config` command for config deployment in Host-list.

Contributes to #154 