### PR TITLE
Fix spurious warning about VPN when no VPN configured

### DIFF
--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -368,13 +368,16 @@ def wait_for_tun(num):
 
     :param num: number of expected tunnel interfaces
     """
+    if num == 0:
+        return
+
     # ensure the interface is up; give up after 5 tries
     for i in range(5):
         logging.debug('Waiting for VPN ...')
         time.sleep(1)
 
         tuns = list_tun_interfaces()
-        if len(tuns) == num:
+        if len(tuns) >= num:
             logging.debug("VPN up: {}".format(", ".join(tuns)))
             return True
     logging.warn('WARNING!: VPN could be unready. SCION may fail to start.')


### PR DESCRIPTION
Fix simple bug occurring if there is no VPN client configured. Was always showing the warning "VPN could be unready. SCION may fail to start." and would always wait for 5 seconds.