### PR TITLE
Vagrantfile: remove unneeded port forwards and disable serial port logging

### DIFF
--- a/scionlab/hostfiles/Vagrantfile.tmpl
+++ b/scionlab/hostfiles/Vagrantfile.tmpl
@@ -46,8 +46,9 @@ Unattended-Upgrade::Automatic-Reboot-Time "02:00";' > /etc/apt/apt.conf.d/51unat
   config.vm.box = "ubuntu/xenial64"
   # BR port forwarding not necessary for OpenVPN setup and depends on connection
   ${PortForwarding}
-  config.vm.network "forwarded_port", guest: 31042, host: 31042, protocol: "udp"
+  # scion dispatcher port, for running SCION endhosts connected to the AS in this VM:
   config.vm.network "forwarded_port", guest: 30041, host: 30041, protocol: "udp"
+  # web, for convenient access to "webapp":
   config.vm.network "forwarded_port", guest: 8000, host: 8000, protocol: "tcp"
   config.vm.provider "virtualbox" do |vb|
     vb.customize [ "setextradata", :id, "VBoxInternal/Devices/VMMDev/0/Config/GetHostTimeDisabled", 1 ]

--- a/scionlab/hostfiles/Vagrantfile.tmpl
+++ b/scionlab/hostfiles/Vagrantfile.tmpl
@@ -52,6 +52,7 @@ Unattended-Upgrade::Automatic-Reboot-Time "02:00";' > /etc/apt/apt.conf.d/51unat
   config.vm.network "forwarded_port", guest: 8000, host: 8000, protocol: "tcp"
   config.vm.provider "virtualbox" do |vb|
     vb.customize [ "setextradata", :id, "VBoxInternal/Devices/VMMDev/0/Config/GetHostTimeDisabled", 1 ]
+    vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
     vb.memory = "2048"
     vb.name = "${vmname}"
   end

--- a/scionlab/hostfiles/Vagrantfile.tmpl
+++ b/scionlab/hostfiles/Vagrantfile.tmpl
@@ -44,11 +44,11 @@ Unattended-Upgrade::Automatic-Reboot-Time "02:00";' > /etc/apt/apt.conf.d/51unat
   SCRIPT
 
   config.vm.box = "ubuntu/xenial64"
-  # BR port forwarding not necessary for OpenVPN setup and depends on connection
+  # forward border router port (unless using OpenVPN):
   ${PortForwarding}
-  # scion dispatcher port, for running SCION endhosts connected to the AS in this VM:
+  # forward scion dispatcher port, for running SCION endhosts connected to the AS in this VM:
   config.vm.network "forwarded_port", guest: 30041, host: 30041, protocol: "udp"
-  # web, for convenient access to "webapp":
+  # forward "webapp" port:
   config.vm.network "forwarded_port", guest: 8000, host: 8000, protocol: "tcp"
   config.vm.provider "virtualbox" do |vb|
     vb.customize [ "setextradata", :id, "VBoxInternal/Devices/VMMDev/0/Config/GetHostTimeDisabled", 1 ]


### PR DESCRIPTION
* Remove useless forwarded UDP port 31042
* Add comments to clarify why the other ports are forwarded (as documentation for us and for users)
* Disable logging serial port by default
  By default this logs to a file `ubuntu-xenial-16.04-cloudimg-console.log`, which is (usually) just clutter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/202)
<!-- Reviewable:end -->
