### PR TITLE
Juagargi/vagrant newbox

### DIFF
--- a/scionlab/hostfiles/Vagrantfile.tmpl
+++ b/scionlab/hostfiles/Vagrantfile.tmpl
@@ -43,7 +43,7 @@ Unattended-Upgrade::Automatic-Reboot-Time "02:00";' > /etc/apt/apt.conf.d/51unat
     echo "SCIONLab VM ready"
   SCRIPT
 
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
   # forward border router port (unless using OpenVPN):
 ${PortForwarding}
   # forward scion dispatcher port, for running SCION endhosts connected to the AS in this VM:

--- a/scionlab/tests/data/test_config_tar/user_as_16.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_16.yml
@@ -46,7 +46,7 @@ Vagrantfile: |
       echo "SCIONLab VM ready"
     SCRIPT
 
-    config.vm.box = "ubuntu/xenial64"
+    config.vm.box = "ubuntu/bionic64"
     # forward border router port (unless using OpenVPN):
 
     # forward scion dispatcher port, for running SCION endhosts connected to the AS in this VM:

--- a/scionlab/tests/data/test_config_tar/user_as_17.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_17.yml
@@ -46,7 +46,7 @@ Vagrantfile: |
       echo "SCIONLab VM ready"
     SCRIPT
 
-    config.vm.box = "ubuntu/xenial64"
+    config.vm.box = "ubuntu/bionic64"
     # forward border router port (unless using OpenVPN):
     config.vm.network "forwarded_port", guest: 54321, host: 54321, protocol: "udp"
     # forward scion dispatcher port, for running SCION endhosts connected to the AS in this VM:


### PR DESCRIPTION
Tested running a VM connecting to Coordinator at localhost:8000
- `scionlab-config` will fail because it came with the production deb files. When replacing it with the new one, it works up to the point of not finding the control service (again, old DEBs)
- The VM itself seems alright, also the execution of the new `scionlab-config`
Closes #192 