### PR TITLE
Check for NULL when iterating over routers/services

### DIFF
--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -1131,7 +1131,10 @@ class BorderRouter(models.Model):
 
     def _br_idx(self):
         # slow!
-        return self.AS.border_routers.filter(pk__lt=self.pk).count() + 1
+        if self.pk:
+            return self.AS.border_routers.filter(pk__lt=self.pk).count() + 1
+        else:
+            return 0
 
     def update(self, host=_placeholder, internal_port=_placeholder, control_port=_placeholder):
         """
@@ -1245,7 +1248,10 @@ class Service(models.Model):
 
     def _service_idx(self):
         # slow!
-        return self.AS.services.filter(type=self.type, pk__lt=self.pk).count() + 1
+        if self.pk:
+            return self.AS.services.filter(type=self.type, pk__lt=self.pk).count() + 1
+        else:
+            return 0
 
     def _pre_delete(self):
         """


### PR DESCRIPTION
When deleting a border router or a service it turns out we are
trying to iterate over a list containing the element which is being
removed. This causes creating a DB lookup over non-existing element
what in effect crashes the engine.

This change workarounds it by catching this case and returning an
arbitrary ID for this service. As we are not showing it in the UI
anymore (because it's being deleted), it does not have an visible
impact.

Close: #216