### PR TITLE
Dockerfile-django: remove unneeded AS directive that breaks build in production

### DIFF
--- a/deploy/Dockerfile-django
+++ b/deploy/Dockerfile-django
@@ -1,4 +1,4 @@
-FROM python:3.6 AS scionlab_django
+FROM python:3.6
 ENV PYTHONUNBUFFERED 1
 
 # Graphviz is used to render the topology (see scionlab.views.topology); the python


### PR DESCRIPTION
Seems to break build in docker-compose in production (with old?? docker version).