### PR TITLE
Add version number to API

### DIFF
--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -749,7 +749,7 @@ class HostAdmin(HostAdminMixin, admin.ModelAdmin):
     def get_config(self, request, object_id):
         """
         View to retrieve configuration tar ball for a host.
-        Returns same content as api/host/<int:pk>/config, but authentication is by user (admin), not
+        Returns same content as api_get_config, but authentication is by user (admin), not
         host/secret.
         """
         host = get_object_or_404(Host, pk=object_id)

--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -115,13 +115,8 @@ def _add_vpn_client_configs(host, archive):
         name = client.vpn.server.AS.isd_as_path_str()
         configs[name] = generate_vpn_client_config(client)
 
-    if len(configs) == 1:
-        # Keep old file name if only one client configured:
-        # TODO(matzf): backwards compatibility, remove this with next set of breaking changes
-        archive.write_text("client.conf", next(iter(configs.values())))
-    else:
-        for name, config in configs.items():
-            archive.write_text("client-scionlab-{}.conf".format(name), config)
+    for name, config in configs.items():
+        archive.write_text("client-scionlab-{}.conf".format(name), config)
 
 
 def _add_vpn_server_config(host, archive):

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -180,7 +180,7 @@ def fetch_config(config_info):
         - tarfile.tar the configuration archive
     """
 
-    url = '{coordinator_url}/api/host/{host_id}/config'.format(
+    url = '{coordinator_url}/api/v2/host/{host_id}/config'.format(
         coordinator_url=config_info.url.rstrip('/'),
         host_id=config_info.host_id
     )
@@ -222,7 +222,7 @@ def confirm_deployed(args):
     if args.url:
         config_info = config_info._replace(url=args.url)
 
-    url = '{coordinator_url}/api/host/{host_id}/deployed_config_version'.format(
+    url = '{coordinator_url}/api/v2/host/{host_id}/deployed_config_version'.format(
         coordinator_url=config_info.url.rstrip('/'),
         host_id=config_info.host_id
     )

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -105,6 +105,8 @@ def parse_command_line_args(argv):
 
     parser.add_argument('--tar')
 
+    parser.add_argument('--version', action='version', version='%(prog)s 2.0, api/v2, March 2020')
+
     return parser.parse_args(argv[1:])
 
 

--- a/scionlab/tests/data/test_config_tar/user_as_19.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_19.yml
@@ -1,6 +1,6 @@
 README.md: |-
   content_not_checked
-client.conf: |
+client-scionlab-20-ffaa_0_1405.conf: |
   # Specify that we are a client
   client
 

--- a/scionlab/tests/test_api.py
+++ b/scionlab/tests/test_api.py
@@ -24,7 +24,7 @@ class GetHostConfigTests(TestCase):
     def setUp(self):
         # Avoid duplication, get this info here:
         self.host = Host.objects.last()
-        self.url = '/api/host/%s/config' % self.host.uid
+        self.url = '/api/v2/host/%s/config' % self.host.uid
         self.auth_headers = basic_auth(self.host.uid, self.host.secret)
 
     def test_aaa(self):
@@ -88,7 +88,7 @@ class GetHostConfigExtraServicesTests(TestCase):
 
     @staticmethod
     def _get_url(host):
-        return '/api/host/%s/config' % host.uid
+        return '/api/v2/host/%s/config' % host.uid
 
     @staticmethod
     def _get_auth_headers(host):
@@ -111,7 +111,7 @@ class PostHostConfigVersionTests(TestCase):
     def setUp(self):
         # Avoid duplication, get this info here:
         self.host = Host.objects.last()
-        self.url = '/api/host/%s/deployed_config_version' % self.host.uid
+        self.url = '/api/v2/host/%s/deployed_config_version' % self.host.uid
         self.auth_headers = basic_auth(self.host.uid, self.host.secret)
 
     def test_bad_auth(self):
@@ -156,3 +156,24 @@ class PostHostConfigVersionTests(TestCase):
 
         self.host.refresh_from_db()
         self.assertEqual(self.host.config_version_deployed, self.host.config_version)
+
+
+class OldVersionTests(TestCase):
+    fixtures = ['testdata']
+
+    def test_get_config(self):
+        # Note: using an existing host and correct auth headers, but this will not matter.
+        host = Host.objects.last()
+        url = '/api/host/%s/config' % host.uid
+        auth_headers = basic_auth(host.uid, host.secret)
+
+        ret = self.client.get(url, **auth_headers)
+        self.assertEqual(ret.status_code, 410)
+
+    def test_post_(self):
+        host = Host.objects.last()
+        url = '/api/host/%s/deployed_config_version' % host.uid
+        auth_headers = basic_auth(host.uid, host.secret)
+
+        ret = self.client.post(url, {'version': 1}, **auth_headers)
+        self.assertEqual(ret.status_code, 410)

--- a/scionlab/urls.py
+++ b/scionlab/urls.py
@@ -15,7 +15,7 @@
 from django.views.generic.base import TemplateView
 from django.contrib import admin
 from django.contrib.auth.decorators import login_required
-from django.urls import include, path
+from django.urls import include, path, re_path
 
 from scionlab.views.user_as_views import (
     UserASesView,
@@ -25,7 +25,7 @@ from scionlab.views.user_as_views import (
     UserASDetailView,
     UserASGetConfigView)
 from scionlab.views.registration_view import UserRegistrationView, UserRegistrationResendView
-from scionlab.views.api import GetHostConfig, PostHostDeployedConfigVersion
+from scionlab.views.api import GetHostConfig, PostHostDeployedConfigVersion, gone
 from scionlab.views.topology import topology_png
 
 urlpatterns = [
@@ -73,10 +73,12 @@ urlpatterns = [
     path('topology.png', topology_png, name='topology.png'),
 
     # API:
-    path('api/host/<slug:uid>/config',
+    path('api/v2/host/<slug:uid>/config',
          GetHostConfig.as_view(),
          name='api_get_config'),
-    path('api/host/<slug:uid>/deployed_config_version',
+    path('api/v2/host/<slug:uid>/deployed_config_version',
          PostHostDeployedConfigVersion.as_view(),
          name='api_post_deployed_version'),
+    # no longer supported versions of the API
+    re_path(r'^api/host/', gone)
 ]

--- a/scionlab/views/api.py
+++ b/scionlab/views/api.py
@@ -23,6 +23,7 @@ from django.utils.decorators import method_decorator
 from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
+    HttpResponseGone,
     HttpResponseNotModified
 )
 
@@ -138,3 +139,10 @@ def _get_version_param(request_params):
         else:
             return _BAD_VERSION
     return None
+
+
+def gone(request):
+    """
+    View for removed versions of the API. Responds with 410 Gone.
+    """
+    return HttpResponseGone()


### PR DESCRIPTION
The functionality of the API is unchanged, but the content returned in the config-tarfile is not compatible with older versions. Bumping the API version number will ensure that only updated clients can fetch data once the coordinator has been updated.

* Add `api/v2/` URLs
* Add view for old URL pattern that responds with "410 Gone"
* Use `api/v2/` URLs in `scionlab-config`
* Remove backwards compatibility logic in VPN client config filenames
* Add `--version` flag to `scionlab-config` (version is "2.0, api/v2, March 2020")

Closes #248 