### PR TITLE
Order Entries in User-AS List

### DIFF
--- a/scionlab/views/user_as_views.py
+++ b/scionlab/views/user_as_views.py
@@ -240,7 +240,7 @@ class OwnedUserASQuerysetMixin:
     To be used in a View that uses `django.views.generic.detail.SingleObjectMixin`
     """
     def get_queryset(self):
-        return UserAS.objects.filter(owner=self.request.user)
+        return super().get_queryset().filter(owner=self.request.user)
 
 
 class UserASDetailView(OwnedUserASQuerysetMixin, UpdateView):
@@ -305,6 +305,7 @@ class UserASGetConfigView(OwnedUserASQuerysetMixin, SingleObjectMixin, View):
 class UserASesView(OwnedUserASQuerysetMixin, ListView):
     template_name = "scionlab/user.html"
     model = UserAS
+    ordering = ['as_id']
 
 
 def _add_attachment_point_data(context):

--- a/scionlab/views/user_as_views.py
+++ b/scionlab/views/user_as_views.py
@@ -240,7 +240,7 @@ class OwnedUserASQuerysetMixin:
     To be used in a View that uses `django.views.generic.detail.SingleObjectMixin`
     """
     def get_queryset(self):
-        return super().get_queryset().filter(owner=self.request.user)
+        return UserAS.objects.filter(owner=self.request.user)
 
 
 class UserASDetailView(OwnedUserASQuerysetMixin, UpdateView):
@@ -302,10 +302,13 @@ class UserASGetConfigView(OwnedUserASQuerysetMixin, SingleObjectMixin, View):
         return resp
 
 
-class UserASesView(OwnedUserASQuerysetMixin, ListView):
+class UserASesView(ListView):
     template_name = "scionlab/user.html"
     model = UserAS
     ordering = ['as_id']
+
+    def get_queryset(self):
+        return super().get_queryset().filter(owner=self.request.user)
 
 
 def _add_attachment_point_data(context):


### PR DESCRIPTION
We've observed that the order of ASes in the list page sometimes changes,
as it is just the order in which the DB returned the entries.

This fix is only for cosmetics, with only 5 ASes it would not be a real
problem to find an AS even if it the order would change on every
refresh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/201)
<!-- Reviewable:end -->
