### PR TITLE
Fix hiding IP fields in user AS form

### DIFF
--- a/scionlab/forms/attachment_conf_form.py
+++ b/scionlab/forms/attachment_conf_form.py
@@ -130,7 +130,7 @@ class AttachmentConfFormHelper(FormHelper):
     conf_body = Div(
             Row(
                 Column(AppendedText('public_ip', '<span class="fa fa-external-link"/>'),
-                       css_class='col-md-6'),
+                       css_class='col-md-6 hidable'),
                 Column(AppendedText('public_port', '<span class="fa fa-share-square-o"/>'),
                        css_class='col-md-6')
                 ),
@@ -144,9 +144,9 @@ class AttachmentConfFormHelper(FormHelper):
                 ),
             Row(
                 Column(AppendedText('bind_ip', '<span class="fa fa-external-link-square"/>'),
-                       css_class='col-md-6'),
+                       css_class='col-md-6 hidable'),
                 Column(AppendedText('bind_port', '<span class="fa fa-share-square"/>'),
-                       css_class='col-md-6'),
+                       css_class='col-md-6 hidable'),
                 css_class="bind-row"
                 ),
             css_class="card-body"

--- a/scionlab/templates/scionlab/partials/user_as_form_script.html
+++ b/scionlab/templates/scionlab/partials/user_as_form_script.html
@@ -115,9 +115,9 @@ function update_use_vpn_enable(sel) {
 function update_ip_fields_show(toggle) {
   // Traverse the DOM to get the container of this attachment point
   let attachment = toggle.closest('.attachment');
-  let public_ip_container = attachment.find("input[id*='public_ip']").closest('.formColumn')
-  let bind_ip_container = attachment.find("input[id*='bind_ip']").closest('.formColumn')
-  let bind_port_container = attachment.find("input[id*='bind_port']").closest('.formColumn')
+  let public_ip_container = attachment.find("input[id*='public_ip']").closest('.hidable')
+  let bind_ip_container = attachment.find("input[id*='bind_ip']").closest('.hidable')
+  let bind_port_container = attachment.find("input[id*='bind_port']").closest('.hidable')
   let bind_options_collapser = attachment.find('.bind-row-collapser')
   if(toggle.prop("checked")) {
     public_ip_container.hide();


### PR DESCRIPTION
The JS attempts to hide the div-containers holding the IP input fields,
when the VPN option is enabled.
The div container no longer had the class that the JS code was looking
for.
This was caused by the update to django-3, in particular the update
django-crispy-forms.
Fixed by adding an explicit 'hidable' class on the appropriate div.

Fixes #291 