### PR TITLE
Import new GEANT/DFN/fed4fire topology

### DIFF
--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -155,7 +155,7 @@ class ASManager(models.Manager):
                                      bind_ip=None, internal_ip=None,
                                      init_certificates=True):
         """
-        Create the AS, initialise the required keys and create a default sel object
+        Create the AS, initialise the required keys and create a default Host object
         with default services.
         Create the AS and initialise the required keys
         :param ISD isd:
@@ -944,10 +944,14 @@ class LinkManager(models.Manager):
         # TODO(matzf): validation (should be reusable for forms and for global system checks)
         # - no provider loops
         # - core links only for core ases
-        # - no providers links for core ases
-        # - no cross ISD provider links
         if as_a == as_b:
-            raise ValueError("Loop AS-link (from AS to itself) not allowed")
+            raise ValidationError("Loop AS-link (from AS to itself) not allowed")
+        if (type == Link.CORE) != (as_a.is_core and as_b.is_core):
+            raise ValidationError("CORE links only between core ASes")
+        if as_b.is_core and type == Link.PROVIDER:
+            raise ValidationError("No providers for core ASes")
+        if as_a.isd_id != as_b.isd_id and type == Link.PROVIDER:
+            raise ValidationError("No provider links between ISDs")
 
 
 class Link(models.Model):

--- a/scripts/fed4fire-scionlab.yml
+++ b/scripts/fed4fire-scionlab.yml
@@ -1,4 +1,3 @@
-#GTS
 ases:
   19-ffaa:0:1302:
     core: true
@@ -32,7 +31,16 @@ ases:
         address: 10.42.42.13
       prg1:
         address: 10.42.42.14
-  
+
+  19-ffaa:0:1305:
+    replace: false
+    label: SIDN
+    hosts:
+      rossum:
+        address: 94.198.159.72
+        public: 94.198.159.72
+    # hopper:  (existing)
+
   19-ffaa:0:130b:
     core: true
     label: DFN
@@ -56,7 +64,7 @@ ases:
   #       address: 10.44.44.1
   #     vw1:
   #       address: 10.44.44.2
-  
+
   # 19-ffaa:0:130d:
   #   label: Grid5000
   #   hosts:
@@ -64,11 +72,11 @@ ases:
   #       address: 1.2.3.4
   #     g5k1:
   #       address: 1.2.3.5
-  
+
   # 19-ffaa:0:130e:
   #   label: ExoGeni
   #   hosts:
-  #     exo0: 
+  #     exo0:
   #       address: 1.2.3.4
 
 links:
@@ -88,7 +96,7 @@ links:
     dst:
       address: 10.1.1.2
       vlan: VLAN 1176 / ?untagged
-  ams2--1305-hopper:
+  ams2--1305-rossum:
     src:
       address: 10.1.3.1
       interface: ens20 / p15
@@ -96,7 +104,7 @@ links:
     dst:
       address: 10.1.3.5
       vlan: VLAN 34 / tagged
-  ams3--1305-hopper:
+  ams3--1305-rossum:
     src:
       address: 10.1.2.1
       interface: ens20 / p15
@@ -104,13 +112,13 @@ links:
     dst:
       address: 10.1.2.5
       vlan: VLAN 40 / tagged
-  ams4--KREONET: #XXX 
+  ams4--KREONET: #XXX
     src:
       address: 10.1.4.1
       interface: ens20 / p15
     dst:
       address: 10.1.4.8
-  ams5--KREONET: #XXX 
+  ams5--KREONET: #XXX
     src:
       address: 10.1.5.1
       interface: ens20 / p15

--- a/scripts/fed4fire-scionlab.yml
+++ b/scripts/fed4fire-scionlab.yml
@@ -2,109 +2,222 @@
 ases:
   19-ffaa:0:1302:
     core: true
-    label: GTS
+    label: GEANT
     hosts:
-      ams0: 10.42.42.1
-      ams1: 10.42.42.2
-      ams2: 10.42.42.3
-      ams3: 10.42.42.4
-      ams4: 10.42.42.5
-      ams5: 10.42.42.6
-      par0: 10.42.42.7
-      par1: 10.42.42.8
-      par2: 10.42.42.9
-      ham0: 10.42.42.10
-      ham1: 10.42.42.11
-      ham2: 10.42.42.12
-      prg0: 10.42.42.13
-      prg1: 10.42.42.14
-
-  19-ffaa:0:130b:
-    label: VirtualWall
-    hosts:
-      vw0: 10.44.44.1
-      vw1: 10.44.44.2
+      ams0:
+        address: 10.42.42.1
+      ams1:
+        address: 10.42.42.2
+      ams2:
+        address: 10.42.42.3
+      ams3:
+        address: 10.42.42.4
+      ams4:
+        address: 10.42.42.5
+      ams5:
+        address: 10.42.42.6
+      par0:
+        address: 10.42.42.7
+      par1:
+        address: 10.42.42.8
+      par2:
+        address: 10.42.42.9
+      ham0:
+        address: 10.42.42.10
+      ham1:
+        address: 10.42.42.11
+      ham2:
+        address: 10.42.42.12
+      prg0:
+        address: 10.42.42.13
+      prg1:
+        address: 10.42.42.14
   
-  19-ffaa:0:130c:
+  19-ffaa:0:130b:
+    core: true
     label: DFN
     hosts:
-      dfn0: 10.43.43.1
-      dfn1: 10.43.43.2
-      dfn2: 10.43.43.3
-      dfn3: 10.43.43.4
+      zuse:
+        address: 10.43.43.1
+      bauer:
+        address: 10.43.43.2
+      bayer:
+        address: 10.43.43.3
+        public: 193.174.10.21
+      seidel:
+        address: 10.43.43.4
+        public: 193.174.10.20
 
-  19-ffaa:0:130d:
-    label: Grid5000
-    hosts:
-      g5k0: 1.2.3.4 # XXX
+  # XXX NOT READY
+  # 19-ffaa:0:130c:
+  #   label: VirtualWall
+  #   hosts:
+  #     vw0:
+  #       address: 10.44.44.1
+  #     vw1:
+  #       address: 10.44.44.2
   
-  19-ffaa:0:130e:
-    label: ExoGeny
-    hosts:
-      exo0: 1.2.3.4 # XXX
+  # 19-ffaa:0:130d:
+  #   label: Grid5000
+  #   hosts:
+  #     g5k0:
+  #       address: 1.2.3.4
+  #     g5k1:
+  #       address: 1.2.3.5
+  
+  # 19-ffaa:0:130e:
+  #   label: ExoGeni
+  #   hosts:
+  #     exo0: 
+  #       address: 1.2.3.4
 
 links:
-  vw0--g5k0:
-    src: 10.1.15.2 # XXX
-    dst: 10.1.15.7
-  vw0--exo0:
-    src: 10.1.16.2 # XXX
-    dst: 10.1.16.3
-  vw1--g5k0:
-    src: 10.1.17.2 # XXX
-    dst: 10.1.17.7
-  vw1--exo0:
-    src: 10.1.18.2 # XXX
-    dst: 10.1.18.3
-  vw0--ams0:
-    src: 10.1.1.2
-    dst: 10.1.1.1
-  vw1--par0:
-    src: 10.1.7.2
-    dst: 10.1.7.1
-  1305-hopper--ams1:
-    src: 10.1.2.5
-    dst: 10.1.2.1
-  1305-hopper--ams2:
-    src: 10.1.3.5
-    dst: 10.1.3.1
-  # KREONET-ams3:
-  #   src: 10.1.4.8
-  #   dst: 10.1.4.1
-  # KREONET-ams4:
-  #   src: 10.1.5.8
-  #   dst: 10.1.5.1
-  curie--ams5:
-    type: CORE
-    src: 10.1.6.6
-    dst: 10.1.6.1
-  curie--ham2:
-    type: CORE
-    src: 10.1.12.6
-    dst: 10.1.12.1
-  dfn0--ham0:
-    src: 10.1.10.4
-    dst: 10.1.10.1
-  dfn1--ham1:
-    src: 10.1.11.4
-    dst: 10.1.11.1
-  g5k0--par1:
-     src: 10.1.8.7 # XXX
-     dst: 10.1.8.1
-  g5k0--par2:
-     src: 10.1.9.7 # XXX
-     dst: 10.1.9.1
+  ams0--vw1:
+    src:
+      address: 10.1.7.1
+      interface: ens20 / p15
+      vlan: VLAN 25 / untagged
+    dst:
+      address: 10.1.7.2
+      vlan: VLAN 1175 / ?untagged
+  ams1--vw0:
+    src:
+      address: 10.1.1.1
+      interface: ens20 / p15
+      vlan: VLAN 37 / untagged
+    dst:
+      address: 10.1.1.2
+      vlan: VLAN 1176 / ?untagged
+  ams2--1305-hopper:
+    src:
+      address: 10.1.3.1
+      interface: ens20 / p15
+      vlan: VLAN 34 / untagged
+    dst:
+      address: 10.1.3.5
+      vlan: VLAN 34 / tagged
+  ams3--1305-hopper:
+    src:
+      address: 10.1.2.1
+      interface: ens20 / p15
+      vlan: VLAN 40 / untagged
+    dst:
+      address: 10.1.2.5
+      vlan: VLAN 40 / tagged
+  ams4--KREONET: #XXX 
+    src:
+      address: 10.1.4.1
+      interface: ens20 / p15
+    dst:
+      address: 10.1.4.8
+  ams5--KREONET: #XXX 
+    src:
+      address: 10.1.5.1
+      interface: ens20 / p15
+    dst:
+      address: 10.1.5.8
+  par0--g5k0:
+    src:
+      address: 10.1.8.1
+      interface: ens20 / p15
+    dst:
+      address: 10.1.8.7
+  par1--1108-curie:
+    src:
+      address: 10.1.6.1
+      interface: ens20 / p15
+      vlan: VLAN 35 / untagged
+    dst:
+      address: 10.1.6.6
+      interface: ens2f0.11
+      vlan: VLAN 11 / tagged
+  par2--g5k1:
+    src:
+      address: 10.1.9.1
+      interface: ens20 / p15
+    dst:
+      address: 10.1.9.7
+  ham0--zuse:
+    src:
+      address: 10.1.10.1
+      interface: ens20 / p15
+      vlan: VLAN 26 / untagged
+    dst:
+      address: 10.1.10.4
+      interface: ens10 / p5
+      vlan: VLAN 26 / untagged
+  ham1--bauer:
+    src:
+      address: 10.1.11.1
+      interface: ens20 / p15
+      vlan: VLAN 33 / untagged
+    dst:
+      address: 10.1.11.4
+      interface: ens10 / p5
+      vlan: VLAN 33 / untagged
+  ham2--1108-curie:
+    src:
+      address: 10.1.12.1
+      interface: ens20 / p15
+      vlan: VLAN 44 / untagged
+    dst:
+      address: 10.1.12.6
+      interface: ens2f0.16
+      vlan: VLAN 16 / tagged
   prg0--1101-turing:
-    type: CORE
-    src: 10.1.13.1
-    dst: 10.1.13.9
+    src:
+      address: 10.1.13.1
+      interface: ens20 / p15
+    dst:
+      address: 10.1.13.9
   prg0--1303-gauss:
-    src: 10.1.19.1
-    dst: 10.1.19.10
+    src:
+      address: 10.1.19.1
+      interface: ens20 / p15
+    dst:
+      address: 10.1.19.10
   prg1--1307-ptolemy:
-    src: 10.1.14.1
-    dst: 10.1.14.11
+    src:
+      address: 10.1.14.1
+      interface: ens20 / p15
+    dst:
+      address: 10.1.14.11
   prg1--1301-banach:
-    type: CORE
-    src: 10.1.20.1
-    dst: 10.1.20.12
+    src:
+      address: 10.1.20.1
+      interface: ens20 / p15
+    dst:
+      address: 10.1.20.12
+  vw0--g5k0:
+    src:
+      address: 10.1.15.2
+    dst:
+      address: 10.1.15.7
+  vw0--exo0:
+    src:
+      address: 10.1.16.2
+    dst:
+      address: 10.1.16.3
+  vw1--g5k0:
+    src:
+      address: 10.1.17.2
+    dst:
+      address: 10.1.17.7
+  vw1--exo0:
+    src:
+      address: 10.1.18.2
+    dst:
+      address: 10.1.18.3
+
+
+  # XXX appended manually:
+  bayer--1301-banach:
+    src:
+      address:
+    dst:
+      address:
+  seidel--1303-gauss:
+    src:
+      address:
+    dst:
+      address:

--- a/scripts/fed4fire-scionlab.yml
+++ b/scripts/fed4fire-scionlab.yml
@@ -1,0 +1,110 @@
+#GTS
+ases:
+  19-ffaa:0:1302:
+    core: true
+    label: GTS
+    hosts:
+      ams0: 10.42.42.1
+      ams1: 10.42.42.2
+      ams2: 10.42.42.3
+      ams3: 10.42.42.4
+      ams4: 10.42.42.5
+      ams5: 10.42.42.6
+      par0: 10.42.42.7
+      par1: 10.42.42.8
+      par2: 10.42.42.9
+      ham0: 10.42.42.10
+      ham1: 10.42.42.11
+      ham2: 10.42.42.12
+      prg0: 10.42.42.13
+      prg1: 10.42.42.14
+
+  19-ffaa:0:130b:
+    label: VirtualWall
+    hosts:
+      vw0: 10.44.44.1
+      vw1: 10.44.44.2
+  
+  19-ffaa:0:130c:
+    label: DFN
+    hosts:
+      dfn0: 10.43.43.1
+      dfn1: 10.43.43.2
+      dfn2: 10.43.43.3
+      dfn3: 10.43.43.4
+
+  19-ffaa:0:130d:
+    label: Grid5000
+    hosts:
+      g5k0: 1.2.3.4 # XXX
+  
+  19-ffaa:0:130e:
+    label: ExoGeny
+    hosts:
+      exo0: 1.2.3.4 # XXX
+
+links:
+  vw0--g5k0:
+    src: 10.1.15.2 # XXX
+    dst: 10.1.15.7
+  vw0--exo0:
+    src: 10.1.16.2 # XXX
+    dst: 10.1.16.3
+  vw1--g5k0:
+    src: 10.1.17.2 # XXX
+    dst: 10.1.17.7
+  vw1--exo0:
+    src: 10.1.18.2 # XXX
+    dst: 10.1.18.3
+  vw0--ams0:
+    src: 10.1.1.2
+    dst: 10.1.1.1
+  vw1--par0:
+    src: 10.1.7.2
+    dst: 10.1.7.1
+  1305-hopper--ams1:
+    src: 10.1.2.5
+    dst: 10.1.2.1
+  1305-hopper--ams2:
+    src: 10.1.3.5
+    dst: 10.1.3.1
+  # KREONET-ams3:
+  #   src: 10.1.4.8
+  #   dst: 10.1.4.1
+  # KREONET-ams4:
+  #   src: 10.1.5.8
+  #   dst: 10.1.5.1
+  curie--ams5:
+    type: CORE
+    src: 10.1.6.6
+    dst: 10.1.6.1
+  curie--ham2:
+    type: CORE
+    src: 10.1.12.6
+    dst: 10.1.12.1
+  dfn0--ham0:
+    src: 10.1.10.4
+    dst: 10.1.10.1
+  dfn1--ham1:
+    src: 10.1.11.4
+    dst: 10.1.11.1
+  g5k0--par1:
+     src: 10.1.8.7 # XXX
+     dst: 10.1.8.1
+  g5k0--par2:
+     src: 10.1.9.7 # XXX
+     dst: 10.1.9.1
+  prg0--1101-turing:
+    type: CORE
+    src: 10.1.13.1
+    dst: 10.1.13.9
+  prg0--1303-gauss:
+    src: 10.1.19.1
+    dst: 10.1.19.10
+  prg1--1307-ptolemy:
+    src: 10.1.14.1
+    dst: 10.1.14.11
+  prg1--1301-banach:
+    type: CORE
+    src: 10.1.20.1
+    dst: 10.1.20.12

--- a/scripts/fed4fire-scionlab.yml
+++ b/scripts/fed4fire-scionlab.yml
@@ -2,6 +2,7 @@ ases:
   19-ffaa:0:1302:
     core: true
     label: GEANT
+    replace: true
     hosts:
       ams0:
         address: 10.42.42.1

--- a/scripts/import_topo.py
+++ b/scripts/import_topo.py
@@ -1,0 +1,125 @@
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+:mod: scripts.import_topo
+=========================
+
+
+Run with python manage.py runscript import_topo --script-args <topo.yml>
+"""
+
+import yaml
+import pathlib
+from django.db import transaction
+from scionlab.models.core import ISD, AS, Host, Service, BorderRouter, Interface, Link
+
+
+class DryRunException(Exception):
+    pass
+
+
+def run(*args):
+    if len(args) != 1:
+        print("run with --script-args <topo-file.yml>")
+        return
+    filename = args[0]
+    topo = yaml.safe_load(pathlib.Path(filename).read_text())
+    dry_run = False
+    try:
+        import_topo(topo, dry_run)
+    except DryRunException:
+        print("Dry run complete, transaction rolled back")
+
+
+@transaction.atomic
+def import_topo(topo, dry_run):
+    ases = topo['ases']
+    links = topo['links']
+    create_ases(ases)
+    create_links(links)
+    if dry_run:
+        raise DryRunException()
+
+
+def create_ases(ases):
+    for ia, data in ases.items():
+        as_ = create_as(ia, data)
+        create_hosts(as_, data['hosts'])
+
+
+def create_as(ia, data):
+    isd_id, as_id = ia.split('-')
+    isd = ISD.objects.filter(isd_id=isd_id).get()
+
+    is_core = data.get('core', False)
+    label = data['label']
+    as_ = AS.objects.filter(as_id=as_id).first()
+    if as_:
+        as_.label = label
+        as_.save()
+        if as_.is_core != is_core:
+            raise NotImplementedError("Cannot change AS is_core")
+        as_.hosts.all().delete()
+        print("Reset existing internal topology of AS", as_)
+    else:
+        as_ = AS.objects.create(isd=isd, as_id=as_id, label=label, is_core=is_core)
+        print("Created AS", as_)
+    return as_
+
+
+def create_hosts(as_, hosts):
+    for name, ip in hosts.items():
+        as_short_id = as_.as_id.split(':')[-1]
+        ssh_host = 'scionlab-%s-%s' % (as_short_id, name)
+
+        Host.objects.create(
+            AS=as_,
+            public_ip=ip,
+            bind_ip=None,
+            internal_ip=ip,
+            ssh_host=ssh_host,
+        )
+
+    service_host = as_.hosts.first()
+    Service.objects.create(host=service_host, type=Service.CS)
+
+
+def create_links(links):
+    for link, data in links.items():
+        a, b = link.split('--')
+        host_a = Host.objects.filter(ssh_host__endswith=a).get()
+        host_b = Host.objects.filter(ssh_host__endswith=b).get()
+
+        create_link(host_a, host_b, data)
+
+
+def create_link(host_a, host_b, data):
+    public_a = data['src']
+    public_b = data['dst']
+    type = data.get('type', 'PROVIDER')
+
+    # XXX(matzf): crappy input; fix obviously wrong link order
+    if host_b.AS.is_core:
+        host_a, host_b = host_b, host_a
+        public_a, public_b = public_b, public_a
+    Link.objects._check_link(type, host_a.AS, host_b.AS)
+
+    br_a = BorderRouter.objects.first_or_create(host_a)
+    br_b = BorderRouter.objects.first_or_create(host_b)
+    interface_a = Interface.objects.create(border_router=br_a, public_ip=public_a)
+    interface_b = Interface.objects.create(border_router=br_b, public_ip=public_b)
+    link = Link.objects.create(type, interface_a, interface_b)
+    print("Created link", link)

--- a/scripts/import_topo.py
+++ b/scripts/import_topo.py
@@ -71,7 +71,7 @@ def create_as(ia, data):
 
     is_core = data.get('core', False)
     label = data['label']
-    replace = data.get('replace', True)
+    replace = data.get('replace', False)
 
     as_ = AS.objects.filter(as_id=as_id).first()
     if as_:


### PR DESCRIPTION
Add a very ad-hoc script to import the topology for GEANT/DFN/fed4fire from a yaml file.

The input yaml file is a (manually) extended / modified version of a the yaml dump from https://fin-ger.github.io/scionlab-fed4fire-topology/