### PR TITLE
Allow accessing home view and API in mainteance mode

### DIFF
--- a/scionlab/settings/common.py
+++ b/scionlab/settings/common.py
@@ -96,6 +96,11 @@ CRISPY_TEMPLATE_PACK = 'bootstrap4'
 # Note: do not change this file to enable maintenance mode. Just run
 #   python manage.py maitenance_mode <on|off>
 MAINTENANCE_MODE_IGNORE_ADMIN_SITE = True
+MAINTENANCE_MODE_IGNORE_URLS = (
+    r'^/$',               # home
+    r'^/topology.png$',   # topology map on home page
+    r'^/api/',            # get config, set deployed version
+)
 MAINTENANCE_MODE_STATE_FILE_PATH = os.path.join(BASE_DIR, 'run', 'maintenance_mode_state.txt')
 
 # ##### DEFAULT SETTINGS CONFIGURATION ####################

--- a/scionlab/static/scionlab/style.css
+++ b/scionlab/static/scionlab/style.css
@@ -132,6 +132,9 @@ pre {
   box-shadow: 0 3px 10px -5px rgba(0, 0, 0, 1);
 }
 
+.ribbon-yellow {
+  background: linear-gradient(#F79E05 0%, #8F5408 100%);
+}
 .ribbon-red {
   background: linear-gradient(#F70505 0%, #8F0808 100%);
 }

--- a/scionlab/templates/scionlab/base.html
+++ b/scionlab/templates/scionlab/base.html
@@ -19,8 +19,10 @@
 <body>
   <header class="navbar navbar-expand navbar-dark" style="background-color: #00539F;" >
 
-    {# Ribbon to indicate dev/testing instances #}
-    {% if 'debug' in instance_indicator %}
+    {# Ribbon to indicate maintenance mode/dev/testing instances #}
+    {% if maintenance_mode %}
+    <div class="ribbon"><span class="ribbon-yellow">Maintenance</span></div>
+    {% elif 'debug' in instance_indicator %}
     <div class="ribbon"><span class="ribbon-red">{{ instance_indicator }}</span></div>
     {% elif instance_indicator %}
     <div class="ribbon"><span class="ribbon-blue">{{ instance_indicator }}</span></div>

--- a/scionlab/tests/test_maintenance_mode.py
+++ b/scionlab/tests/test_maintenance_mode.py
@@ -18,9 +18,15 @@ from django.urls import reverse
 
 @override_settings(MAINTENANCE_MODE=True)
 class MaintenanceModeTests(TestCase):
+
     def test_get(self):
-        response = self.client.get('/')
+        response = self.client.get('/user/')
         self.check_response_maintenance(response)
+
+    def test_get_exceptions(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(b'<span class="ribbon-yellow">Maintenance</span>' in response.content)
 
     def test_post(self):
         response = self.client.post(


### PR DESCRIPTION
This helps for the next planned maintenance, where we mainly want to disallow changes on user ASes.

As we may want to keep maintenance mode on for more than a few minutes, it makes sense to at least show the home page.

Allowing access to the API to fetch host configuration is ok here as it's a read-only operation. Setting the deployed config version is obviously not read only, but seems low risk as it's not directly used.
This may simplify the update procedure, as the maintenance mode can be kept on until all the infrastructure machines are updated.