### PR TITLE
Add missing key usage key_encipherment to vpn server certificate

### DIFF
--- a/scionlab/openvpn_config.py
+++ b/scionlab/openvpn_config.py
@@ -277,7 +277,7 @@ def _make_cert(subject_name, subject_key, issuer_name, issuer_key,
         critical=False,
     ).add_extension(
         # digital_signature
-        x509.KeyUsage(True, False, False, False, False, False, False, False, False),
+        x509.KeyUsage(True, False, True, False, False, False, False, False, False),
         critical=True,
     ).add_extension(
         x509.ExtendedKeyUsage([extended_key_usage_oid]),


### PR DESCRIPTION
Newly created server certificates were missing X509v3 Key Usage `Key Encipherment`
Expected value for field `X509v3 Key Usage`: `Digital Signature, Key Encipherment`
Previous value for field `X509v3 Key Usage`: `Digital Signature`

Symptoms:
Clients fail to connect with message
```
scionlab-ffaa-1-0 ovpn-client[11]: Validating certificate key usage
scionlab-ffaa-1-0 ovpn-client[11]: ++ Certificate has key usage  0080, expects 00a0
scionlab-ffaa-1-0 ovpn-client[11]: ++ Certificate has key usage  0080, expects 0088
scionlab-ffaa-1-0 ovpn-client[11]: VERIFY KU ERROR
scionlab-ffaa-1-0 ovpn-client[11]: TLS_ERROR: BIO read tls_read_plaintext error: error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed
scionlab-ffaa-1-0 ovpn-client[11]: TLS Error: TLS object -> incoming plaintext read error
scionlab-ffaa-1-0 ovpn-client[11]: TLS Error: TLS handshake failed
```