### PR TITLE
Virtualbox 6 UART fix

### DIFF
--- a/scionlab/hostfiles/Vagrantfile.tmpl
+++ b/scionlab/hostfiles/Vagrantfile.tmpl
@@ -52,7 +52,7 @@ ${PortForwarding}
   config.vm.network "forwarded_port", guest: 8000, host: 8000, protocol: "tcp"
   config.vm.provider "virtualbox" do |vb|
     vb.customize [ "setextradata", :id, "VBoxInternal/Devices/VMMDev/0/Config/GetHostTimeDisabled", 1 ]
-    vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
+    vb.customize [ "modifyvm", :id, "--uartmode1", "file", File::NULL ]
     vb.memory = "2048"
     vb.name = "${vmname}"
   end

--- a/scionlab/tests/data/test_config_tar/user_as_16.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_16.yml
@@ -55,7 +55,7 @@ Vagrantfile: |
     config.vm.network "forwarded_port", guest: 8000, host: 8000, protocol: "tcp"
     config.vm.provider "virtualbox" do |vb|
       vb.customize [ "setextradata", :id, "VBoxInternal/Devices/VMMDev/0/Config/GetHostTimeDisabled", 1 ]
-      vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
+      vb.customize [ "modifyvm", :id, "--uartmode1", "file", File::NULL ]
       vb.memory = "2048"
       vb.name = "SCIONLabVM-ffaa_1_1"
     end

--- a/scionlab/tests/data/test_config_tar/user_as_17.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_17.yml
@@ -55,7 +55,7 @@ Vagrantfile: |
     config.vm.network "forwarded_port", guest: 8000, host: 8000, protocol: "tcp"
     config.vm.provider "virtualbox" do |vb|
       vb.customize [ "setextradata", :id, "VBoxInternal/Devices/VMMDev/0/Config/GetHostTimeDisabled", 1 ]
-      vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
+      vb.customize [ "modifyvm", :id, "--uartmode1", "file", File::NULL ]
       vb.memory = "2048"
       vb.name = "SCIONLabVM-ffaa_1_2"
     end


### PR DESCRIPTION
Avoid the creation of the `ubuntu-xenial-16.04-cloudimg-console.log` file by redirecting serial output to `/dev/null` instead of disconnecting the serial port.
Tested in Ubuntu and macOS.

Closes #294 
Relates to #202 
Relates to #293 
