### PR TITLE
Generate systemd configuration for BWtester

### DIFF
--- a/scionlab/fixtures/testdata.yaml
+++ b/scionlab/fixtures/testdata.yaml
@@ -2301,12 +2301,6 @@
     host: 15
     type: CS
 - model: scionlab.service
-  pk: 46
-  fields:
-    AS: 4
-    host: 4
-    type: PP
-- model: scionlab.service
   pk: 47
   fields:
     AS: 4

--- a/scionlab/fixtures/testtopo.py
+++ b/scionlab/fixtures/testtopo.py
@@ -103,7 +103,6 @@ links = [
 
 # other than default services
 extra_services = [
-    (_expand_as_id(0x1107), Service.PP),
     (_expand_as_id(0x1107), Service.BW),
     (_expand_as_id(0x1406), Service.BW),
 ]

--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -1210,6 +1210,10 @@ class Service(models.Model):
         (BW, 'Bandwidth tester server'),
         (PP, 'Pingpong server'),
     )
+    STATIC_SERVICE_TYPES = (
+        BW,
+        PP,
+    )
     SERVICE_PORTS = {
         BS: BS_PORT,
         PS: PS_PORT,

--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -1210,7 +1210,7 @@ class Service(models.Model):
         (BW, 'Bandwidth tester server'),
         (PP, 'Pingpong server'),
     )
-    STATIC_SERVICE_TYPES = (
+    EXTRA_SERVICE_TYPES = (
         BW,
         PP,
     )

--- a/scionlab/scion_config.py
+++ b/scionlab/scion_config.py
@@ -57,21 +57,15 @@ from lib.defines import (
     SCIOND_API_SOCKDIR,
 )
 
-SERVICE_TYPES_CONTROL_PLANE = [Service.BS, Service.CS, Service.PS]
-SERVICE_TYPES_SERVER_APPS = [Service.BW, Service.PP]
-
 TYPE_BR = 'BR'
 TYPE_SD = 'SD'
 SERVICES_TO_SYSTEMD_NAMES = {
     Service.BS: 'scion-beacon-server',
     Service.CS: 'scion-certificate-server',
     Service.PS: 'scion-path-server',
+    Service.BW: 'scion-bwtestserver',
     TYPE_BR: 'scion-border-router',
-    TYPE_SD: 'scion-daemon',
 }
-SYSTEMD_NAMES_ALWAYS_PRESENT = [
-    'scion-dispatcher.service'
-]
 
 DEFAULT_ENV = ['TZ=UTC']
 BORDER_ENV = DEFAULT_ENV + ['GODEBUG="cgocheck=0"']
@@ -208,9 +202,13 @@ class _ConfigGenerator:
 
     def _write_systemd_services_file(self):
         instance_names = [r.instance_name for r in self._routers()] + \
-                         [s.instance_name for s in self._services()] + \
-                         ["sd%s" % self.AS.isd_as_path_str()]
-        unit_names = _get_systemd_services(instance_names)
+                         [s.instance_name for s in self._services()]
+
+        unit_names = _convert_instances_to_systemd_services(instance_names)
+        unit_names += _convert_static_to_systemd_services(self._static_services())
+        unit_names.append('scion-daemon@%s.service' % self.AS.isd_as_path_str())
+        unit_names.append('scion-dispatcher.service')
+
         self.archive.write_text('scionlab-services.txt', '\n'.join(unit_names))
 
     def _write_supervisord_files(self):
@@ -250,6 +248,9 @@ class _ConfigGenerator:
 
     def _services(self):
         return (s for s in self.topo_info.services if s.host == self.host)
+
+    def _static_services(self):
+        return list(self.host.services.filter(type__in=Service.STATIC_SERVICE_TYPES))
 
     def _elem_dir(self, elem_id):
         return os.path.join(_isd_as_dir(self.AS), elem_id)
@@ -436,7 +437,7 @@ def _isd_as_dir(as_):
     return os.path.join(GEN_PATH, "ISD%s" % as_.isd.isd_id, "AS%s" % as_.as_path_str())
 
 
-def _get_systemd_services(instance_names):
+def _convert_instances_to_systemd_services(instance_names):
     """
     converts instance names ('cs17-ffaa_1_a-1')
     to systemd names ('scion-certificate-server@17-ffaa_1_a-1.service')
@@ -451,4 +452,15 @@ def _get_systemd_services(instance_names):
             continue
         unit = '{sysd}@{name}.service'.format(sysd=systemd_unit, name=name)
         units.append(unit)
-    return units + SYSTEMD_NAMES_ALWAYS_PRESENT
+    return units
+
+
+def _convert_static_to_systemd_services(services):
+    """
+    Converts services to systemd names
+    :param services: list of services
+    """
+    units = []
+    for p in services:
+        units.append(SERVICES_TO_SYSTEMD_NAMES.get(p.type)+".service")
+    return units

--- a/scionlab/scion_config.py
+++ b/scionlab/scion_config.py
@@ -249,8 +249,8 @@ class _ConfigGenerator:
     def _services(self):
         return (s for s in self.topo_info.services if s.host == self.host)
 
-    def _static_services(self):
-        return list(self.host.services.filter(type__in=Service.STATIC_SERVICE_TYPES))
+    def _extra_services(self):
+        return list(self.host.services.filter(type__in=Service.EXTRA_SERVICE_TYPES))
 
     def _elem_dir(self, elem_id):
         return os.path.join(_isd_as_dir(self.AS), elem_id)

--- a/scionlab/scion_config.py
+++ b/scionlab/scion_config.py
@@ -202,10 +202,12 @@ class _ConfigGenerator:
 
     def _write_systemd_services_file(self):
         ia = self.AS.isd_as_path_str()
-        unit_names = ["scion-border-router@%s-%i.service" % (ia, router.instance_id) for router in self._routers()]
+        unit_names = ["scion-border-router@%s-%i.service" % (ia, router.instance_id)
+                      for router in self._routers()]
         unit_names += ["%s@%s-%i.service" % (SERVICES_TO_SYSTEMD_NAMES[service.type], ia, service.instance_id)
                        for service in self._services()]
-        unit_names += ["%s.service" % SERVICES_TO_SYSTEMD_NAMES[service.type] for service in self._extra_services()]
+        unit_names += ["%s.service" % SERVICES_TO_SYSTEMD_NAMES[service.type]
+                       for service in self._extra_services()]
         unit_names.append('scion-daemon@%s.service' % self.AS.isd_as_path_str())
         unit_names.append('scion-dispatcher.service')
 

--- a/scionlab/scion_config.py
+++ b/scionlab/scion_config.py
@@ -204,8 +204,8 @@ class _ConfigGenerator:
         ia = self.AS.isd_as_path_str()
         unit_names = ["scion-border-router@%s-%i.service" % (ia, router.instance_id)
                       for router in self._routers()]
-        unit_names += ["%s@%s-%i.service" % (SERVICES_TO_SYSTEMD_NAMES[service.type], ia, service.instance_id)
-                       for service in self._services()]
+        unit_names += ["%s@%s-%i.service" % (SERVICES_TO_SYSTEMD_NAMES[service.type], ia,
+                                             service.instance_id) for service in self._services()]
         unit_names += ["%s.service" % SERVICES_TO_SYSTEMD_NAMES[service.type]
                        for service in self._extra_services()]
         unit_names.append('scion-daemon@%s.service' % self.AS.isd_as_path_str())

--- a/scionlab/scion_topology.py
+++ b/scionlab/scion_topology.py
@@ -76,7 +76,7 @@ def _fetch_routers(as_):
 
 def _fetch_services(as_):
     services = []
-    for stype, _ in Service.SERVICE_TYPES:
+    for stype, _ in [x for x in Service.SERVICE_TYPES if x[0] not in Service.STATIC_SERVICE_TYPES]:
         for id, service in enumerate(as_.services.filter(type=stype).order_by('pk'), start=1):
             service.instance_id = id
             service.instance_name = "%s%s-%s" % (stype.lower(), as_.isd_as_path_str(), id)

--- a/scionlab/scion_topology.py
+++ b/scionlab/scion_topology.py
@@ -76,7 +76,7 @@ def _fetch_routers(as_):
 
 def _fetch_services(as_):
     services = []
-    for stype, _ in [x for x in Service.SERVICE_TYPES if x[0] not in Service.STATIC_SERVICE_TYPES]:
+    for stype, _ in [x for x in Service.SERVICE_TYPES if x[0] not in Service.EXTRA_SERVICE_TYPES]:
         for id, service in enumerate(as_.services.filter(type=stype).order_by('pk'), start=1):
             service.instance_id = id
             service.instance_name = "%s%s-%s" % (stype.lower(), as_.isd_as_path_str(), id)

--- a/scionlab/tests/data/test_config_tar/host_4.yml
+++ b/scionlab/tests/data/test_config_tar/host_4.yml
@@ -1450,6 +1450,7 @@ scionlab-services.txt: |-
   scion-beacon-server@17-ffaa_0_1107-1.service
   scion-path-server@17-ffaa_0_1107-1.service
   scion-certificate-server@17-ffaa_0_1107-1.service
+  scion-bwtestserver.service
   scion-daemon@17-ffaa_0_1107.service
   scion-dispatcher.service
 server.conf: |

--- a/scionlab/tests/test_config_tar.py
+++ b/scionlab/tests/test_config_tar.py
@@ -50,7 +50,7 @@ class ConfigTarRegressionTests(TestCase):
         self.maxDiff = None
 
     def test_host(self):
-        extra_srv = Service.objects.filter(type__in=[Service.PP, Service.BW]).first()
+        extra_srv = Service.objects.filter(type__in=[Service.BW]).first()
         host = extra_srv.host
         archive = DictWriter()
         generate_host_config_tar(host, archive)


### PR DESCRIPTION
Currently the coordinator is not generating any systemd configuration for BWtester. Its existence introduces multiple classes of services running on the hosts

- static services running always (like dispatcher)
- instantiated services running always (like daemon)
- instantiated services running based on the config (like border routers)
- static services running based on the config (like bandwidth tester)

Having the first 3 already covered, this patch introduces support for the last class. Apart from this, it removes references to the "Service.PP" which has been deprecated some time ago.

Please note this patch do not introduce generating supervisord configuration for the 4th class of the services, mainly because in the current state bwtestserver is not meant to be run on non-infrastructure nodes using coordinator and all the infrastructure nodes are using systemd deployment model.

Related-bug: #178 