### PR TITLE
WIP: Start OpenVPN client when starting scionlab.target

### DIFF
--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -117,6 +117,9 @@ def _add_vpn_config(host, archive):
                                                           '-scionlab\\x2dvpn.device\nBindsTo=sys'
                                                           '-devices-virtual-net-scionlab\\x2dvpn'
                                                           '.device\n')
+        archive.write_text("vpn_udev.rules", 'ACTION=="add", SUBSYSTEM=="net", '
+                                             'KERNEL=="scionlab-vpn", RUN+="/bin/systemctl '
+                                             '--no-block start scionlab.target"\n')
 
     vpn_servers = list(host.vpn_servers.all())
     for vpn_server in vpn_servers:

--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -113,6 +113,10 @@ def _add_vpn_config(host, archive):
         client_config = generate_vpn_client_config(vpn_client)
         archive.write_text("client.conf", client_config)
         archive.write_text("override_openvpn_client.conf", '[Install]\nWantedBy=scionlab.target\n')
+        archive.write_text("override_border_router.conf", '[Unit]\nAfter=sys-devices-virtual-net'
+                                                          '-scionlab\\x2dvpn.device\nBindsTo=sys'
+                                                          '-devices-virtual-net-scionlab\\x2dvpn'
+                                                          '.device\n')
 
     vpn_servers = list(host.vpn_servers.all())
     for vpn_server in vpn_servers:

--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -112,6 +112,7 @@ def _add_vpn_config(host, archive):
     for vpn_client in vpn_clients:
         client_config = generate_vpn_client_config(vpn_client)
         archive.write_text("client.conf", client_config)
+        archive.write_text("override.conf", '[Install]\nWantedBy=scionlab.target\n')
 
     vpn_servers = list(host.vpn_servers.all())
     for vpn_server in vpn_servers:

--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -112,7 +112,7 @@ def _add_vpn_config(host, archive):
     for vpn_client in vpn_clients:
         client_config = generate_vpn_client_config(vpn_client)
         archive.write_text("client.conf", client_config)
-        archive.write_text("override.conf", '[Install]\nWantedBy=scionlab.target\n')
+        archive.write_text("override_openvpn_client.conf", '[Install]\nWantedBy=scionlab.target\n')
 
     vpn_servers = list(host.vpn_servers.all())
     for vpn_server in vpn_servers:

--- a/scionlab/hostfiles/client.conf.tmpl
+++ b/scionlab/hostfiles/client.conf.tmpl
@@ -2,7 +2,8 @@
 client
 
 # We use a TUN device, a virtual point-to-point IP link
-dev tun
+dev-type tun
+dev scionlab-vpn
 
 # Connecting to a UDP server
 proto udp

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -320,8 +320,8 @@ def restart_scion():
 
 
 def install_vpn_client_config(tmpdir):
-    exists, changed = _install_file(tmpdir, 'client.conf', '/etc/openvpn/')
-    _, _ = _install_file(tmpdir, 'override.conf', '/etc/systemd/system/openvpn@client.service.d/')
+    exists, changed = _install_file(tmpdir, 'client.conf', '/etc/openvpn/', 'client.conf')
+    _, _ = _install_file(tmpdir, 'override_openvpn_client.conf', '/etc/systemd/system/openvpn@client.service.d/', 'override.conf')
 
     if exists:
         scionlab_services = os.path.join(tmpdir, 'scionlab-services.txt')
@@ -354,7 +354,7 @@ def install_vpn_client_config(tmpdir):
 
 
 def install_vpn_server_config(tmpdir):
-    exists, changed = _install_file(tmpdir, 'server.conf', '/etc/openvpn/')
+    exists, changed = _install_file(tmpdir, 'server.conf', '/etc/openvpn/', 'server.conf')
 
     if exists:
         scionlab_services = os.path.join(tmpdir, 'scionlab-services.txt')
@@ -380,7 +380,7 @@ def _mv_dir(srcdir, dirname, dstdir):
     shutil.move(os.path.join(srcdir, dirname), dstdir)
 
 
-def _install_file(srcdir, filename, dstdir):
+def _install_file(srcdir, srcfilename, dstdir, dstfilename):
     """
     Installs the file from srcdir into the directory dstdir.
     If the file doesn't exist in srcdir, the file at dstdir will be removed.
@@ -388,8 +388,8 @@ def _install_file(srcdir, filename, dstdir):
                     exists indicates whether the file exists now.
                     changed indicates whether the file was changed.
     """
-    srcfilename = os.path.join(srcdir, filename)
-    dstfilename = os.path.join(dstdir, filename)
+    srcfilename = os.path.join(srcdir, srcfilename)
+    dstfilename = os.path.join(dstdir, dstfilename)
     if not os.path.exists(srcfilename):
         if os.path.exists(dstfilename):
             subprocess.run(['rm', dstfilename], check=True)

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -273,9 +273,9 @@ def install_config(tar):
         tmpdir = tempfile.mkdtemp()
         tar.extractall(path=tmpdir)
         install_vpn_client_config(tmpdir)
+        install_vpn_server_config(tmpdir)
         install_scionlab_service(tmpdir)
         install_scion_config(tmpdir)
-        install_vpn_server_config(tmpdir)
     finally:
         shutil.rmtree(tmpdir)
 
@@ -322,44 +322,57 @@ def restart_scion():
 def install_vpn_client_config(tmpdir):
     exists, changed = _install_file(tmpdir, 'client.conf', '/etc/openvpn/')
     _, _ = _install_file(tmpdir, 'override.conf', '/etc/systemd/system/openvpn@client.service.d/')
-    if changed:
-        if exists:
-            subprocess.run(['systemctl', 'daemon-reload'], check=True)
-            subprocess.run(['systemctl', 'restart', 'openvpn@client'], check=True)
-            # ensure the interface is up; give up after 5 tries
-            vpn_ready = False
-            for i in range(5):
-                logging.debug('Waiting for VPN ...')
-                time.sleep(1)
-                st = subprocess.run(['ip', 'address', 'show', 'dev', 'tun0'],
-                                    stdout=subprocess.DEVNULL,
-                                    stderr=subprocess.DEVNULL)
-                if st.returncode == 0:
-                    vpn_ready = True
-                    break
-            if vpn_ready:
-                logging.debug("Got VPN")
-            else:
-                logging.warn('WARNING!: VPN could be unready. SCION may fail to start.')
-        else:
-            subprocess.run(['systemctl', 'daemon-reload'], check=True)
-            subprocess.run(['systemctl', 'stop', 'openvpn@client'], check=True)
+
+    if exists:
+        scionlab_services = os.path.join(tmpdir, 'scionlab-services.txt')
+        if not os.path.exists(scionlab_services):
+            _error_exit("Could not find the scionlab-services.txt file in %s", tmpdir)
+
+        with open(scionlab_services, 'a') as f:
+            f.write('\nopenvpn@client.service')
+
+        # (TODO) We do not start OpenVPN client here, thus this logic has to be moved somewhere else
+
+        # if changed:
+        #     # ensure the interface is up; give up after 5 tries
+        #     vpn_ready = False
+        #     for i in range(5):
+        #         logging.debug('Waiting for VPN ...')
+        #         time.sleep(1)
+        #         st = subprocess.run(['ip', 'address', 'show', 'dev', 'tun0'],
+        #                             stdout=subprocess.DEVNULL,
+        #                             stderr=subprocess.DEVNULL)
+        #         if st.returncode == 0:
+        #             vpn_ready = True
+        #             break
+        #     if vpn_ready:
+        #         logging.debug("Got VPN")
+        #     else:
+        #         logging.warn('WARNING!: VPN could be unready. SCION may fail to start.')
+    else:
+        subprocess.run(['systemctl', 'stop', 'openvpn@client'], check=False)
 
 
 def install_vpn_server_config(tmpdir):
     exists, changed = _install_file(tmpdir, 'server.conf', '/etc/openvpn/')
-    if changed:
-        if exists:
-            if not os.path.exists('/etc/openvpn/dh.pem'):
-                subprocess.run(['openssl', 'dhparam', '-out', '/etc/openvpn/dh.pem', '2048'],
-                               check=True)
-            subprocess.run(['systemctl', 'restart', 'openvpn@server'], check=True)
-        else:
-            subprocess.run(['systemctl', 'stop', 'openvpn@server'], check=False)
 
     if exists:
+        scionlab_services = os.path.join(tmpdir, 'scionlab-services.txt')
+        if not os.path.exists(scionlab_services):
+            _error_exit("Could not find the scionlab-services.txt file in %s", tmpdir)
+
+        with open(scionlab_services, 'a') as f:
+            f.write('\nopenvpn@server.service')
+
         subprocess.run(['rm', '-rf', '/etc/openvpn/ccd/'], check=True)
         subprocess.run(['mv', os.path.join(tmpdir, 'ccd'), '/etc/openvpn/'], check=True)
+
+        if changed and not os.path.exists('/etc/openvpn/dh.pem'):
+            subprocess.run(['openssl', 'dhparam', '-out', '/etc/openvpn/dh.pem', '2048'],
+                           check=True)
+
+    else:
+        subprocess.run(['systemctl', 'stop', 'openvpn@server'], check=False)
 
 
 def _mv_dir(srcdir, dirname, dstdir):

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -321,7 +321,10 @@ def restart_scion():
 
 def install_vpn_client_config(tmpdir):
     exists, changed = _install_file(tmpdir, 'client.conf', '/etc/openvpn/', 'client.conf')
-    _, _ = _install_file(tmpdir, 'override_openvpn_client.conf', '/etc/systemd/system/openvpn@client.service.d/', 'override.conf')
+    _, _ = _install_file(tmpdir, 'override_openvpn_client.conf',
+                         '/etc/systemd/system/openvpn@client.service.d/', 'override.conf')
+    _, _ = _install_file(tmpdir, 'override_border_router.conf',
+                         '/etc/systemd/system/scion-border-router@.service.d/', 'override.conf')
 
     if exists:
         scionlab_services = os.path.join(tmpdir, 'scionlab-services.txt')
@@ -331,24 +334,6 @@ def install_vpn_client_config(tmpdir):
         with open(scionlab_services, 'a') as f:
             f.write('\nopenvpn@client.service')
 
-        # (TODO) We do not start OpenVPN client here, thus this logic has to be moved somewhere else
-
-        # if changed:
-        #     # ensure the interface is up; give up after 5 tries
-        #     vpn_ready = False
-        #     for i in range(5):
-        #         logging.debug('Waiting for VPN ...')
-        #         time.sleep(1)
-        #         st = subprocess.run(['ip', 'address', 'show', 'dev', 'tun0'],
-        #                             stdout=subprocess.DEVNULL,
-        #                             stderr=subprocess.DEVNULL)
-        #         if st.returncode == 0:
-        #             vpn_ready = True
-        #             break
-        #     if vpn_ready:
-        #         logging.debug("Got VPN")
-        #     else:
-        #         logging.warn('WARNING!: VPN could be unready. SCION may fail to start.')
     else:
         subprocess.run(['systemctl', 'stop', 'openvpn@client'], check=False)
 

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -321,8 +321,10 @@ def restart_scion():
 
 def install_vpn_client_config(tmpdir):
     exists, changed = _install_file(tmpdir, 'client.conf', '/etc/openvpn/')
+    _, _ = _install_file(tmpdir, 'override.conf', '/etc/systemd/system/openvpn@client.service.d/')
     if changed:
         if exists:
+            subprocess.run(['systemctl', 'daemon-reload'], check=True)
             subprocess.run(['systemctl', 'restart', 'openvpn@client'], check=True)
             # ensure the interface is up; give up after 5 tries
             vpn_ready = False
@@ -340,6 +342,7 @@ def install_vpn_client_config(tmpdir):
             else:
                 logging.warn('WARNING!: VPN could be unready. SCION may fail to start.')
         else:
+            subprocess.run(['systemctl', 'daemon-reload'], check=True)
             subprocess.run(['systemctl', 'stop', 'openvpn@client'], check=True)
 
 

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -325,6 +325,11 @@ def install_vpn_client_config(tmpdir):
                          '/etc/systemd/system/openvpn@client.service.d/', 'override.conf')
     _, _ = _install_file(tmpdir, 'override_border_router.conf',
                          '/etc/systemd/system/scion-border-router@.service.d/', 'override.conf')
+    _, udev_rules_changed = _install_file(tmpdir, 'vpn_udev.rules', '/etc/udev/rules.d/',
+                                          '90-scionlab-vpn.rules')
+
+    if udev_rules_changed:
+        subprocess.run(['udevadm', 'control', '--reload-rules'])
 
     if exists:
         scionlab_services = os.path.join(tmpdir, 'scionlab-services.txt')

--- a/scionlab/tests/data/test_config_tar/user_as_18.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_18.yml
@@ -1,5 +1,8 @@
 README.md: |-
   content_not_checked
+override.conf: |
+  [Install]
+  WantedBy=scionlab.target
 client.conf: |
   # Specify that we are a client
   client

--- a/scionlab/tests/data/test_config_tar/user_as_18.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_18.yml
@@ -3,12 +3,17 @@ README.md: |-
 override_openvpn_client.conf: |
   [Install]
   WantedBy=scionlab.target
+override_border_router.conf: |
+  [Unit]
+  After=sys-devices-virtual-net-scionlab\x2dvpn.device
+  BindsTo=sys-devices-virtual-net-scionlab\x2dvpn.device
 client.conf: |
   # Specify that we are a client
   client
 
   # We use a TUN device, a virtual point-to-point IP link
-  dev tun
+  dev-type tun
+  dev scionlab-vpn
 
   # Connecting to a UDP server
   proto udp

--- a/scionlab/tests/data/test_config_tar/user_as_18.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_18.yml
@@ -7,6 +7,8 @@ override_border_router.conf: |
   [Unit]
   After=sys-devices-virtual-net-scionlab\x2dvpn.device
   BindsTo=sys-devices-virtual-net-scionlab\x2dvpn.device
+vpn_udev.rules: |
+  ACTION=="add", SUBSYSTEM=="net", KERNEL=="scionlab-vpn", RUN+="/bin/systemctl --no-block start scionlab.target"
 client.conf: |
   # Specify that we are a client
   client

--- a/scionlab/tests/data/test_config_tar/user_as_18.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_18.yml
@@ -1,6 +1,6 @@
 README.md: |-
   content_not_checked
-override.conf: |
+override_openvpn_client.conf: |
   [Install]
   WantedBy=scionlab.target
 client.conf: |


### PR DESCRIPTION
This change adds dependency on the `scionlab.target` to the `openvpn@client.service` causing the latter to be started when the former is starting. This means it is no longer required to manually start the client VPN session.

This also adds dependency on the TUN device to the scion-border-router services causing
- border router wait till VPN is up and running
- border router stop if VPN goes down

Please note currently border router will not come back automatically after VPN is back again.

Closes: #190 
Closes: #206

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/211)
<!-- Reviewable:end -->
