### PR TITLE
Increase DATA_UPLOAD_MAX_NUMBER_FIELDS to 10000

### DIFF
--- a/scionlab/settings/common.py
+++ b/scionlab/settings/common.py
@@ -164,3 +164,6 @@ except IOError:
             f.write(SECRET_KEY)
     except IOError:
         raise Exception('Could not open %s for writing!' % SECRET_FILE)
+
+# ##### SCALING AND PERFORMANCE #####################
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000


### PR DESCRIPTION
In order to allow modification of the arbitrarily big entities
the DATA_UPLOAD_MAX_NUMBER_FIELDS needs to be increased from the
default value of 1000.

Closes: #214