### PR TITLE
Fix re-sending activation email

### DIFF
--- a/scionlab/forms/registration_form.py
+++ b/scionlab/forms/registration_form.py
@@ -57,4 +57,12 @@ class RegistrationFormWithCaptcha(RegistrationForm):
 
 
 class RegistrationResendForm(Form):
+    # quirk: to access the `send_activation_email` functionality, we need a RegistrationView (design
+    # bug) in which we use this form. The RegistrationView does some magic checking to ensure
+    # that the User model is configured properly, for which it accesses the Meta.
+    # So this Meta just serves to make this check happy and is otherwise useless.
+    class Meta:
+        model = User
+    _meta = Meta()
+
     email = EmailField()


### PR DESCRIPTION
* Fix form in UserRegistrationResendView
  Quirky, see comment on RegistrationResendForm.
  Was probably broken since updating the django-registration dependency from 3.0 to 3.1.
* Add tests for resending activation email and split up registration test into smaller units.

Fixes #304

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/305)
<!-- Reviewable:end -->
