### PR TITLE
Fix VM provider not supporting IA in box name

### DIFF
--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -147,7 +147,7 @@ def _expand_vagrantfile_template(host):
         host_secret=host.secret,
         url=settings.SCIONLAB_SITE,
         hostname="scionlab-" + host.AS.as_id.replace(":", "-"),
-        vmname="SCIONLabVM-" + host.AS.as_id,
+        vmname="SCIONLabVM-" + host.AS.as_id.as_path_str()
     )
 
 

--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -147,7 +147,7 @@ def _expand_vagrantfile_template(host):
         host_secret=host.secret,
         url=settings.SCIONLAB_SITE,
         hostname="scionlab-" + host.AS.as_id.replace(":", "-"),
-        vmname="SCIONLabVM-" + host.AS.as_id.as_path_str()
+        vmname="SCIONLabVM-" + host.AS.as_path_str()
     )
 
 

--- a/scionlab/tests/data/test_config_tar/user_as_16.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_16.yml
@@ -29,6 +29,6 @@ Vagrantfile: "# -*- mode: ruby -*-\n# vi: set ft=ruby :\n\nENV['VAGRANT_DEFAULT_
   \ \"forwarded_port\", guest: 8000, host: 8000, protocol: \"tcp\"\n  config.vm.provider\
   \ \"virtualbox\" do |vb|\n    vb.customize [ \"setextradata\", :id, \"VBoxInternal/Devices/VMMDev/0/Config/GetHostTimeDisabled\"\
   , 1 ]\n    vb.customize [ \"modifyvm\", :id, \"--uartmode1\", \"disconnected\" ]\n\
-  \    vb.memory = \"2048\"\n    vb.name = \"SCIONLabVM-ffaa:1:1\"\n  end\n  config.vm.hostname\
+  \    vb.memory = \"2048\"\n    vb.name = \"SCIONLabVM-ffaa_1_1\"\n  end\n  config.vm.hostname\
   \ = \"scionlab-ffaa-1-1\"\n  config.vm.provision \"shell\", privileged: true, inline:\
   \ $setup_scion\nend\n"

--- a/scionlab/tests/data/test_config_tar/user_as_17.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_17.yml
@@ -57,7 +57,7 @@ Vagrantfile: |
       vb.customize [ "setextradata", :id, "VBoxInternal/Devices/VMMDev/0/Config/GetHostTimeDisabled", 1 ]
       vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
       vb.memory = "2048"
-      vb.name = "SCIONLabVM-ffaa:1:2"
+      vb.name = "SCIONLabVM-ffaa_1_2"
     end
     config.vm.hostname = "scionlab-ffaa-1-2"
     config.vm.provision "shell", privileged: true, inline: $setup_scion

--- a/scionlab/tests/utils.py
+++ b/scionlab/tests/utils.py
@@ -420,7 +420,7 @@ def check_tarball_user_as(testcase, response, user_as):
         vagrantfile = tar.extractfile('Vagrantfile')
         lines = [l.decode() for l in vagrantfile]
         name_lines = [l.strip() for l in lines if l.strip().startswith('vb.name')]
-        testcase.assertEqual(name_lines, ['vb.name = "SCIONLabVM-%s"' % user_as.as_id])
+        testcase.assertEqual(name_lines, ['vb.name = "SCIONLabVM-%s"' % user_as.as_path_str()])
     else:
         testcase.assertEquals(sorted(['README.md', 'gen']),
                               _tar_ls(tar, ''))


### PR DESCRIPTION
Virtualbox fails to create configuration directories on macOS and Windows, since it is using the vmname containing colons
Use the filename format

Fixes issue #241