### PR TITLE
Fix run mount path in CI

### DIFF
--- a/.circleci/docker-compose.yml
+++ b/.circleci/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - "8432:8000"
     volumes:
-      - ./run/:/scionlab/run/
+      - ../run/:/scionlab/run/:z
 
   huey:
     build:
@@ -30,7 +30,7 @@ services:
       as_net:
         ipv4_address: 172.31.0.11
     volumes:
-      - ./run/:/scionlab/run/
+      - ../run/:/scionlab/run/
 
   as1301:
     build:


### PR DESCRIPTION
>You can mount a relative path on the host, that expands relative to the directory of the Compose configuration file being used

The context only applies to the build section.