### PR TITLE
Add support for fixed links to non-AP ASes

### DIFF
--- a/scionlab/forms/user_as_form.py
+++ b/scionlab/forms/user_as_form.py
@@ -86,11 +86,10 @@ class UserASForm(forms.Form):
                                                         max_num=UserAS.MAX_AP_PER_USERAS,
                                                         validate_max=True,
                                                         can_delete=True)
-        attach_links = Link.objects.filter(
-            interfaceB__AS=instance,
-        ).exclude(  # ignore links to non-APs (can be added through the admin panel)
-            interfaceA__AS__attachment_point_info=None,
-        ).order_by('pk')
+        if instance:
+            attach_links = instance.attachment_links().order_by('pk')
+        else:
+            attach_links = Link.objects.none()
         return attachment_conf_form_set(data, queryset=attach_links,
                                         userASForm=self,
                                         form_kwargs={'user': self.user, 'userAS': instance})

--- a/scionlab/forms/user_as_form.py
+++ b/scionlab/forms/user_as_form.py
@@ -86,7 +86,11 @@ class UserASForm(forms.Form):
                                                         max_num=UserAS.MAX_AP_PER_USERAS,
                                                         validate_max=True,
                                                         can_delete=True)
-        attach_links = Link.objects.filter(interfaceB__AS=instance).order_by('pk')
+        attach_links = Link.objects.filter(
+            interfaceB__AS=instance,
+        ).exclude(  # ignore links to non-APs (can be added through the admin panel)
+            interfaceA__AS__attachment_point_info=None,
+        ).order_by('pk')
         return attachment_conf_form_set(data, queryset=attach_links,
                                         userASForm=self,
                                         form_kwargs={'user': self.user, 'userAS': instance})

--- a/scionlab/models/user_as.py
+++ b/scionlab/models/user_as.py
@@ -403,7 +403,7 @@ class UserAS(AS):
     def attachment_points_labels(self):
         return [ap.AS.label for ap in self.attachment_points()]
 
-    def attachment_links(self, active: bool = True):
+    def attachment_links(self):
         """
         :returns: queryset for links to attachment points
         """

--- a/scionlab/templates/scionlab/user_as_details.html
+++ b/scionlab/templates/scionlab/user_as_details.html
@@ -10,13 +10,40 @@
         {% csrf_token %}
         {% crispy form %}
 
-        <h4 class="mt-4" >Provider links</h4>
+        <h4 class="mt-4">Provider links</h4>
         {{ form.attachment_conf_form_set.management_form|crispy }}
         {{ form.attachment_conf_form_set|as_crispy_errors }}
         {% for form in form.attachment_conf_form_set %}
           {% crispy form %}
         {% endfor %}
     </form>
+
+    {% if object.fixed_links %}
+      <h4 class="mt-4">Fixed links<sup style="font-size: small" class="fa fa-info-circle" title="These links were created by the SCIONLab admins. Please reach out to us if you believe this was in error or if you require modifications."/></h4>
+
+      <table class="table table-striped">
+      <thead>
+        <tr>
+          <th scope="col">Type</th>
+          <th scope="col">AS A</th>
+          <th scope="col">IP/Port A</th>
+          <th scope="col">AS B</th>
+          <th scope="col">IP/Port B</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for l in object.fixed_links %}
+        <tr>
+          <td>{{ l.type }}<sup style="font-size: small" class="fa fa-info-circle" title="{{ l.get_type_display }}"/></td>
+          <td>{{ l.interfaceA.AS }}</td>
+          <td>{{ l.interfaceA.get_public_ip }}:{{l.interfaceA.public_port}}</td>
+          <td>{{ l.interfaceB.AS }}</td>
+          <td>{{ l.interfaceB.get_public_ip }}:{{l.interfaceB.public_port}}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+      </table>
+    {% endif %}
 
     <hr>
     <button type="submit" class="btn btn-primary savebtn mt-2" form="id_user_as_form">Save Changes</button>


### PR DESCRIPTION
Links between user ASes and to non-attachment point ASes can only be created/modified by admins. For they user, they are read-only and so we call them "fixed links".
All applicable link types are allowed, i.e. Infra AS - User AS and User AS - User AS for both peering and provider links (in either direction). Note: core links are not an option, user ASes are not core.

Existing fixed provider links (regardless of which direction) disallow the user from changing the ISD for this user AS.

As all other changes through the admin panel, changes to these links do not trigger an automatic config deployment for the affected hosts.

The user sees a list of the fixed links. Example:
![screenshot-useras-fixed-links](https://user-images.githubusercontent.com/42933359/92578590-52fee080-f28c-11ea-9892-57cde3a3f768.png)



Fixes #299

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/302)
<!-- Reviewable:end -->
