### PR TITLE
Flat configuration directory hierarchy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,12 @@ jobs:
             docker-compose build
 
       - run:
+          name: Set date so certificates in test data are valid
+          command: |
+            # Certificates are valid between 2019-10-02 and 2020-10-01.
+            sudo date -s "2020-04-01"  # haha
+
+      - run:
           name: Start coordinator
           working_directory: ~/project/.circleci
           <<: *start_coordinator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           command: |
             . /tmp/venv/bin/activate
             mkdir -p test-reports/flake8/
-            flake8 --config=flake8.ini --format junit-xml --output-file=test-reports/flake8/results.xml
+            flake8 --format junit-xml --output-file=test-reports/flake8/results.xml
 
       # run Django's tests (using nose as the test runner)
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
           command: |
             set -x
 
-            prev_version=$(docker-compose exec -T as1303 cat /etc/scion/gen/scionlab-config.json | jq .version)
+            prev_version=$(docker-compose exec -T as1303 cat /etc/scion/scionlab-config.json | jq .version)
 
             # Start the huey worker
             docker-compose up -d huey
@@ -207,7 +207,7 @@ jobs:
 
             # Check that
             # i) configuration was deployed
-            new_version=$(docker-compose exec -T as1303 cat /etc/scion/gen/scionlab-config.json | jq .version)
+            new_version=$(docker-compose exec -T as1303 cat /etc/scion/scionlab-config.json | jq .version)
             [ "$prev_version" -lt "$new_version" ]
             # ii) connection still works
             docker-compose exec -T as1303 /bin/bash -c \
@@ -221,7 +221,7 @@ jobs:
 
             # Show current TRC
             TRC_version=1
-            docker-compose exec -T as1301 scion-pki trcs human "/etc/scion/gen/ISD19/ASffaa_0_1301/endhost/certs/ISD19-V${TRC_version}.trc"
+            docker-compose exec -T as1301 scion-pki trcs human "/etc/scion/certs/ISD19-V${TRC_version}.trc"
 
             # Update core keys which requires creating a new TRC
             docker-compose exec -T coord /bin/bash -c \
@@ -236,12 +236,12 @@ jobs:
             TRC_version=$((TRC_version + 1))
             docker-compose exec -T as1301 /bin/bash -c \
              "mkdir -p /tmp/pki/ISD19/trcs/;
-              cp /etc/scion/gen/ISD19/ASffaa_0_1301/endhost/certs/ISD19*.trc /tmp/pki/ISD19/trcs/;
+              cp /etc/scion/certs/ISD19*.trc /tmp/pki/ISD19/trcs/;
               scion-pki trcs human /tmp/pki/ISD19/trcs/ISD19-V${TRC_version}.trc;
               scion-pki trcs verify -d /tmp/pki/ /tmp/pki/ISD19/trcs/ISD19-V${TRC_version}.trc"
 
-            docker-compose exec -T as1303 stat -t "/etc/scion/gen/ISD19/ASffaa_0_1303/endhost/certs/ISD19-V${TRC_version}.trc"
-            docker-compose exec -T as1305 stat -t "/etc/scion/gen/ISD19/ASffaa_0_1305/endhost/certs/ISD19-V${TRC_version}.trc"
+            docker-compose exec -T as1303 stat -t "/etc/scion/certs/ISD19-V${TRC_version}.trc"
+            docker-compose exec -T as1305 stat -t "/etc/scion/certs/ISD19-V${TRC_version}.trc"
 
             # Check that infra still works
             sleep 30 # wait for paths to register, see `Check SCION connections` for an active wait
@@ -416,17 +416,17 @@ jobs:
             docker cp ./setup/check_tun0_in_topo.py $(docker-compose ps -q as1405):/home/scionlab/
             docker-compose exec -T as1405 /bin/bash -c \
               "apt-get install -y jq > /dev/null 2>&1; "\
-              "jq .BorderRouters[].Interfaces /etc/scion/gen/ISD20/ASffaa_0_1405/endhost/topology.json; "\
+              "jq .BorderRouters[].Interfaces /etc/scion/topology.json; "\
               "ip address show tun0; "\
-              "python3 /home/scionlab/check_tun0_in_topo.py /etc/scion/gen/ISD20/ASffaa_0_1405/endhost/topology.json"
+              "python3 /home/scionlab/check_tun0_in_topo.py /etc/scion/topology.json"
             # Check configuration on client
             echo "Client AS4 new VPN configuration"
             docker cp ./setup/check_tun0_in_topo.py $(docker-compose ps -q useras4):/home/scionlab/
             docker-compose exec -T useras4 /bin/bash -c \
               "apt-get install -y jq > /dev/null 2>&1; "\
-              "jq .BorderRouters[].Interfaces /etc/scion/gen/ISD20/ASffaa_1_4/endhost/topology.json; "\
+              "jq .BorderRouters[].Interfaces /etc/scion/topology.json; "\
               "ip address show tun0; "\
-              "python3 /home/scionlab/check_tun0_in_topo.py /etc/scion/gen/ISD20/ASffaa_1_4/endhost/topology.json"
+              "python3 /home/scionlab/check_tun0_in_topo.py /etc/scion/topology.json"
 
       - run:
           name: NEW -- Check CA and server VPN certificates on server and client

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,13 @@
 [flake8]
 exclude =
-  env
+  .venv/
+  .env/
+  .venv/
+  env/
+  venv/
+  ENV/
+  env.bak/
+  venv.bak/
   migrations
   scionlab/settings/development.py
   scionlab/settings/production.py

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ These commands are also recorded in the preamble of the `*.txt` files.
 ##### Style checker:
 
 ```bash
-flake8 --config=flake8.ini
+flake8
 ```
 
 ##### Integration tests:

--- a/flake8.ini
+++ b/flake8.ini
@@ -4,4 +4,7 @@ exclude =
   migrations
   scionlab/settings/development.py
   scionlab/settings/production.py
+filename =
+  *.py
+  ./scionlab/hostfiles/scionlab-config
 max-line-length = 100

--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -18,7 +18,7 @@ import string
 
 from django.conf import settings
 from scionlab.defines import OPENVPN_CONFIG_DIR
-from scionlab.scion.config import generate_scion_config_systemd, generate_scion_config_supervisord
+from scionlab.scion.config import generate_systemd_scion_config, generate_supervisord_scion_config
 from scionlab.models.user_as import UserAS
 from scionlab.openvpn_config import (
     generate_vpn_client_config,
@@ -83,7 +83,7 @@ def _add_files_user_as_src(archive, host):
     - VPN config /etc/openvpn/client-scionlab-*.conf (if using VPN)
     """
     _add_vpn_client_configs(host, archive)
-    generate_scion_config_supervisord(host, archive, with_sig_dummy_entry=True)
+    generate_supervisord_scion_config(host, archive, with_sig_dummy_entry=True)
     archive.add("README.md", _hostfiles_path("README_dedicated.md"))
 
 
@@ -95,7 +95,7 @@ def generate_host_config_tar(host, archive):
     :param scionlab.util.archive.BaseArchiveWriter archive: output archive-writer
     """
     hashed_archive = HashedArchiveWriter(archive)
-    units = generate_scion_config_systemd(host,
+    units = generate_systemd_scion_config(host,
                                           hashed_archive,
                                           with_sig_dummy_entry=hasattr(host.AS, 'useras'))
     _add_vpn_client_configs(host, hashed_archive)  # note: not adding these to the file list

--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -114,7 +114,7 @@ def _add_vpn_client_configs(host, archive):
     """
     Generate the VPN config files and add them to the tar.
     """
-    vpn_dir = OPENVPN_CONFIG_DIR.lstrip("/")
+    vpn_dir = OPENVPN_CONFIG_DIR.lstrip("/")  # don't use absolute paths in the archive
     # Each host can run at most one VPN-Client per VPN
     clients = host.vpn_clients.filter(active=True).select_related('vpn__server__AS').all()
     configs = dict()
@@ -123,18 +123,18 @@ def _add_vpn_client_configs(host, archive):
         configs[name] = generate_vpn_client_config(client)
 
     for name, config in configs.items():
-        archive.write_text(vpn_dir + "/client-scionlab-{}.conf".format(name), config)
+        archive.write_text((vpn_dir, "client-scionlab-{}.conf".format(name)), config)
 
 
 def _add_vpn_server_config(host, archive):
-    vpn_dir = OPENVPN_CONFIG_DIR.lstrip("/")
+    vpn_dir = OPENVPN_CONFIG_DIR.lstrip("/")  # don't use absolute paths in the archive
     server = host.vpn_servers.first()  # only one server per host supported for now
     if server:
-        archive.write_text(vpn_dir + "/server.conf", generate_vpn_server_config(server))
-        archive.add_dir(vpn_dir + "/ccd")
+        archive.write_text((vpn_dir, "server.conf"), generate_vpn_server_config(server))
+        archive.add_dir((vpn_dir, "ccd"))
         for client in server.clients.iterator():
             common_name, config_string = ccd_config(client)
-            archive.write_text(vpn_dir + "/ccd/" + common_name, config_string)
+            archive.write_text((vpn_dir, "ccd", common_name), config_string)
 
 
 def _add_vagrantfiles(host, archive):

--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -175,8 +175,13 @@ def _add_config_info(host, hashes, systemd_units, archive):
 
 def _generate_config_info_json(host, hashes, systemd_units):
     """
-    Return a dict containing the authentication parameters for the host
-    and the current configuration version number.
+    Return a dict containing
+    - authentication parameters for the host
+    - current configuration version number
+    - hashes of all installed config files; used in scionlab-config to determine
+      whether a file has local changes
+    - list of systemd units to be started
+
     :param Host host:
     :param hashes: dict filename -> hash
     :param List[str] systemd_units:

--- a/scionlab/defines.py
+++ b/scionlab/defines.py
@@ -50,6 +50,7 @@ PROPAGATE_TIME_NONCORE = 5  # higher frequency in non-cores ASes to have quicker
 SCION_CONFIG_DIR = "/etc/scion"
 SCION_LOG_DIR = "/var/log/scion"
 SCION_VAR_DIR = "/var/lib/scion"
+OPENVPN_CONFIG_DIR = "/etc/openvpn"
 
 # Default expiration time for keys; we currently only distinguish between core/non-core keys.
 # Note: the expiration of the core keys also defines the expiration of the TRCs.

--- a/scionlab/defines.py
+++ b/scionlab/defines.py
@@ -50,7 +50,6 @@ PROPAGATE_TIME_NONCORE = 5  # higher frequency in non-cores ASes to have quicker
 SCION_CONFIG_DIR = "/etc/scion"
 SCION_LOG_DIR = "/var/log/scion"
 SCION_VAR_DIR = "/var/lib/scion"
-GEN_PATH = "gen"
 
 # Default expiration time for keys; we currently only distinguish between core/non-core keys.
 # Note: the expiration of the core keys also defines the expiration of the TRCs.

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -409,10 +409,6 @@ def check_file_conflicts(old_files, new_files):
     return skip
 
 
-def extract_files(tar, files, tmpdir):
-    """ Extract listed files from tar to tmpdir """
-
-
 def install_config_files(old_files, new_files, skip, tmpdir):
     """ Install scion config to /etc/scion/"""
 
@@ -602,36 +598,6 @@ def _sha1(path):
     """ Compute the sha1 of the file at path """
     with open(path, 'rb') as f:
         return hashlib.sha1(f.read()).hexdigest()
-
-
-def _mv_dir(srcdir, dirname, dstdir):
-    shutil.rmtree(os.path.join(dstdir, dirname), ignore_errors=True)
-    shutil.move(os.path.join(srcdir, dirname), dstdir)
-
-
-def _install_file(srcdir, filename, dstdir):
-    """
-    Installs the file from srcdir into the directory dstdir.
-    If the file doesn't exist in srcdir, the file at dstdir will be removed.
-    :returns:   tuple (exists, changed):
-                    exists indicates whether the file exists now.
-                    changed indicates whether the file was changed.
-    """
-    srcfilename = os.path.join(srcdir, filename)
-    dstfilename = os.path.join(dstdir, filename)
-    if not os.path.exists(srcfilename):
-        if os.path.exists(dstfilename):
-            subprocess.run(['rm', dstfilename], check=True)
-            return (False, True)
-        return (False, False)
-
-    equal = subprocess.run(['diff', '-q', srcfilename, dstfilename],
-                           check=False,
-                           stdout=subprocess.DEVNULL,
-                           stderr=subprocess.DEVNULL).returncode == 0
-    if not equal:
-        subprocess.run(['mv', srcfilename, dstfilename], check=True)
-    return (True, not equal)
 
 
 def _prompt(explanation, question, options, default=None):

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -44,6 +44,8 @@ import time
 import urllib.request
 from collections import namedtuple
 
+SCRIPT_VERSION = '3.0, api/v3, October 2020'
+
 SCION_CONFIG_PATH = '/etc/scion'
 OPENVPN_CONFIG_DIR = '/etc/openvpn'
 
@@ -151,7 +153,7 @@ def parse_command_line_args(argv):
     group_fetch.add_argument('--host-secret', help='Authentication for host')
     group_fetch.add_argument('--url', help='URL of the SCIONLab coordination service')
 
-    parser.add_argument('--version', action='version', version='%(prog)s 3.0, api/v3, October 2020')
+    parser.add_argument('--version', action='version', version='%(prog)s ' + SCRIPT_VERSION)
 
     args = parser.parse_args(argv)
     # additional validation:

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -27,6 +27,7 @@ Prerequisites:
 
 import argparse
 import base64
+import datetime
 import hashlib
 import io
 import json
@@ -38,8 +39,8 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import time
 import textwrap
+import time
 import urllib.request
 from collections import namedtuple
 
@@ -326,6 +327,29 @@ def _error_exit(*args, **kwargs):
 
 
 def install_config(args, tar):
+    """
+    Install the configuration files from the tar ball.
+    Checks for modification conflicts, i.e. for files that are modified locally and that would also
+    be changed by installing the new file.
+    If running with --force, the conflicting files will be overwritten, but a backup is created.
+    Otherwise, the user is prompted for choice (replace/replace and backup/skip) where necessary.
+
+                           result
+       old   disk    new   default  force
+        x      x      x     x
+        x      x      z     z
+        x      x      -     -
+        x      y      x     y       x     keep y (with --force: replace + backup)
+        x      y      y     y
+        x      y      z     ?       z     prompt (with --force: replace + backup)
+        x      y      -     -             delete (guessing modification is no longer relevant)
+        -      y      -     -
+        -      y      y     y
+        -      y      z     ?       z     prompt (with --force: replace + backup)
+        x      -      x     x
+        x      -      y     y
+        x      -      -     -        -
+    """
     # Get metadata about currently installed configuration
     old_config_info = _read_config_info_file()
     old_files = old_config_info.files if old_config_info is not None else {}
@@ -334,10 +358,12 @@ def install_config(args, tar):
     new_config_info = _read_config_info_tar_member(tar)
     new_files = new_config_info.files
 
-    if args.force:
-        skip = []
-    else:
-        skip = check_file_conflicts(old_files, new_files)
+    skip, backup = resolve_file_conflicts(args.force, old_files, new_files)
+
+    if args.force and backup:  # only warn in --force, otherwise user has already been prompted
+        logging.warn("Overwriting files with local modifications, creating backup: %s",
+                     ", ".join(_root(f) for f in backup))
+    backup_files(backup)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # safely extract files; new_files list has been checked
@@ -359,58 +385,87 @@ def install_config(args, tar):
         shutil.rmtree(os.path.join(SCION_CONFIG_PATH, 'gen'), ignore_errors=True)
 
 
-def check_file_conflicts(old_files, new_files):
+def resolve_file_conflicts(force, old_files, new_files):
     """
-    Checks that the files are save to modify. Prompts the user for choice where necessary.
-    Returns a list of files (existing or new) that should be _skipped_ during the installation.
+    Check for modification conflicts and determines the appropriate action, prompting the user
+    where necessary. Returns the lists of files to be skipped and backed-up
 
-       old   disk    new   result
-        x      x      x     x
-        x      x      z     z
-        x      x      -     -
-        x      y      x     y     skip (keep y)
-        x      y      y     y
-        x      y      z     ?     prompt (skip/replace)
-        x      y      -     -     OK, delete (guessing modification is no longer relevant)
-        -      y      -     -
-        -      y      y     y
-        -      y      z     ?     prompt
-        x      -      x     x
-        x      -      y     y
-        x      -      -     -
+    :returns: list of files to be skipped, list of files to backed up
     """
+    conflicts = find_file_conflicts(old_files, new_files)
+    if force:
+        skip = []
+        backup = conflicts
+    else:
+        unchanged = [f for f in new_files if new_files[f] == old_files.get(f, None)]
+        prompts = sorted(set(conflicts) - set(unchanged))
+        skip, backup = prompt_conflicts(old_files, new_files, prompts)
+        skip += unchanged
+
+    return skip, backup
+
+
+def find_file_conflicts(old_files, new_files):
+    """
+    Find any local files which are replaced by a new file and are not identical
+    to the old installed file.
+    :returns: list of conflicting file names
+    """
+
     disk_files = {}
     for f in set(old_files.keys()) | set(new_files.keys()):
         if os.path.exists(_root(f)):
             disk_files[f] = _sha1(_root(f))
 
-    prompt = []
-    skip = []
+    conflicts = []
     for f, h in disk_files.items():
-        if f not in old_files or h != old_files[f]:
-            if f in new_files and f in old_files and old_files[f] == new_files[f]:
-                skip.append(f)
-            elif f in new_files and h != new_files[f]:
-                prompt.append(f)
+        if (f in new_files and h != new_files[f]) and (f not in old_files or h != old_files[f]):
+            conflicts.append(f)
+    return conflicts
 
-    for f in prompt:
+
+def prompt_conflicts(old_files, new_files, conflicts):
+    skip = []
+    backup = []
+    for f in conflicts:
         if f in old_files:
             explanation = "File '/%s' was modified and the updated config would overwrite it." % f
         else:
             explanation = "File '/%s' exists on disk and the updated config would overwrite it." % f
 
-        question = "Do you want to (s)kip/(r)eplace/(q)uit (default: replace)?"
-        reply = _prompt(explanation, question, ["skip", "replace", "quit"], default="replace")
+        question = ("Do you want to (b)ackup + replace, (o)verwrite, or (k)eep the file? "
+                    "(default: backup + replace)?")
+        options = ["backup", "overwrite", "keep", "quit"]
+        reply = _prompt(explanation, question, options, default="backup")
         if reply == "quit":
             sys.exit(1)
-        elif reply == "skip":
+        elif reply == "keep":
             skip.append(f)
+        elif reply == "backup":
+            backup.append(f)
 
-    return skip
+    return skip, backup
+
+
+def backup_files(files):
+    """ Create a backup copy of files. Files are given as list of root-relative paths. """
+    suffix = ".bk-" + datetime.date.today().strftime("%Y%m%d")
+    for f in files:
+        backup_file(_root(f), suffix)
+
+
+def backup_file(path, suffix):
+    """ Create a backup copy of file at path. Finds a non-existing name for the backup file """
+    bkname = path + suffix
+    idx = 0
+    while os.path.exists(bkname):
+        idx += 1
+        bkname = path + suffix + "-%i" % idx
+    os.rename(path, bkname)
 
 
 def install_config_files(old_files, new_files, skip, tmpdir):
-    """ Install scion config to /etc/scion/"""
+    """ Install new config files by copying from tmpdir, and remove old files """
 
     to_delete = set(old_files) - set(new_files) - set(skip)
     for f in to_delete:

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -454,7 +454,7 @@ def stop_scion():
 
 
 def run_scion():
-    subprocess.run(['systemctl', 'restart', 'scionlab.target'], check=True)
+    subprocess.run(['systemctl', 'start', 'scionlab.target'], check=True)
 
 
 def run_vpn_tunnels(old_files, new_files):

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -27,40 +27,54 @@ Prerequisites:
 
 import argparse
 import base64
+import hashlib
 import io
 import json
 import logging
 import os
-import shutil
 import shlex
+import shutil
 import subprocess
 import sys
 import tarfile
 import tempfile
-import urllib.request
 import time
-import re
+import textwrap
+import urllib.request
 from collections import namedtuple
 
-SCION_CONFIG_PATH = '/etc/scion/'
-SERVICE_FILES_DIR = '/etc/systemd/system/'
-OPENVPN_CONFIG_DIR = '/etc/openvpn/'
-OPENVPN_CLIENT_NAME_REGEX = re.compile(r"client(-scionlab.*)?.conf")
+SCION_CONFIG_PATH = '/etc/scion'
+OPENVPN_CONFIG_DIR = '/etc/openvpn'
 
-DEFAULT_CONFIG_INFO_PATH = os.path.join(SCION_CONFIG_PATH, 'gen/scionlab-config.json')
+CONFIG_INFO_FILE = 'scionlab-config.json'
+CONFIG_INFO_PATH = os.path.join(SCION_CONFIG_PATH, CONFIG_INFO_FILE)
+FALLBACK_CONFIG_INFO_PATH = os.path.join(SCION_CONFIG_PATH, 'gen', CONFIG_INFO_FILE)
+
+# Names for
+FALLBACK_SYSTEMD_UNIT_PATTERNS = [
+    'scion-border-router', 'scion-control-service', 'scion-daemon', 'scionlab-dispatcher'
+]
+
 DEFAULT_COORDINATOR_URL = 'https://www.scionlab.org'
 REQUEST_TIMEOUT_SECONDS = 10
 
 _CONFIG_EMPTY = object()
 _CONFIG_UNCHANGED = object()
 
-ConfigInfo = namedtuple('ConfigInfo',
-                        ['host_id',
-                         'host_secret',
-                         'url',
-                         'version'])
+# FetchInfo is the information needed to retrieve the configuration from the coordinator webserver
+FetchInfo = namedtuple('FetchInfo',
+                       ['host_id',
+                        'host_secret',
+                        'url',
+                        'version'])
 
-logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.WARNING)
+# ConfigInfo contains metadata about the scionlab configuration; lists of files (with hashes) and of
+# services installed by this script.
+ConfigInfo = namedtuple('ConfigInfo',
+                        ['files',
+                         'systemd_units'])
+
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
 
 def main(argv):
@@ -70,103 +84,141 @@ def main(argv):
     if os.geteuid() != 0:
         _error_exit("The script must be run as root")
     if not args.tar:
-        config_info = get_config_info(args)
-        config = fetch_config(config_info)
+        fetch_info = get_fetch_info(args)
+        config = fetch_config(fetch_info)
         if config is _CONFIG_EMPTY:
             stop_scion()
         elif config is _CONFIG_UNCHANGED:
             logging.info('Configuration unchanged (version %s). Nothing to do.',
-                         config_info.version)
+                         fetch_info.version)
         else:
-            install_config(config)
+            install_config(args, config)
             confirm_deployed(args)
     else:
         tar = tarfile.open(args.tar, mode='r')
-        install_config(tar)
+        install_config(args, tar)
 
 
 def parse_command_line_args(argv):
-    parser = argparse.ArgumentParser(description='Install configuration for a SCIONLab host.')
+    description = textwrap.dedent(
+        """
+        Install configuration for a SCIONLab host.
 
-    group_fetch = parser.add_argument_group('Fetch options')
-    parser.add_argument('--config-info',
-                        help="Path to json file containing host-id, secret and the local version. "
-                             "(default=%s)" % DEFAULT_CONFIG_INFO_PATH)
+        When invoked with no parameters, will attempt to fetch the latest configuration
+        for this host from the SCIONLab API and install it. The host-id/secret (and URL)
+        parameters for the SCIONLab API are read from, and stored to,
+        /etc/scion/scionlab-config.json.
+
+        The configuration for the SCION services is installed to /etc/scion.
+        If a VPN tunnel is configured, additional files are installed to /etc/openvpn.
+
+        By default, this script is cautious and will not overwrite local modifications to
+        configuration files. If a conflict occurs, e.g. if a file appears to be modified
+        locally and is also changed in the new version of the configuration, the script
+        asks for confirmation before overwriting the file.
+        Use --force to overwrite all locally modified config files and disable prompts
+        in case of conflicting file modifications.
+        """
+    )
+
+    epilog = textwrap.dedent(
+        """
+        Files:
+          /etc/scion/scionlab-config.json      Metadata about installed configuration
+          /etc/scion/*                         Configuration for SCION services
+          /etc/openvpn/client-scionlab-*.conf  Configuration for VPN tunnels
+        """
+    )
+
+    parser = argparse.ArgumentParser(prog='scionlab-config',
+                                     description=description,
+                                     epilog=epilog,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    group_config = parser.add_argument_group('Configuration installation options')
+    group_config.add_argument('--force',
+                              action='store_true',
+                              help='Overwrite locally modified configuration files. '
+                                   'Unconditionally fetch latest configuration from SCIONLab API.')
+    group_config.add_argument('--tar',
+                              type=argparse.FileType('r'),
+                              help='Install configuration from a tar-file already obtained from '
+                                   'the SCIONLab coordination service')
+
+    group_fetch = parser.add_argument_group('SCIONLab API options')
     group_fetch.add_argument('--host-id', help='Host identifier')
     group_fetch.add_argument('--host-secret', help='Authentication for host')
-    # Either 'local-version' or 'force'
-    group_version = group_fetch.add_mutually_exclusive_group()
-    group_version.add_argument('--local-version', help='',
-                               action='store', type=int)
-    group_version.add_argument('--force', help='',
-                               action='store_true')
     group_fetch.add_argument('--url', help='URL of the SCIONLab coordination service')
 
-    parser.add_argument('--tar')
+    parser.add_argument('--version', action='version', version='%(prog)s 3.0, api/v3, October 2020')
 
-    parser.add_argument('--version', action='version', version='%(prog)s 2.0, api/v2, March 2020')
-
-    return parser.parse_args(argv[1:])
-
-
-def get_config_info(args):
-    if args.config_info:
-        return _get_config_info_from_file(args.config_info, args)
-    elif args.host_id or args.host_secret:
-        if not args.host_id and args.host_secret:
-            _error_exit("Either none of or --host-id and --host-secret parameters need to be set")
-        return ConfigInfo(args.host_id,
-                          args.host_secret,
-                          args.url or DEFAULT_COORDINATOR_URL,
-                          args.local_version if not args.force else None)
+    args = parser.parse_args(argv)
+    # additional validation:
+    if args.tar:
+        if args.host_id or args.host_secret or args.url:
+            parser.error("argument --tar cannot be combined with any of --host-id, --host-secret, "
+                         "or --url\n")
     else:
-        if not os.path.exists(DEFAULT_CONFIG_INFO_PATH):
-            _error_exit("No scionlab config info file found at '%s'. Please specify the path to "
-                        "an existing config info file with --config-info, or explicitly provide "
-                        "authentication parameters for this host with --host-id and --host-secret.",
-                        DEFAULT_CONFIG_INFO_PATH)
-        return _get_config_info_from_file(DEFAULT_CONFIG_INFO_PATH, args)
+        if bool(args.host_id) != bool(args.host_secret):
+            parser.error("arguments --host-id and --host-secret must be used together\n")
+    return args
 
 
-def _get_config_info_from_file(file, args):
+def get_fetch_info(args):
+    if args.host_id:
+        assert args.host_secret
+        return FetchInfo(args.host_id,
+                         args.host_secret,
+                         args.url or DEFAULT_COORDINATOR_URL,
+                         None)
+    else:
+        for file in [CONFIG_INFO_PATH, FALLBACK_CONFIG_INFO_PATH]:
+            if os.path.exists(file):
+                return _load_fetch_info(file, args)
+        else:
+            _error_exit("No scionlab config info file found at '%s'. "
+                        "Please specify authentication parameters for this host "
+                        "with --host-id and --host-secret.",
+                        CONFIG_INFO_PATH)
+
+
+def _load_fetch_info(file, args):
     """
     Load config info file.
     Overwrite url with the URL argument.
-    Overwrite the version if '--force' or '--local-version' are given.
+    Overwrite the version if '--force' is given.
     """
-    config_info = _load_config_info(file)
+    fetch_info = _read_fetch_info(file)
 
     if args.url:
-        config_info = config_info._replace(url=args.url)
+        fetch_info = fetch_info._replace(url=args.url)
 
     if args.force:
-        config_info = config_info._replace(version=None)
-    elif args.local_version:
-        config_info = config_info._replace(version=args.local_version)
+        fetch_info = fetch_info._replace(version=None)
 
-    return config_info
+    return fetch_info
 
 
-def _load_config_info(file):
+def _read_fetch_info(file):
     """
-    Load and parse the config info json-file.
-    :returns: ConfigInfo
+    Load and parse the fetch information from the scionlab-config.json file.
+    :returns: FetchInfo
     """
     try:
         with open(file, 'r') as f:
             config_info_dict = json.load(f)
-    except IOError as e:
+    except (IOError, json.decoder.JSONDecodeError) as e:
         _error_exit("Error loading the scionlab config info file '%s': %s", file, e)
     try:
-        return ConfigInfo(config_info_dict['host_id'],
-                          config_info_dict['host_secret'],
-                          config_info_dict.get('url') or DEFAULT_COORDINATOR_URL,
-                          config_info_dict.get('version'))
+        return FetchInfo(config_info_dict['host_id'],
+                         config_info_dict['host_secret'],
+                         config_info_dict.get('url') or DEFAULT_COORDINATOR_URL,
+                         config_info_dict.get('version'))
     except KeyError as e:
         _error_exit("Invalid scionlab config info file '%s': %s", file, e)
 
 
-def fetch_config(config_info):
+def fetch_config(fetch_info):
     """
     Request configuration tar-ball from SCIONLab coordinator.
 
@@ -174,28 +226,28 @@ def fetch_config(config_info):
     request sent to the coordinator will include the currently installed version. If the current
     version is already the latest version, the server will reply with 304 Not Modified.
 
-    :param ConfigInfo config_info: base url, host-id/secret for authentication, version (optional).
+    :param FetchInfo fetch_info: base url, host-id/secret for authentication, version (optional).
     :returns:
         - _CONFIG_UNCHANGED if the current version is already the latest version, or
         - _CONFIG_EMPTY if there is currently no configuration for this host, or
         - tarfile.tar the configuration archive
     """
 
-    url = '{coordinator_url}/api/v2/host/{host_id}/config'.format(
-        coordinator_url=config_info.url.rstrip('/'),
-        host_id=config_info.host_id
+    url = '{coordinator_url}/api/v3/host/{host_id}/config'.format(
+        coordinator_url=fetch_info.url.rstrip('/'),
+        host_id=fetch_info.host_id
     )
 
     # version may be None (if "--force" is used or if version is not in the config info file and
     # we will behave like --force here if the config is not yet ready for deb packages)
     data = {}
-    if config_info.version:
-        data['version'] = config_info.version
+    if fetch_info.version:
+        data['version'] = fetch_info.version
 
     error_msg = "Failed to fetch configuration from SCIONLab coordinator at %s: %s"
 
     try:
-        conn = _http_get(url, data, username=config_info.host_id, password=config_info.host_secret)
+        conn = _http_get(url, data, username=fetch_info.host_id, password=fetch_info.host_secret)
         code = conn.getcode()
         if code == 200:
             response_data = conn.read()
@@ -203,14 +255,14 @@ def fetch_config(config_info):
         elif code == 204:
             return _CONFIG_EMPTY
         else:
-            _error_exit(error_msg, config_info.url, code)
+            _error_exit(error_msg, fetch_info.url, code)
     except urllib.error.HTTPError as e:
         if e.code == 304:
             return _CONFIG_UNCHANGED
         else:
-            _error_exit(error_msg, config_info.url, e)
+            _error_exit(error_msg, fetch_info.url, e)
     except Exception as e:
-        _error_exit(error_msg, config_info.url, e)
+        _error_exit(error_msg, fetch_info.url, e)
 
 
 def confirm_deployed(args):
@@ -223,16 +275,16 @@ def confirm_deployed(args):
     :param args: commandline arguments for optional coordinator URL
     """
     # Get newly installed config info
-    config_info = _load_config_info(DEFAULT_CONFIG_INFO_PATH)
+    fetch_info = _read_fetch_info(CONFIG_INFO_PATH)
     if args.url:
-        config_info = config_info._replace(url=args.url)
+        fetch_info = fetch_info._replace(url=args.url)
 
-    url = '{coordinator_url}/api/v2/host/{host_id}/deployed_config_version'.format(
-        coordinator_url=config_info.url.rstrip('/'),
-        host_id=config_info.host_id
+    url = '{coordinator_url}/api/v3/host/{host_id}/deployed_config_version'.format(
+        coordinator_url=fetch_info.url.rstrip('/'),
+        host_id=fetch_info.host_id
     )
-    data = {'version': config_info.version}
-    _http_post(url, data, username=config_info.host_id, password=config_info.host_secret)
+    data = {'version': fetch_info.version}
+    _http_post(url, data, username=fetch_info.host_id, password=fetch_info.host_secret)
 
 
 def _http_get(url, params, username, password):
@@ -273,97 +325,173 @@ def _error_exit(*args, **kwargs):
     sys.exit(1)
 
 
-def install_config(tar):
-    try:
-        tmpdir = tempfile.mkdtemp()
-        tar.extractall(path=tmpdir)
-        install_vpn_client_configs(tmpdir)
-        install_vpn_server_config(tmpdir)
-        # TODO quick reload: only restart if set of processes changed, otherwise trigger config
-        # reloading
+def install_config(args, tar):
+    # Get metadata about currently installed configuration
+    old_config_info = _read_config_info_file()
+    old_files = old_config_info.files if old_config_info is not None else {}
+
+    # Load new metadata from tar:
+    new_config_info = _read_config_info_tar_member(tar)
+    new_files = new_config_info.files
+
+    if args.force:
+        skip = []
+    else:
+        skip = check_file_conflicts(old_files, new_files)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # safely extract files; new_files list has been checked
+        # (c.f. warning on tarfile.TarFile.extractall)
+        to_extract = list(new_files) + [CONFIG_INFO_FILE]
+        tar.extractall(path=tmpdir, members=[tar.getmember(f) for f in to_extract])
+
         stop_scion()
-        install_scionlab_service(tmpdir)
-        install_scion_config(tmpdir)
-        restart_scion()
-    finally:
-        shutil.rmtree(tmpdir)
+
+        install_config_files(old_files, new_files, skip, tmpdir)
+        enable_scionlab_services(old_config_info, new_config_info)
+        os.replace(os.path.join(tmpdir, CONFIG_INFO_FILE), CONFIG_INFO_PATH)
+
+        run_vpn_tunnels(old_files, new_files)
+        run_scion()
+
+    # Cleanup configuration in gen/ directory (old style)
+    if os.path.exists(FALLBACK_CONFIG_INFO_PATH):
+        shutil.rmtree(os.path.join(SCION_CONFIG_PATH, 'gen'), ignore_errors=True)
 
 
-def install_scion_config(tmpdir):
-    """ Moves gen to /etc/scion/gen """
-    sc = SCION_CONFIG_PATH
-    if not os.path.isdir(sc):
-        _error_exit('No SCION configuration directory found at %s', sc)
-    _mv_dir(tmpdir, 'gen', sc)
-    subprocess.run(['chown', '-R', 'scion:scion', os.path.join(SCION_CONFIG_PATH, 'gen')])
+def check_file_conflicts(old_files, new_files):
+    """
+    Checks that the files are save to modify. Prompts the user for choice where necessary.
+    Returns a list of files (existing or new) that should be _skipped_ during the installation.
+
+       old   disk    new   result
+        x      x      x     x
+        x      x      z     z
+        x      x      -     -
+        x      y      x     y     skip (keep y)
+        x      y      y     y
+        x      y      z     ?     prompt (skip/replace)
+        x      y      -     -     OK, delete (guessing modification is no longer relevant)
+        -      y      -     -
+        -      y      y     y
+        -      y      z     ?     prompt
+        x      -      x     x
+        x      -      y     y
+        x      -      -     -
+    """
+    disk_files = {}
+    for f in set(old_files.keys()) | set(new_files.keys()):
+        if os.path.exists(_root(f)):
+            disk_files[f] = _sha1(_root(f))
+
+    prompt = []
+    skip = []
+    for f, h in disk_files.items():
+        if f not in old_files or h != old_files[f]:
+            if f in new_files and f in old_files and old_files[f] == new_files[f]:
+                skip.append(f)
+            elif f in new_files and h != new_files[f]:
+                prompt.append(f)
+
+    for f in prompt:
+        if f in old_files:
+            explanation = "File '/%s' was modified and the updated config would overwrite it." % f
+        else:
+            explanation = "File '/%s' exists on disk and the updated config would overwrite it." % f
+
+        question = "Do you want to (s)kip/(r)eplace/(q)uit (default: replace)?"
+        reply = _prompt(explanation, question, ["skip", "replace", "quit"], default="replace")
+        if reply == "quit":
+            sys.exit(1)
+        elif reply == "skip":
+            skip.append(f)
+
+    return skip
 
 
-def install_scionlab_service(tmpdir):
+def extract_files(tar, files, tmpdir):
+    """ Extract listed files from tar to tmpdir """
+
+
+def install_config_files(old_files, new_files, skip, tmpdir):
+    """ Install scion config to /etc/scion/"""
+
+    to_delete = set(old_files) - set(new_files) - set(skip)
+    for f in to_delete:
+        os.remove(_root(f))
+
+    to_install = set(new_files) - set(skip)
+    for f in to_install:
+        os.makedirs(os.path.dirname(_root(f)), exist_ok=True)
+        os.replace(os.path.join(tmpdir, f), _root(f))
+        subprocess.run(['chown', 'scion:scion', _root(f)])
+
+
+def enable_scionlab_services(old_config_info, new_config_info):
     """ Creates the appropriate dependencies for scionlab.target """
 
-    scionlab_services = os.path.join(tmpdir, 'scionlab-services.txt')
-    if not os.path.exists(scionlab_services):
-        _error_exit("Could not find the scionlab-services.txt file in %s", tmpdir)
-
-    # 1. remove existing links to scionlab.target
+    # 1. disable old units
+    # systemctl disable appears to have issues when the "physical" unit-file no longer exists (e.g.
+    # package has been removed or file was renamed). Directly deleting the symlinks always works.
     wants = '/etc/systemd/system/scionlab.target.wants/'
     if os.path.exists(wants):
-        for f in os.listdir(wants):
-            f = os.path.join(wants, f)
-            os.remove(f)
+        for unit in os.listdir(wants):
+            if _controlled_unit(old_config_info, unit):
+                os.remove(os.path.join(wants, unit))
         subprocess.run(['systemctl', 'daemon-reload'], check=True)
 
-    # 2. add links to scionlab.target
-    with open(scionlab_services, 'r') as f:
-        services = f.readlines()
-    for srv in services:
-        srv = srv.strip()
-        subprocess.run(['systemctl', 'enable', srv])
+    # 2. enable new units
+    for unit in new_config_info.systemd_units:
+        subprocess.run(['systemctl', 'enable', unit])
+
+
+def _controlled_unit(old_config_info, unit):
+    """ Returns true if unit is a systemd unit that was (probably) installed by this script. """
+    if old_config_info is not None:
+        return unit in old_config_info.systemd_units
+    else:
+        return any(unit.startswith(p) for p in FALLBACK_SYSTEMD_UNIT_PATTERNS)
 
 
 def stop_scion():
     subprocess.run(['systemctl', 'stop', 'scionlab.target'], check=True)
 
 
-def restart_scion():
+def run_scion():
     subprocess.run(['systemctl', 'restart', 'scionlab.target'], check=True)
 
 
-def install_vpn_client_configs(tmpdir):
+def run_vpn_tunnels(old_files, new_files):
+    def vpn_config_files(files):
+        return [f for f in files
+                if os.path.dirname(_root(f)) == OPENVPN_CONFIG_DIR
+                and os.path.splitext(f)[1] == '.conf']
 
-    def list_client_confs(path):
-        return list(filter(OPENVPN_CLIENT_NAME_REGEX.fullmatch, os.listdir(path)))
+    def unit_name(config):
+        return 'openvpn@{}'.format(os.path.splitext(os.path.basename(config))[0])
 
-    def unit_name(config_filename):
-        return 'openvpn@{}'.format(os.path.splitext(conf)[0])
+    old = vpn_config_files(old_files)
+    new = vpn_config_files(new_files)
 
-    old = list_client_confs(OPENVPN_CONFIG_DIR)
-    new = list_client_confs(tmpdir)
+    if any(unit_name(f) == 'openvpn@server' for f in new):
+        _init_vpn_server_dhparam()
 
-    for conf in sorted(set(old) - set(new)):
-        subprocess.run(['systemctl', 'stop', unit_name(conf)], check=True)
-        os.remove(os.path.join(OPENVPN_CONFIG_DIR, conf))
-
-    for conf in sorted(new):
-        shutil.copy(os.path.join(tmpdir, conf), OPENVPN_CONFIG_DIR)
-        subprocess.run(['systemctl', 'restart', unit_name(conf)], check=True)
+    for config in sorted(set(old) - set(new)):
+        subprocess.run(['systemctl', 'stop', unit_name(config)], check=True)
+    for config in sorted(new):
+        # Note: why not reload-or-restart? If a reload-or-restart fails because e.g. the
+        # configuration is messed up, the unit will be left in a state ("activating") that prevents
+        # future reload-or-restart even if the config is fixed. So we'd have to check for that and
+        # that seems too clunky for its worth.
+        subprocess.run(['systemctl', 'restart', unit_name(config)], check=True)
 
     wait_for_tun(len(new))
 
 
-def install_vpn_server_config(tmpdir):
-    exists, changed = _install_file(tmpdir, 'server.conf', '/etc/openvpn/')
-    if exists:
-        _mv_dir(tmpdir, 'ccd', '/etc/openvpn/')
-    if changed:
-        if exists:
-            if not os.path.exists('/etc/openvpn/dh.pem'):
-                subprocess.run(['openssl', 'dhparam', '-out', '/etc/openvpn/dh.pem', '2048'],
-                               check=True)
-            subprocess.run(['systemctl', 'restart', 'openvpn@server'], check=True)
-            wait_for_tun(1)
-        else:
-            subprocess.run(['systemctl', 'stop', 'openvpn@server'], check=False)
+def _init_vpn_server_dhparam():
+    if not os.path.exists('/etc/openvpn/dh.pem'):
+        subprocess.run(['openssl', 'dhparam', '-out', '/etc/openvpn/dh.pem', '2048'],
+                       check=True)
 
 
 def wait_for_tun(num):
@@ -389,7 +517,7 @@ def wait_for_tun(num):
         if len(tuns) >= num:
             logging.debug("VPN up: {}".format(", ".join(tuns)))
             return True
-    logging.warn('WARNING!: VPN could be unready. SCION may fail to start.')
+    logging.warn('VPN could be unready. SCION may fail to start.')
     return False
 
 
@@ -404,6 +532,76 @@ def list_tun_interfaces():
                         stderr=subprocess.DEVNULL,
                         check=True)
     return [line[:line.find(b':')].decode() for line in st.stdout.strip().split(b'\n')]
+
+
+def _read_config_info_file():
+    """
+    Load and parse the fetch information from the scionlab-config.json file.
+    :returns: ConfigInfo or None
+    """
+    if not os.path.exists(CONFIG_INFO_PATH):
+        return None
+
+    try:
+        with open(CONFIG_INFO_PATH, 'r') as f:
+            return _read_config_info(f)
+    except (IOError, json.decoder.JSONDecodeError, KeyError, ValueError) as e:
+        _error_exit("Error loading the scionlab config info file '%s': %s", CONFIG_INFO_PATH, e)
+
+
+def _read_config_info_tar_member(tar):
+    """
+    Load and parse the fetch information from the scionlab-config.json tar member.
+    :returns: ConfigInfo
+    """
+    try:
+        with tar.extractfile(tar.getmember(CONFIG_INFO_FILE)) as f:
+            return _read_config_info(f)
+    except (IOError, json.decoder.JSONDecodeError, KeyError, ValueError) as e:
+        _error_exit("Error loading the scionlab config info from the tar: %s", e)
+
+
+def _read_config_info(f):
+    """
+    Load and parse the config information from the file-like f.
+    :returns: ConfigInfo
+    """
+    config_info_dict = json.load(f)
+    info = ConfigInfo(config_info_dict['files'],
+                      config_info_dict['systemd_units'])
+    _sanity_check_file_list(info.files)
+    return info
+
+
+def _sanity_check_file_list(files):
+    """
+    Sanity check that the file list contains entries only in the expected directories.
+    As this script is running as root, we should be extra careful when later extracting these files
+    from the tar.
+    """
+    # note: file list must contain relative paths only (relative to the tar root)
+    acceptable_dirs = [
+        "etc/scion",
+        "etc/openvpn",
+    ]
+    for f in files:
+        if (os.path.normpath(f) != f   # not norm is fishy
+                or f.startswith("/")   # must not be absolute
+                or f.endswith("/")     # should not (obviously) be a dir
+                or not any(os.path.commonpath([os.path.dirname(f), d]) == d
+                           for d in acceptable_dirs)):
+            raise ValueError("The list of files has a fishy entry ('%s')." % f)
+
+
+def _root(path):
+    """ Returns /path """
+    return "/" + path
+
+
+def _sha1(path):
+    """ Compute the sha1 of the file at path """
+    with open(path, 'rb') as f:
+        return hashlib.sha1(f.read()).hexdigest()
 
 
 def _mv_dir(srcdir, dirname, dstdir):
@@ -436,6 +634,37 @@ def _install_file(srcdir, filename, dstdir):
     return (True, not equal)
 
 
+def _prompt(explanation, question, options, default=None):
+    """
+    Ask a question via input() and return the answer.
+
+    explanation is the context that is printed once.
+    question is the explicit question that is presented to the user; this is repeated on bad inputs.
+    options is a list of distinct answers;
+    options must be lowercase and the first letter of each choice must be distinct.
+
+    Returns the selected option.
+    """
+    sys.stdout.write(explanation + " " + question)
+    prompt = " [%s] " % "/".join(o[0].upper() if o == default else o[0] for o in options)
+    while True:
+        try:
+            choice = input(prompt).lower()
+        except EOFError:
+            sys.stdout.write("\n")
+            sys.exit(1)
+
+        if default is not None and choice == '':
+            return default
+        for option in options:
+            if option.startswith(choice):
+                return option
+        else:
+            sys.stdout.write("Please respond with any of " +
+                             "/".join(o[0] for o in options) + ".\n")
+            sys.stdout.write(question)
+
+
 def _get_argv():
     """
     Parse args from SSH_ORIGINAL_COMMAND, if set.
@@ -447,13 +676,13 @@ def _get_argv():
     ssh_original_cmd = os.environ.get('SSH_ORIGINAL_COMMAND')
     if ssh_original_cmd:
         argv = shlex.split(ssh_original_cmd)
-        if not argv or argv[0] != os.path.basename(sys.argv[0]):  # avoid silly things
+        if not argv or argv[0] != 'scionlab-config':  # avoid silly things
             return None
-        return argv
-    return sys.argv
+        return argv[1:]
+    return sys.argv[1:]
 
 
 if __name__ == '__main__':
     argv = _get_argv()
-    if argv:
+    if argv is not None:
         main(argv)

--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -99,7 +99,7 @@ class _ConfigGeneratorBase:
         self.topo_info = TopologyInfo(self.AS, with_sig_dummy_entry)
 
     def _write_as_config(self, cb: '_ConfigBuilder'):
-        config_dir = cb.config_dir.lstrip('/')  # dont use absolute paths in the archive
+        config_dir = cb.config_dir.lstrip('/')  # don't use absolute paths in the archive
 
         for router in self._routers():
             self.archive.write_toml((config_dir, f'{router.instance_name}.toml'),
@@ -417,18 +417,6 @@ def _join_host_port(host, port):
         return '[%s]:%s' % (host, port)
     else:
         return '%s:%s' % (host, port)
-
-
-def _localhost(ip):
-    """
-    Returns a/the loopback address for an address of the same type as host_ip
-    :param str host_ip: IP address
-    :return str: loopback address
-    """
-    if isinstance(ipaddress.ip_address(ip), ipaddress.IPv6Address):
-        return "::1"
-    else:
-        return "127.0.0.1"
 
 
 def _chain_dicts(dict0, *dicts):

--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -63,7 +63,7 @@ CMDS = {
 }
 
 
-def generate_scion_config_systemd(host, archive, with_sig_dummy_entry=False):
+def generate_systemd_scion_config(host, archive, with_sig_dummy_entry=False):
     """
     Generate the configuration archive for the :host: in the given archive-writer
     :param host: Host object
@@ -75,7 +75,7 @@ def generate_scion_config_systemd(host, archive, with_sig_dummy_entry=False):
     return generator.systemd_units()
 
 
-def generate_scion_config_supervisord(host, archive, with_sig_dummy_entry=False):
+def generate_supervisord_scion_config(host, archive, with_sig_dummy_entry=False):
     """
     Generate the configuration archive for the :host: in the given archive-writer
     :param host: Host object

--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import configparser
-import ipaddress
 import os
 from collections import OrderedDict
 

--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -156,7 +156,6 @@ class _ConfigGeneratorBase:
                 if s.type in Service.CONTROL_SERVICE_TYPES and s.host == self.host)
 
     def _extra_services(self):
-        # XXX(matzf) drop this!
         return (s for s in self.topo_info.services
                 if s.type in Service.EXTRA_SERVICE_TYPES and s.host == self.host)
 
@@ -178,7 +177,10 @@ class _ConfigGeneratorSystemd(_ConfigGeneratorBase):
                  for router in self._routers()]
         units += ["%s@%s.service" % (SERVICES_TO_SYSTEMD_NAMES[service.type], service.instance_name)
                   for service in self._control_services()]
-        units.append('scion-daemon.service')
+        # XXX(matzf) drop this!
+        units += ["%s.service" % SERVICES_TO_SYSTEMD_NAMES[service.type]
+                  for service in self._extra_services()]
+        units.append('scion-daemon@sd.service')
         units.append('scion-dispatcher.service')
         return units
 

--- a/scionlab/scion/topology.py
+++ b/scionlab/scion/topology.py
@@ -74,7 +74,7 @@ def _fetch_routers(as_):
     for id, router in enumerate(as_.border_routers.order_by('pk').iterator(), start=1):
         if router.interfaces.active().exists():  # skip empty BRs
             router.instance_id = id
-            router.instance_name = "br%s-%s" % (as_.isd_as_path_str(), id)
+            router.instance_name = f"br-{id}"
             routers.append(router)
     return routers
 
@@ -84,7 +84,7 @@ def _fetch_services(as_):
     for stype, _ in Service.SERVICE_TYPES:
         for id, service in enumerate(as_.services.filter(type=stype).order_by('pk'), start=1):
             service.instance_id = id
-            service.instance_name = "%s%s-%s" % (stype.lower(), as_.isd_as_path_str(), id)
+            service.instance_name = f"{stype.lower()}-{id}"
             services.append(service)
     return services
 
@@ -201,7 +201,7 @@ def _topo_add_sig_dummy_entry(topo_dict, host, as_address_type):
     error behaviour slighly when receiving packets addressed to the SIG without the SIG running.
     """
     topo_dict["SIG"] = {
-        "sig%s-1" % host.AS.isd_as_path_str(): {  # id is irrelevant, not used for anything
+        "sig-1": {  # id is irrelevant, not used for anything
             "Addrs": {
                 as_address_type: {
                     "Public": {

--- a/scionlab/tests/data/test_config_tar/host_4.yml
+++ b/scionlab/tests/data/test_config_tar/host_4.yml
@@ -1,997 +1,7 @@
-ccd/: null
-ccd/exbert@scionlab.org_ffaa_1_1: |-
+etc/openvpn/ccd/: null
+etc/openvpn/ccd/exbert@scionlab.org_ffaa_1_1: |-
   ifconfig-push 10.0.0.1 255.255.0.0
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-1/br.toml: |
-  [general]
-  config_dir = "/etc/scion/gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-1"
-  id = "br17-ffaa_0_1107-1"
-  reconnect_to_dispatcher = true
-
-  [metrics]
-  prometheus = "127.0.0.1:30442"
-
-  [log.file]
-  level = "debug"
-  max_age = 3
-  max_backups = 1
-  path = "/var/log/scion/br17-ffaa_0_1107-1.log"
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-1/certs/ISD17-ASffaa_0_1107-V1.crt: |-
-  [
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIklsOGRqbHVkRXEyazRHNGxxY2gwWUZibmk2ZnF1MllId0p1YWUzTmJHN0k9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjcml0IjogWyJ0eXBlIiwgInRyY192ZXJzaW9uIl0sICJ0cmNfdmVyc2lvbiI6IDEsICJ0eXBlIjogInRyYyJ9",
-      "signature": "w21oYonO1a92V7P9ypwkuVPBEH6NFCMseMkgYemgeCOvvtYRa_y0PKj7q7PJapJluUyJ35FNhzWmVxsmVrsYDg"
-    },
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImFzIiwgImRlc2NyaXB0aW9uIjogIkFTIGNlcnRpZmljYXRlIiwgImZvcm1hdF92ZXJzaW9uIjogMSwgImlzc3VlciI6IHsiY2VydGlmaWNhdGVfdmVyc2lvbiI6IDEsICJpc2RfYXMiOiAiMTctZmZhYTowOjExMDEifSwgImtleXMiOiB7ImVuY3J5cHRpb24iOiB7ImFsZ29yaXRobSI6ICJjdXJ2ZTI1NTE5IiwgImtleSI6ICJtRFpwcGNWeDMrb29GcExSZ3VrQTFqcWYrcnZIQ0pzZTNJMkxYOC9xMTFZPSIsICJrZXlfdmVyc2lvbiI6IDF9LCAic2lnbmluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIlpHSmNOOFFqdWRTMW12bG9meDB3NEtsSXZYQkRrVTdEc21Ecmw5Q1h2K0E9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwNyIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYwMTU1MDQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjZXJ0aWZpY2F0ZV92ZXJzaW9uIjogMSwgImNyaXQiOiBbInR5cGUiLCAiY2VydGlmaWNhdGVfdmVyc2lvbiIsICJpc2RfYXMiXSwgImlzZF9hcyI6ICIxNy1mZmFhOjA6MTEwMSIsICJ0eXBlIjogImNlcnRpZmljYXRlIn0",
-      "signature": "DwcEIl3hNOuXIibScIcMpEzrw6YWBVNDk5v21f55j6T6XyM-U29EY4G7lV-EV3hJ_aRRc1BK-BoxiF7xivI-BQ"
-    }
-  ]
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-1/certs/ISD17-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "gZb3KXzvSt0UXfzOmsVkSnwRFLT0YcXoFZZvYreWtcYx_vVbhk06OThC002x4OgpK0BjBMJcrL_cn3blsh4UCQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "ePlI06GLjIBr8a28UC8MsdDi3sFZLFb0KYev7mt-aEAd-LEFKUXJcvUM9Dhz_huMkPFMJVFLZ9JffAovOZ5DDA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "G8LhE9WyxIG0N7dLtMtGeGbnGzktTd-ogguIVubgU62K-fi_U-MQRGoDVwc3OHkWEYzs3SzxPOWQy67SzsZdDA"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-1/certs/ISD19-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "3YGYoxPTR8jgDGadWM5ac03jNC6eIyrYVYJ3IFL_0d6ESO1eDfaWhPpEJPjni_am5DM-BGTC_6dl4IM4i58vDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "mKhwMiacq-3sJOEkkQ_e92622gR6pnFTvrI829vdoC64lkieM-18HGbJANXVmi-Bpl_CcF0uQyMSswapax23BQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "IyAgvp-9ZOHOnnVkUXMqlS22nF-KO2VYP_bXd09AONuJHsWlsGXDjoxOmH6SN2FwPpSDc_hkXuskHCUrk76HCg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "yBo9CKM5LgNk95QcjjK3UMdDVq3z0rsDIvvaWrKeWnbc1ejDpVK4IgM9hcpYLrRSt6y5sncFHw2Q1wTTlhSrDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "S0jmllXbdZL-1HQmT0C_29zIyuGnA03nKv2CiLpoeccWJN9sCoBc9AG9SaZQzasvJvEE7JNAHxrpNjB_j6bQCw"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wV0ZrVAXx88EUvIuk673MJLIAXcqQ-iV4vCCH50LCs0tLx65cI7ps6a31PSgIAnbp3SEg1VerkhUxJTxzyhzAg"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-1/certs/ISD20-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "lMflSxDL23pPZdxm4kCQrrExtho-3qWjBUGtFR9DCyADGjuhBBvJhUYXKCQgJmZwZKQ6sNvZhQrN650H7pXIAQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "IEQs-UKm_a0azRdYCBKgfytqLPKkC-KicEn8WyGNj_nJEpc6il5SvfUJkfv1TAUu2m5TK3Cwi_06dlKaOuacDQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "5x2TpKF5nJA3Z9gLdD45NZGm7nJZn8ndLaN8groZogAR9jW4y4qICkXuXz9ESYyA0JWVNLv_NsEEcaT33-hHBA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "LdhZ-vIz-I2G2dPJ3genkYhOCFJxsB3fZ_JDkm8w-94n8pAfh4CzdkiVLFJkW5xjIdcH6v-M5SyF-_4vwaXNAg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "CMXlaUloufb05e0myd4-fICnAVzCHrgJ7-mDegDHjMqSi3QuE70Gm-Muf887Rey_OHV9x7woExKQ-NpjSaa8Cg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wdZ-vcrtMLvPFnTTp1367W2i9CNq-kDLtpRJyEp4G2bf5KhdqdW_gtuYFEArtW0oGZ4-tiIErM3ng9Rvv7EjDQ"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-1/keys/as-decrypt-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: curve25519xsalsa20poly1305
-  ia: 17-ffaa:0:1107
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-decrypt
-  version: 1
-
-  yh3cQSKnhdGmpVgd3ydH2QQKCjSuQo5Q8l3wkejZCtg=
-  -----END PRIVATE KEY-----
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-1/keys/as-signing-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: ed25519
-  ia: 17-ffaa:0:1107
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-signing
-  version: 1
-
-  v/azm6d+tqTndaNvX9+JLTVglkoCIyZFVVbKXrcXVsc=
-  -----END PRIVATE KEY-----
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-1/keys/master0.key: |-
-  R7D6Lhl52uxloBQFRulzzA==
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-1/keys/master1.key: |-
-  R7D6Lhl52uxloBQFRulzzA==
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-1/topology.json: |-
-  {
-    "Attributes": [],
-    "BorderRouters": {
-      "br17-ffaa_0_1107-1": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30242
-            }
-          }
-        },
-        "Interfaces": {
-          "1": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:0:1102",
-            "LinkTo": "PARENT",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "192.0.2.17",
-              "OverlayPort": 50000
-            },
-            "RemoteOverlay": {
-              "Addr": "192.0.2.12",
-              "OverlayPort": 50001
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30042
-            }
-          }
-        }
-      },
-      "br17-ffaa_0_1107-2": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30243
-            }
-          }
-        },
-        "Interfaces": {
-          "2": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:1:1",
-            "LinkTo": "CHILD",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "10.0.8.1",
-              "OverlayPort": 50000
-            },
-            "RemoteOverlay": {
-              "Addr": "10.0.0.1",
-              "OverlayPort": 54321
-            }
-          },
-          "3": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:1:5",
-            "LinkTo": "CHILD",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "192.0.2.17",
-              "OverlayPort": 50001
-            },
-            "RemoteOverlay": {
-              "Addr": "172.31.0.200",
-              "OverlayPort": 54321
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30043
-            }
-          }
-        }
-      }
-    },
-    "ControlService": {
-      "cs17-ffaa_0_1107-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30254
-            }
-          }
-        }
-      }
-    },
-    "ISD_AS": "17-ffaa:0:1107",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4"
-  }
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-2/br.toml: |
-  [general]
-  config_dir = "/etc/scion/gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-2"
-  id = "br17-ffaa_0_1107-2"
-  reconnect_to_dispatcher = true
-
-  [metrics]
-  prometheus = "127.0.0.1:30443"
-
-  [log.file]
-  level = "debug"
-  max_age = 3
-  max_backups = 1
-  path = "/var/log/scion/br17-ffaa_0_1107-2.log"
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-2/certs/ISD17-ASffaa_0_1107-V1.crt: |-
-  [
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIklsOGRqbHVkRXEyazRHNGxxY2gwWUZibmk2ZnF1MllId0p1YWUzTmJHN0k9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjcml0IjogWyJ0eXBlIiwgInRyY192ZXJzaW9uIl0sICJ0cmNfdmVyc2lvbiI6IDEsICJ0eXBlIjogInRyYyJ9",
-      "signature": "w21oYonO1a92V7P9ypwkuVPBEH6NFCMseMkgYemgeCOvvtYRa_y0PKj7q7PJapJluUyJ35FNhzWmVxsmVrsYDg"
-    },
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImFzIiwgImRlc2NyaXB0aW9uIjogIkFTIGNlcnRpZmljYXRlIiwgImZvcm1hdF92ZXJzaW9uIjogMSwgImlzc3VlciI6IHsiY2VydGlmaWNhdGVfdmVyc2lvbiI6IDEsICJpc2RfYXMiOiAiMTctZmZhYTowOjExMDEifSwgImtleXMiOiB7ImVuY3J5cHRpb24iOiB7ImFsZ29yaXRobSI6ICJjdXJ2ZTI1NTE5IiwgImtleSI6ICJtRFpwcGNWeDMrb29GcExSZ3VrQTFqcWYrcnZIQ0pzZTNJMkxYOC9xMTFZPSIsICJrZXlfdmVyc2lvbiI6IDF9LCAic2lnbmluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIlpHSmNOOFFqdWRTMW12bG9meDB3NEtsSXZYQkRrVTdEc21Ecmw5Q1h2K0E9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwNyIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYwMTU1MDQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjZXJ0aWZpY2F0ZV92ZXJzaW9uIjogMSwgImNyaXQiOiBbInR5cGUiLCAiY2VydGlmaWNhdGVfdmVyc2lvbiIsICJpc2RfYXMiXSwgImlzZF9hcyI6ICIxNy1mZmFhOjA6MTEwMSIsICJ0eXBlIjogImNlcnRpZmljYXRlIn0",
-      "signature": "DwcEIl3hNOuXIibScIcMpEzrw6YWBVNDk5v21f55j6T6XyM-U29EY4G7lV-EV3hJ_aRRc1BK-BoxiF7xivI-BQ"
-    }
-  ]
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-2/certs/ISD17-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "gZb3KXzvSt0UXfzOmsVkSnwRFLT0YcXoFZZvYreWtcYx_vVbhk06OThC002x4OgpK0BjBMJcrL_cn3blsh4UCQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "ePlI06GLjIBr8a28UC8MsdDi3sFZLFb0KYev7mt-aEAd-LEFKUXJcvUM9Dhz_huMkPFMJVFLZ9JffAovOZ5DDA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "G8LhE9WyxIG0N7dLtMtGeGbnGzktTd-ogguIVubgU62K-fi_U-MQRGoDVwc3OHkWEYzs3SzxPOWQy67SzsZdDA"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-2/certs/ISD19-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "3YGYoxPTR8jgDGadWM5ac03jNC6eIyrYVYJ3IFL_0d6ESO1eDfaWhPpEJPjni_am5DM-BGTC_6dl4IM4i58vDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "mKhwMiacq-3sJOEkkQ_e92622gR6pnFTvrI829vdoC64lkieM-18HGbJANXVmi-Bpl_CcF0uQyMSswapax23BQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "IyAgvp-9ZOHOnnVkUXMqlS22nF-KO2VYP_bXd09AONuJHsWlsGXDjoxOmH6SN2FwPpSDc_hkXuskHCUrk76HCg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "yBo9CKM5LgNk95QcjjK3UMdDVq3z0rsDIvvaWrKeWnbc1ejDpVK4IgM9hcpYLrRSt6y5sncFHw2Q1wTTlhSrDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "S0jmllXbdZL-1HQmT0C_29zIyuGnA03nKv2CiLpoeccWJN9sCoBc9AG9SaZQzasvJvEE7JNAHxrpNjB_j6bQCw"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wV0ZrVAXx88EUvIuk673MJLIAXcqQ-iV4vCCH50LCs0tLx65cI7ps6a31PSgIAnbp3SEg1VerkhUxJTxzyhzAg"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-2/certs/ISD20-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "lMflSxDL23pPZdxm4kCQrrExtho-3qWjBUGtFR9DCyADGjuhBBvJhUYXKCQgJmZwZKQ6sNvZhQrN650H7pXIAQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "IEQs-UKm_a0azRdYCBKgfytqLPKkC-KicEn8WyGNj_nJEpc6il5SvfUJkfv1TAUu2m5TK3Cwi_06dlKaOuacDQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "5x2TpKF5nJA3Z9gLdD45NZGm7nJZn8ndLaN8groZogAR9jW4y4qICkXuXz9ESYyA0JWVNLv_NsEEcaT33-hHBA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "LdhZ-vIz-I2G2dPJ3genkYhOCFJxsB3fZ_JDkm8w-94n8pAfh4CzdkiVLFJkW5xjIdcH6v-M5SyF-_4vwaXNAg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "CMXlaUloufb05e0myd4-fICnAVzCHrgJ7-mDegDHjMqSi3QuE70Gm-Muf887Rey_OHV9x7woExKQ-NpjSaa8Cg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wdZ-vcrtMLvPFnTTp1367W2i9CNq-kDLtpRJyEp4G2bf5KhdqdW_gtuYFEArtW0oGZ4-tiIErM3ng9Rvv7EjDQ"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-2/keys/as-decrypt-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: curve25519xsalsa20poly1305
-  ia: 17-ffaa:0:1107
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-decrypt
-  version: 1
-
-  yh3cQSKnhdGmpVgd3ydH2QQKCjSuQo5Q8l3wkejZCtg=
-  -----END PRIVATE KEY-----
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-2/keys/as-signing-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: ed25519
-  ia: 17-ffaa:0:1107
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-signing
-  version: 1
-
-  v/azm6d+tqTndaNvX9+JLTVglkoCIyZFVVbKXrcXVsc=
-  -----END PRIVATE KEY-----
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-2/keys/master0.key: |-
-  R7D6Lhl52uxloBQFRulzzA==
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-2/keys/master1.key: |-
-  R7D6Lhl52uxloBQFRulzzA==
-gen/ISD17/ASffaa_0_1107/br17-ffaa_0_1107-2/topology.json: |-
-  {
-    "Attributes": [],
-    "BorderRouters": {
-      "br17-ffaa_0_1107-1": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30242
-            }
-          }
-        },
-        "Interfaces": {
-          "1": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:0:1102",
-            "LinkTo": "PARENT",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "192.0.2.17",
-              "OverlayPort": 50000
-            },
-            "RemoteOverlay": {
-              "Addr": "192.0.2.12",
-              "OverlayPort": 50001
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30042
-            }
-          }
-        }
-      },
-      "br17-ffaa_0_1107-2": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30243
-            }
-          }
-        },
-        "Interfaces": {
-          "2": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:1:1",
-            "LinkTo": "CHILD",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "10.0.8.1",
-              "OverlayPort": 50000
-            },
-            "RemoteOverlay": {
-              "Addr": "10.0.0.1",
-              "OverlayPort": 54321
-            }
-          },
-          "3": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:1:5",
-            "LinkTo": "CHILD",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "192.0.2.17",
-              "OverlayPort": 50001
-            },
-            "RemoteOverlay": {
-              "Addr": "172.31.0.200",
-              "OverlayPort": 54321
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30043
-            }
-          }
-        }
-      }
-    },
-    "ControlService": {
-      "cs17-ffaa_0_1107-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30254
-            }
-          }
-        }
-      }
-    },
-    "ISD_AS": "17-ffaa:0:1107",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4"
-  }
-gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/beacon_policy.yaml: |
-  Filter:
-    AllowIsdLoop: false
-gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/certs/ISD17-ASffaa_0_1107-V1.crt: |-
-  [
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIklsOGRqbHVkRXEyazRHNGxxY2gwWUZibmk2ZnF1MllId0p1YWUzTmJHN0k9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjcml0IjogWyJ0eXBlIiwgInRyY192ZXJzaW9uIl0sICJ0cmNfdmVyc2lvbiI6IDEsICJ0eXBlIjogInRyYyJ9",
-      "signature": "w21oYonO1a92V7P9ypwkuVPBEH6NFCMseMkgYemgeCOvvtYRa_y0PKj7q7PJapJluUyJ35FNhzWmVxsmVrsYDg"
-    },
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImFzIiwgImRlc2NyaXB0aW9uIjogIkFTIGNlcnRpZmljYXRlIiwgImZvcm1hdF92ZXJzaW9uIjogMSwgImlzc3VlciI6IHsiY2VydGlmaWNhdGVfdmVyc2lvbiI6IDEsICJpc2RfYXMiOiAiMTctZmZhYTowOjExMDEifSwgImtleXMiOiB7ImVuY3J5cHRpb24iOiB7ImFsZ29yaXRobSI6ICJjdXJ2ZTI1NTE5IiwgImtleSI6ICJtRFpwcGNWeDMrb29GcExSZ3VrQTFqcWYrcnZIQ0pzZTNJMkxYOC9xMTFZPSIsICJrZXlfdmVyc2lvbiI6IDF9LCAic2lnbmluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIlpHSmNOOFFqdWRTMW12bG9meDB3NEtsSXZYQkRrVTdEc21Ecmw5Q1h2K0E9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwNyIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYwMTU1MDQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjZXJ0aWZpY2F0ZV92ZXJzaW9uIjogMSwgImNyaXQiOiBbInR5cGUiLCAiY2VydGlmaWNhdGVfdmVyc2lvbiIsICJpc2RfYXMiXSwgImlzZF9hcyI6ICIxNy1mZmFhOjA6MTEwMSIsICJ0eXBlIjogImNlcnRpZmljYXRlIn0",
-      "signature": "DwcEIl3hNOuXIibScIcMpEzrw6YWBVNDk5v21f55j6T6XyM-U29EY4G7lV-EV3hJ_aRRc1BK-BoxiF7xivI-BQ"
-    }
-  ]
-gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/certs/ISD17-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "gZb3KXzvSt0UXfzOmsVkSnwRFLT0YcXoFZZvYreWtcYx_vVbhk06OThC002x4OgpK0BjBMJcrL_cn3blsh4UCQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "ePlI06GLjIBr8a28UC8MsdDi3sFZLFb0KYev7mt-aEAd-LEFKUXJcvUM9Dhz_huMkPFMJVFLZ9JffAovOZ5DDA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "G8LhE9WyxIG0N7dLtMtGeGbnGzktTd-ogguIVubgU62K-fi_U-MQRGoDVwc3OHkWEYzs3SzxPOWQy67SzsZdDA"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/certs/ISD19-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "3YGYoxPTR8jgDGadWM5ac03jNC6eIyrYVYJ3IFL_0d6ESO1eDfaWhPpEJPjni_am5DM-BGTC_6dl4IM4i58vDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "mKhwMiacq-3sJOEkkQ_e92622gR6pnFTvrI829vdoC64lkieM-18HGbJANXVmi-Bpl_CcF0uQyMSswapax23BQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "IyAgvp-9ZOHOnnVkUXMqlS22nF-KO2VYP_bXd09AONuJHsWlsGXDjoxOmH6SN2FwPpSDc_hkXuskHCUrk76HCg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "yBo9CKM5LgNk95QcjjK3UMdDVq3z0rsDIvvaWrKeWnbc1ejDpVK4IgM9hcpYLrRSt6y5sncFHw2Q1wTTlhSrDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "S0jmllXbdZL-1HQmT0C_29zIyuGnA03nKv2CiLpoeccWJN9sCoBc9AG9SaZQzasvJvEE7JNAHxrpNjB_j6bQCw"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wV0ZrVAXx88EUvIuk673MJLIAXcqQ-iV4vCCH50LCs0tLx65cI7ps6a31PSgIAnbp3SEg1VerkhUxJTxzyhzAg"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/certs/ISD20-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "lMflSxDL23pPZdxm4kCQrrExtho-3qWjBUGtFR9DCyADGjuhBBvJhUYXKCQgJmZwZKQ6sNvZhQrN650H7pXIAQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "IEQs-UKm_a0azRdYCBKgfytqLPKkC-KicEn8WyGNj_nJEpc6il5SvfUJkfv1TAUu2m5TK3Cwi_06dlKaOuacDQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "5x2TpKF5nJA3Z9gLdD45NZGm7nJZn8ndLaN8groZogAR9jW4y4qICkXuXz9ESYyA0JWVNLv_NsEEcaT33-hHBA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "LdhZ-vIz-I2G2dPJ3genkYhOCFJxsB3fZ_JDkm8w-94n8pAfh4CzdkiVLFJkW5xjIdcH6v-M5SyF-_4vwaXNAg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "CMXlaUloufb05e0myd4-fICnAVzCHrgJ7-mDegDHjMqSi3QuE70Gm-Muf887Rey_OHV9x7woExKQ-NpjSaa8Cg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wdZ-vcrtMLvPFnTTp1367W2i9CNq-kDLtpRJyEp4G2bf5KhdqdW_gtuYFEArtW0oGZ4-tiIErM3ng9Rvv7EjDQ"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/cs.toml: |
-  [beacon_db]
-  backend = "sqlite"
-  connection = "/var/lib/scion/cs17-ffaa_0_1107-1.beacon.db"
-
-  [beaconing]
-  origination_interval = "5s"
-  propagation_interval = "5s"
-  rev_overlap = "5s"
-  rev_ttl = "20s"
-
-  [general]
-  config_dir = "/etc/scion/gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1"
-  id = "cs17-ffaa_0_1107-1"
-  reconnect_to_dispatcher = true
-
-  [metrics]
-  prometheus = "127.0.0.1:30454"
-
-  [path_db]
-  backend = "sqlite"
-  connection = "/var/lib/scion/cs17-ffaa_0_1107-1.path.db"
-
-  [quic]
-  address = "127.0.0.1:30354"
-  cert_file = "/etc/scion/gen-certs/tls.pem"
-  key_file = "/etc/scion/gen-certs/tls.key"
-  resolution_fraction = 0.4
-
-  [trust_db]
-  backend = "sqlite"
-  connection = "/var/lib/scion/cs17-ffaa_0_1107-1.trust.db"
-
-  [beaconing.policies]
-  Propagation = "/etc/scion/gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/beacon_policy.yaml"
-
-  [log.file]
-  level = "debug"
-  max_age = 3
-  max_backups = 1
-  path = "/var/log/scion/cs17-ffaa_0_1107-1.log"
-gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/keys/as-decrypt-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: curve25519xsalsa20poly1305
-  ia: 17-ffaa:0:1107
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-decrypt
-  version: 1
-
-  yh3cQSKnhdGmpVgd3ydH2QQKCjSuQo5Q8l3wkejZCtg=
-  -----END PRIVATE KEY-----
-gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/keys/as-signing-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: ed25519
-  ia: 17-ffaa:0:1107
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-signing
-  version: 1
-
-  v/azm6d+tqTndaNvX9+JLTVglkoCIyZFVVbKXrcXVsc=
-  -----END PRIVATE KEY-----
-gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/keys/master0.key: |-
-  R7D6Lhl52uxloBQFRulzzA==
-gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/keys/master1.key: |-
-  R7D6Lhl52uxloBQFRulzzA==
-gen/ISD17/ASffaa_0_1107/cs17-ffaa_0_1107-1/topology.json: |-
-  {
-    "Attributes": [],
-    "BorderRouters": {
-      "br17-ffaa_0_1107-1": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30242
-            }
-          }
-        },
-        "Interfaces": {
-          "1": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:0:1102",
-            "LinkTo": "PARENT",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "192.0.2.17",
-              "OverlayPort": 50000
-            },
-            "RemoteOverlay": {
-              "Addr": "192.0.2.12",
-              "OverlayPort": 50001
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30042
-            }
-          }
-        }
-      },
-      "br17-ffaa_0_1107-2": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30243
-            }
-          }
-        },
-        "Interfaces": {
-          "2": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:1:1",
-            "LinkTo": "CHILD",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "10.0.8.1",
-              "OverlayPort": 50000
-            },
-            "RemoteOverlay": {
-              "Addr": "10.0.0.1",
-              "OverlayPort": 54321
-            }
-          },
-          "3": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:1:5",
-            "LinkTo": "CHILD",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "192.0.2.17",
-              "OverlayPort": 50001
-            },
-            "RemoteOverlay": {
-              "Addr": "172.31.0.200",
-              "OverlayPort": 54321
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30043
-            }
-          }
-        }
-      }
-    },
-    "ControlService": {
-      "cs17-ffaa_0_1107-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30254
-            }
-          }
-        }
-      }
-    },
-    "ISD_AS": "17-ffaa:0:1107",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4"
-  }
-gen/ISD17/ASffaa_0_1107/endhost/certs/ISD17-ASffaa_0_1107-V1.crt: |-
-  [
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIklsOGRqbHVkRXEyazRHNGxxY2gwWUZibmk2ZnF1MllId0p1YWUzTmJHN0k9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjcml0IjogWyJ0eXBlIiwgInRyY192ZXJzaW9uIl0sICJ0cmNfdmVyc2lvbiI6IDEsICJ0eXBlIjogInRyYyJ9",
-      "signature": "w21oYonO1a92V7P9ypwkuVPBEH6NFCMseMkgYemgeCOvvtYRa_y0PKj7q7PJapJluUyJ35FNhzWmVxsmVrsYDg"
-    },
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImFzIiwgImRlc2NyaXB0aW9uIjogIkFTIGNlcnRpZmljYXRlIiwgImZvcm1hdF92ZXJzaW9uIjogMSwgImlzc3VlciI6IHsiY2VydGlmaWNhdGVfdmVyc2lvbiI6IDEsICJpc2RfYXMiOiAiMTctZmZhYTowOjExMDEifSwgImtleXMiOiB7ImVuY3J5cHRpb24iOiB7ImFsZ29yaXRobSI6ICJjdXJ2ZTI1NTE5IiwgImtleSI6ICJtRFpwcGNWeDMrb29GcExSZ3VrQTFqcWYrcnZIQ0pzZTNJMkxYOC9xMTFZPSIsICJrZXlfdmVyc2lvbiI6IDF9LCAic2lnbmluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIlpHSmNOOFFqdWRTMW12bG9meDB3NEtsSXZYQkRrVTdEc21Ecmw5Q1h2K0E9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwNyIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYwMTU1MDQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjZXJ0aWZpY2F0ZV92ZXJzaW9uIjogMSwgImNyaXQiOiBbInR5cGUiLCAiY2VydGlmaWNhdGVfdmVyc2lvbiIsICJpc2RfYXMiXSwgImlzZF9hcyI6ICIxNy1mZmFhOjA6MTEwMSIsICJ0eXBlIjogImNlcnRpZmljYXRlIn0",
-      "signature": "DwcEIl3hNOuXIibScIcMpEzrw6YWBVNDk5v21f55j6T6XyM-U29EY4G7lV-EV3hJ_aRRc1BK-BoxiF7xivI-BQ"
-    }
-  ]
-gen/ISD17/ASffaa_0_1107/endhost/certs/ISD17-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "gZb3KXzvSt0UXfzOmsVkSnwRFLT0YcXoFZZvYreWtcYx_vVbhk06OThC002x4OgpK0BjBMJcrL_cn3blsh4UCQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "ePlI06GLjIBr8a28UC8MsdDi3sFZLFb0KYev7mt-aEAd-LEFKUXJcvUM9Dhz_huMkPFMJVFLZ9JffAovOZ5DDA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "G8LhE9WyxIG0N7dLtMtGeGbnGzktTd-ogguIVubgU62K-fi_U-MQRGoDVwc3OHkWEYzs3SzxPOWQy67SzsZdDA"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/endhost/certs/ISD19-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "3YGYoxPTR8jgDGadWM5ac03jNC6eIyrYVYJ3IFL_0d6ESO1eDfaWhPpEJPjni_am5DM-BGTC_6dl4IM4i58vDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "mKhwMiacq-3sJOEkkQ_e92622gR6pnFTvrI829vdoC64lkieM-18HGbJANXVmi-Bpl_CcF0uQyMSswapax23BQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "IyAgvp-9ZOHOnnVkUXMqlS22nF-KO2VYP_bXd09AONuJHsWlsGXDjoxOmH6SN2FwPpSDc_hkXuskHCUrk76HCg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "yBo9CKM5LgNk95QcjjK3UMdDVq3z0rsDIvvaWrKeWnbc1ejDpVK4IgM9hcpYLrRSt6y5sncFHw2Q1wTTlhSrDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "S0jmllXbdZL-1HQmT0C_29zIyuGnA03nKv2CiLpoeccWJN9sCoBc9AG9SaZQzasvJvEE7JNAHxrpNjB_j6bQCw"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wV0ZrVAXx88EUvIuk673MJLIAXcqQ-iV4vCCH50LCs0tLx65cI7ps6a31PSgIAnbp3SEg1VerkhUxJTxzyhzAg"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/endhost/certs/ISD20-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "lMflSxDL23pPZdxm4kCQrrExtho-3qWjBUGtFR9DCyADGjuhBBvJhUYXKCQgJmZwZKQ6sNvZhQrN650H7pXIAQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "IEQs-UKm_a0azRdYCBKgfytqLPKkC-KicEn8WyGNj_nJEpc6il5SvfUJkfv1TAUu2m5TK3Cwi_06dlKaOuacDQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "5x2TpKF5nJA3Z9gLdD45NZGm7nJZn8ndLaN8groZogAR9jW4y4qICkXuXz9ESYyA0JWVNLv_NsEEcaT33-hHBA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "LdhZ-vIz-I2G2dPJ3genkYhOCFJxsB3fZ_JDkm8w-94n8pAfh4CzdkiVLFJkW5xjIdcH6v-M5SyF-_4vwaXNAg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "CMXlaUloufb05e0myd4-fICnAVzCHrgJ7-mDegDHjMqSi3QuE70Gm-Muf887Rey_OHV9x7woExKQ-NpjSaa8Cg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wdZ-vcrtMLvPFnTTp1367W2i9CNq-kDLtpRJyEp4G2bf5KhdqdW_gtuYFEArtW0oGZ4-tiIErM3ng9Rvv7EjDQ"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_0_1107/endhost/sd.toml: |
-  [general]
-  config_dir = "/etc/scion/gen/ISD17/ASffaa_0_1107/endhost"
-  id = "sd17-ffaa_0_1107"
-  reconnect_to_dispatcher = true
-
-  [metrics]
-  prometheus = "127.0.0.1:30455"
-
-  [path_db]
-  backend = "sqlite"
-  connection = "/var/lib/scion/sd17-ffaa_0_1107.path.db"
-
-  [sd]
-  address = "127.0.0.1:30255"
-
-  [trust_db]
-  backend = "sqlite"
-  connection = "/var/lib/scion/sd17-ffaa_0_1107.trust.db"
-
-  [log.file]
-  level = "debug"
-  max_age = 3
-  max_backups = 1
-  path = "/var/log/scion/sd17-ffaa_0_1107.log"
-gen/ISD17/ASffaa_0_1107/endhost/topology.json: |-
-  {
-    "Attributes": [],
-    "BorderRouters": {
-      "br17-ffaa_0_1107-1": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30242
-            }
-          }
-        },
-        "Interfaces": {
-          "1": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:0:1102",
-            "LinkTo": "PARENT",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "192.0.2.17",
-              "OverlayPort": 50000
-            },
-            "RemoteOverlay": {
-              "Addr": "192.0.2.12",
-              "OverlayPort": 50001
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30042
-            }
-          }
-        }
-      },
-      "br17-ffaa_0_1107-2": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30243
-            }
-          }
-        },
-        "Interfaces": {
-          "2": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:1:1",
-            "LinkTo": "CHILD",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "10.0.8.1",
-              "OverlayPort": 50000
-            },
-            "RemoteOverlay": {
-              "Addr": "10.0.0.1",
-              "OverlayPort": 54321
-            }
-          },
-          "3": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:1:5",
-            "LinkTo": "CHILD",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "192.0.2.17",
-              "OverlayPort": 50001
-            },
-            "RemoteOverlay": {
-              "Addr": "172.31.0.200",
-              "OverlayPort": 54321
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30043
-            }
-          }
-        }
-      }
-    },
-    "ControlService": {
-      "cs17-ffaa_0_1107-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30254
-            }
-          }
-        }
-      }
-    },
-    "ISD_AS": "17-ffaa:0:1107",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4"
-  }
-gen/dispatcher/disp.toml: |
-  [dispatcher]
-  id = "dispatcher"
-  socket_file_mode = "0777"
-
-  [metrics]
-  prometheus = "127.0.0.1:30441"
-
-  [log.file]
-  level = "debug"
-  max_age = 3
-  max_backups = 1
-  path = "/var/log/scion/dispatcher.log"
-gen/scionlab-config.json: |-
-  {
-    "host_id": "9e090a4529264b958a5c65fd8c214b1d",
-    "host_secret": "7abb3def0c4e4ddb85ba124d67d5544c",
-    "url": "http://localhost:8000",
-    "version": 10
-  }
-scionlab-services.txt: |-
-  scion-border-router@17-ffaa_0_1107-1.service
-  scion-border-router@17-ffaa_0_1107-2.service
-  scion-control-service@17-ffaa_0_1107-1.service
-  scion-bwtestserver.service
-  scion-daemon@17-ffaa_0_1107.service
-  scion-dispatcher.service
-server.conf: |
+etc/openvpn/server.conf: |
   mode server
   tls-server
 
@@ -1116,3 +126,356 @@ server.conf: |
   -----END RSA PRIVATE KEY-----
 
   </key>
+etc/scion/beacon_policy.yaml: |
+  Filter:
+    AllowIsdLoop: false
+etc/scion/br-1.toml: |
+  [general]
+  config_dir = "/etc/scion"
+  id = "br-1"
+  reconnect_to_dispatcher = true
+
+  [metrics]
+  prometheus = "127.0.0.1:30442"
+
+  [log.file]
+  level = "debug"
+  max_age = 3
+  max_backups = 1
+  path = "/var/log/scion/br-1.log"
+etc/scion/br-2.toml: |
+  [general]
+  config_dir = "/etc/scion"
+  id = "br-2"
+  reconnect_to_dispatcher = true
+
+  [metrics]
+  prometheus = "127.0.0.1:30443"
+
+  [log.file]
+  level = "debug"
+  max_age = 3
+  max_backups = 1
+  path = "/var/log/scion/br-2.log"
+etc/scion/certs/ISD17-ASffaa_0_1107-V1.crt: |-
+  [
+    {
+      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIklsOGRqbHVkRXEyazRHNGxxY2gwWUZibmk2ZnF1MllId0p1YWUzTmJHN0k9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
+      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjcml0IjogWyJ0eXBlIiwgInRyY192ZXJzaW9uIl0sICJ0cmNfdmVyc2lvbiI6IDEsICJ0eXBlIjogInRyYyJ9",
+      "signature": "w21oYonO1a92V7P9ypwkuVPBEH6NFCMseMkgYemgeCOvvtYRa_y0PKj7q7PJapJluUyJ35FNhzWmVxsmVrsYDg"
+    },
+    {
+      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImFzIiwgImRlc2NyaXB0aW9uIjogIkFTIGNlcnRpZmljYXRlIiwgImZvcm1hdF92ZXJzaW9uIjogMSwgImlzc3VlciI6IHsiY2VydGlmaWNhdGVfdmVyc2lvbiI6IDEsICJpc2RfYXMiOiAiMTctZmZhYTowOjExMDEifSwgImtleXMiOiB7ImVuY3J5cHRpb24iOiB7ImFsZ29yaXRobSI6ICJjdXJ2ZTI1NTE5IiwgImtleSI6ICJtRFpwcGNWeDMrb29GcExSZ3VrQTFqcWYrcnZIQ0pzZTNJMkxYOC9xMTFZPSIsICJrZXlfdmVyc2lvbiI6IDF9LCAic2lnbmluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIlpHSmNOOFFqdWRTMW12bG9meDB3NEtsSXZYQkRrVTdEc21Ecmw5Q1h2K0E9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwNyIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYwMTU1MDQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
+      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjZXJ0aWZpY2F0ZV92ZXJzaW9uIjogMSwgImNyaXQiOiBbInR5cGUiLCAiY2VydGlmaWNhdGVfdmVyc2lvbiIsICJpc2RfYXMiXSwgImlzZF9hcyI6ICIxNy1mZmFhOjA6MTEwMSIsICJ0eXBlIjogImNlcnRpZmljYXRlIn0",
+      "signature": "DwcEIl3hNOuXIibScIcMpEzrw6YWBVNDk5v21f55j6T6XyM-U29EY4G7lV-EV3hJ_aRRc1BK-BoxiF7xivI-BQ"
+    }
+  ]
+etc/scion/certs/ISD17-V1.trc: |-
+  {
+    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
+    "signatures": [
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
+        "signature": "gZb3KXzvSt0UXfzOmsVkSnwRFLT0YcXoFZZvYreWtcYx_vVbhk06OThC002x4OgpK0BjBMJcrL_cn3blsh4UCQ"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
+        "signature": "ePlI06GLjIBr8a28UC8MsdDi3sFZLFb0KYev7mt-aEAd-LEFKUXJcvUM9Dhz_huMkPFMJVFLZ9JffAovOZ5DDA"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
+        "signature": "G8LhE9WyxIG0N7dLtMtGeGbnGzktTd-ogguIVubgU62K-fi_U-MQRGoDVwc3OHkWEYzs3SzxPOWQy67SzsZdDA"
+      }
+    ]
+  }
+etc/scion/certs/ISD19-V1.trc: |-
+  {
+    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
+    "signatures": [
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
+        "signature": "3YGYoxPTR8jgDGadWM5ac03jNC6eIyrYVYJ3IFL_0d6ESO1eDfaWhPpEJPjni_am5DM-BGTC_6dl4IM4i58vDg"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
+        "signature": "mKhwMiacq-3sJOEkkQ_e92622gR6pnFTvrI829vdoC64lkieM-18HGbJANXVmi-Bpl_CcF0uQyMSswapax23BQ"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
+        "signature": "IyAgvp-9ZOHOnnVkUXMqlS22nF-KO2VYP_bXd09AONuJHsWlsGXDjoxOmH6SN2FwPpSDc_hkXuskHCUrk76HCg"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
+        "signature": "yBo9CKM5LgNk95QcjjK3UMdDVq3z0rsDIvvaWrKeWnbc1ejDpVK4IgM9hcpYLrRSt6y5sncFHw2Q1wTTlhSrDg"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
+        "signature": "S0jmllXbdZL-1HQmT0C_29zIyuGnA03nKv2CiLpoeccWJN9sCoBc9AG9SaZQzasvJvEE7JNAHxrpNjB_j6bQCw"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
+        "signature": "wV0ZrVAXx88EUvIuk673MJLIAXcqQ-iV4vCCH50LCs0tLx65cI7ps6a31PSgIAnbp3SEg1VerkhUxJTxzyhzAg"
+      }
+    ]
+  }
+etc/scion/certs/ISD20-V1.trc: |-
+  {
+    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
+    "signatures": [
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
+        "signature": "lMflSxDL23pPZdxm4kCQrrExtho-3qWjBUGtFR9DCyADGjuhBBvJhUYXKCQgJmZwZKQ6sNvZhQrN650H7pXIAQ"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
+        "signature": "IEQs-UKm_a0azRdYCBKgfytqLPKkC-KicEn8WyGNj_nJEpc6il5SvfUJkfv1TAUu2m5TK3Cwi_06dlKaOuacDQ"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
+        "signature": "5x2TpKF5nJA3Z9gLdD45NZGm7nJZn8ndLaN8groZogAR9jW4y4qICkXuXz9ESYyA0JWVNLv_NsEEcaT33-hHBA"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
+        "signature": "LdhZ-vIz-I2G2dPJ3genkYhOCFJxsB3fZ_JDkm8w-94n8pAfh4CzdkiVLFJkW5xjIdcH6v-M5SyF-_4vwaXNAg"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
+        "signature": "CMXlaUloufb05e0myd4-fICnAVzCHrgJ7-mDegDHjMqSi3QuE70Gm-Muf887Rey_OHV9x7woExKQ-NpjSaa8Cg"
+      },
+      {
+        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
+        "signature": "wdZ-vcrtMLvPFnTTp1367W2i9CNq-kDLtpRJyEp4G2bf5KhdqdW_gtuYFEArtW0oGZ4-tiIErM3ng9Rvv7EjDQ"
+      }
+    ]
+  }
+etc/scion/cs-1.toml: |
+  [beacon_db]
+  backend = "sqlite"
+  connection = "/var/lib/scion/cs-1.beacon.db"
+
+  [beaconing]
+  origination_interval = "5s"
+  propagation_interval = "5s"
+  rev_overlap = "5s"
+  rev_ttl = "20s"
+
+  [general]
+  config_dir = "/etc/scion"
+  id = "cs-1"
+  reconnect_to_dispatcher = true
+
+  [metrics]
+  prometheus = "127.0.0.1:30454"
+
+  [path_db]
+  backend = "sqlite"
+  connection = "/var/lib/scion/cs-1.path.db"
+
+  [quic]
+  address = "127.0.0.1:30354"
+  cert_file = "/etc/scion/gen-certs/tls.pem"
+  key_file = "/etc/scion/gen-certs/tls.key"
+  resolution_fraction = 0.4
+
+  [trust_db]
+  backend = "sqlite"
+  connection = "/var/lib/scion/cs-1.trust.db"
+
+  [beaconing.policies]
+  Propagation = "/etc/scion/beacon_policy.yaml"
+
+  [log.file]
+  level = "debug"
+  max_age = 3
+  max_backups = 1
+  path = "/var/log/scion/cs-1.log"
+etc/scion/keys/as-decrypt-v1.key: |
+  -----BEGIN PRIVATE KEY-----
+  algorithm: curve25519xsalsa20poly1305
+  ia: 17-ffaa:0:1107
+  not_after: 2019-10-02 11:07:41+0000
+  not_before: 2020-10-01 11:07:41+0000
+  usage: as-decrypt
+  version: 1
+
+  yh3cQSKnhdGmpVgd3ydH2QQKCjSuQo5Q8l3wkejZCtg=
+  -----END PRIVATE KEY-----
+etc/scion/keys/as-signing-v1.key: |
+  -----BEGIN PRIVATE KEY-----
+  algorithm: ed25519
+  ia: 17-ffaa:0:1107
+  not_after: 2019-10-02 11:07:41+0000
+  not_before: 2020-10-01 11:07:41+0000
+  usage: as-signing
+  version: 1
+
+  v/azm6d+tqTndaNvX9+JLTVglkoCIyZFVVbKXrcXVsc=
+  -----END PRIVATE KEY-----
+etc/scion/keys/master0.key: |-
+  R7D6Lhl52uxloBQFRulzzA==
+etc/scion/keys/master1.key: |-
+  R7D6Lhl52uxloBQFRulzzA==
+etc/scion/sd.toml: |
+  [general]
+  config_dir = "/etc/scion"
+  id = "sd"
+  reconnect_to_dispatcher = true
+
+  [metrics]
+  prometheus = "127.0.0.1:30455"
+
+  [path_db]
+  backend = "sqlite"
+  connection = "/var/lib/scion/sd.path.db"
+
+  [sd]
+  address = "127.0.0.1:30255"
+
+  [trust_db]
+  backend = "sqlite"
+  connection = "/var/lib/scion/sd.trust.db"
+
+  [log.file]
+  level = "debug"
+  max_age = 3
+  max_backups = 1
+  path = "/var/log/scion/sd.log"
+etc/scion/topology.json: |-
+  {
+    "Attributes": [],
+    "BorderRouters": {
+      "br-1": {
+        "CtrlAddr": {
+          "IPv4": {
+            "Public": {
+              "Addr": "127.0.0.1",
+              "L4Port": 30242
+            }
+          }
+        },
+        "Interfaces": {
+          "1": {
+            "Bandwidth": 1000,
+            "ISD_AS": "17-ffaa:0:1102",
+            "LinkTo": "PARENT",
+            "MTU": 1472,
+            "Overlay": "UDP/IPv4",
+            "PublicOverlay": {
+              "Addr": "192.0.2.17",
+              "OverlayPort": 50000
+            },
+            "RemoteOverlay": {
+              "Addr": "192.0.2.12",
+              "OverlayPort": 50001
+            }
+          }
+        },
+        "InternalAddrs": {
+          "IPv4": {
+            "PublicOverlay": {
+              "Addr": "127.0.0.1",
+              "OverlayPort": 30042
+            }
+          }
+        }
+      },
+      "br-2": {
+        "CtrlAddr": {
+          "IPv4": {
+            "Public": {
+              "Addr": "127.0.0.1",
+              "L4Port": 30243
+            }
+          }
+        },
+        "Interfaces": {
+          "2": {
+            "Bandwidth": 1000,
+            "ISD_AS": "17-ffaa:1:1",
+            "LinkTo": "CHILD",
+            "MTU": 1472,
+            "Overlay": "UDP/IPv4",
+            "PublicOverlay": {
+              "Addr": "10.0.8.1",
+              "OverlayPort": 50000
+            },
+            "RemoteOverlay": {
+              "Addr": "10.0.0.1",
+              "OverlayPort": 54321
+            }
+          },
+          "3": {
+            "Bandwidth": 1000,
+            "ISD_AS": "17-ffaa:1:5",
+            "LinkTo": "CHILD",
+            "MTU": 1472,
+            "Overlay": "UDP/IPv4",
+            "PublicOverlay": {
+              "Addr": "192.0.2.17",
+              "OverlayPort": 50001
+            },
+            "RemoteOverlay": {
+              "Addr": "172.31.0.200",
+              "OverlayPort": 54321
+            }
+          }
+        },
+        "InternalAddrs": {
+          "IPv4": {
+            "PublicOverlay": {
+              "Addr": "127.0.0.1",
+              "OverlayPort": 30043
+            }
+          }
+        }
+      }
+    },
+    "ControlService": {
+      "cs-1": {
+        "Addrs": {
+          "IPv4": {
+            "Public": {
+              "Addr": "127.0.0.1",
+              "L4Port": 30254
+            }
+          }
+        }
+      }
+    },
+    "ISD_AS": "17-ffaa:0:1107",
+    "MTU": 1472,
+    "Overlay": "UDP/IPv4"
+  }
+scionlab-config.json: |-
+  {
+    "files": {
+      "etc/openvpn/ccd/exbert@scionlab.org_ffaa_1_1": "72a44b475588d54d168220d99cb1d5b26a39decd",
+      "etc/openvpn/server.conf": "1ac605e494b70f28906b70434028d3724193aba8",
+      "etc/scion/beacon_policy.yaml": "90c69ea879ca52546774c3007e7d29104766fc07",
+      "etc/scion/br-1.toml": "2df19de492ec1257d6cf3a244ead625c3fe3e102",
+      "etc/scion/br-2.toml": "7fd1b53d6c64cd2eff87c6c70d91990eb8909bcc",
+      "etc/scion/certs/ISD17-ASffaa_0_1107-V1.crt": "89bb64b0a92a9efc6d84e47ce1b2ab9c98bccf47",
+      "etc/scion/certs/ISD17-V1.trc": "ed4f99c371b544e3bd6b4293e14396fd40b0b657",
+      "etc/scion/certs/ISD19-V1.trc": "087f805b006e0ff52e8f4fbab3dcd63d27498601",
+      "etc/scion/certs/ISD20-V1.trc": "df94e1688f2c88dd9648fa4c003f895b546467ab",
+      "etc/scion/cs-1.toml": "0c31ad123b489e233f616393faad56d4a7e93b5d",
+      "etc/scion/keys/as-decrypt-v1.key": "70b7a82e6d8ebbff8018b4f2deb251c308ac2e3b",
+      "etc/scion/keys/as-signing-v1.key": "d79601ba79eea4161cc6b3f074f9d9e1df32bc5f",
+      "etc/scion/keys/master0.key": "d3061b379b7044f794e598e1910f3a95dac95040",
+      "etc/scion/keys/master1.key": "d3061b379b7044f794e598e1910f3a95dac95040",
+      "etc/scion/sd.toml": "6094e9c83d36e8ff82a188880b7612d4fb0f5c07",
+      "etc/scion/topology.json": "cb3d7a4480ec834dcf53201465034af672826b1c"
+    },
+    "host_id": "9e090a4529264b958a5c65fd8c214b1d",
+    "host_secret": "7abb3def0c4e4ddb85ba124d67d5544c",
+    "systemd_units": [
+      "scion-border-router@br-1.service",
+      "scion-border-router@br-2.service",
+      "scion-control-service@cs-1.service",
+      "scion-bwtestserver.service",
+      "scion-daemon@sd.service",
+      "scion-dispatcher.service"
+    ],
+    "url": "http://localhost:8000",
+    "version": 10
+  }

--- a/scionlab/tests/data/test_config_tar/user_as_18.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_18.yml
@@ -1,9 +1,12 @@
 README.md: |-
   content_not_checked
-gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/br.toml: |
+etc/scion/beacon_policy.yaml: |
+  Filter:
+    AllowIsdLoop: false
+etc/scion/br-1.toml: |
   [general]
-  config_dir = "/etc/scion/gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1"
-  id = "br20-ffaa_1_3-1"
+  config_dir = "/etc/scion"
+  id = "br-1"
   reconnect_to_dispatcher = true
 
   [metrics]
@@ -13,8 +16,8 @@ gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/br.toml: |
   level = "debug"
   max_age = 3
   max_backups = 1
-  path = "/var/log/scion/br20-ffaa_1_3-1.log"
-gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/certs/ISD17-V1.trc: |-
+  path = "/var/log/scion/br-1.log"
+etc/scion/certs/ISD17-V1.trc: |-
   {
     "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
     "signatures": [
@@ -32,7 +35,7 @@ gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/certs/ISD17-V1.trc: |-
       }
     ]
   }
-gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/certs/ISD19-V1.trc: |-
+etc/scion/certs/ISD19-V1.trc: |-
   {
     "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
     "signatures": [
@@ -62,7 +65,7 @@ gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/certs/ISD19-V1.trc: |-
       }
     ]
   }
-gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/certs/ISD20-ASffaa_1_3-V1.crt: |-
+etc/scion/certs/ISD20-ASffaa_1_3-V1.crt: |-
   [
     {
       "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIlh3QjBPcDFrQTFVY0d6UHhVSWNwWDNqVmJ0eVJlNHJZMEM1bGpLK2dpNnc9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIyMC1mZmFhOjA6MTQwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
@@ -75,7 +78,7 @@ gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/certs/ISD20-ASffaa_1_3-V1.crt: |-
       "signature": "RqSJCfje4nMDI4yCSBnzyJLEPnnJAEmQm-f36H1l1xHqmeTmfaXL5QYVWCL3K2h2KkkesuNxkWG5ANRT7y0RCA"
     }
   ]
-gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/certs/ISD20-V1.trc: |-
+etc/scion/certs/ISD20-V1.trc: |-
   {
     "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
     "signatures": [
@@ -105,198 +108,10 @@ gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/certs/ISD20-V1.trc: |-
       }
     ]
   }
-gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/keys/as-decrypt-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: curve25519xsalsa20poly1305
-  ia: 20-ffaa:1:3
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-decrypt
-  version: 1
-
-  wA0y4PVBLbmVU0thogpKjW4IrmlEYLo1WCIhHJxbKgc=
-  -----END PRIVATE KEY-----
-gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/keys/as-signing-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: ed25519
-  ia: 20-ffaa:1:3
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-signing
-  version: 1
-
-  bpNldhOktbWuE8dsi7mNIysnNSo6B4Yi0X5b5uGfvEk=
-  -----END PRIVATE KEY-----
-gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/keys/master0.key: |-
-  /t1Iw4Ac7l5YJKBbxHmhhA==
-gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/keys/master1.key: |-
-  /t1Iw4Ac7l5YJKBbxHmhhA==
-gen/ISD20/ASffaa_1_3/br20-ffaa_1_3-1/topology.json: |-
-  {
-    "Attributes": [],
-    "BorderRouters": {
-      "br20-ffaa_1_3-1": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30242
-            }
-          }
-        },
-        "Interfaces": {
-          "1": {
-            "Bandwidth": 1000,
-            "ISD_AS": "20-ffaa:0:1404",
-            "LinkTo": "PARENT",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "172.31.0.200",
-              "OverlayPort": 54321
-            },
-            "RemoteOverlay": {
-              "Addr": "192.0.2.44",
-              "OverlayPort": 50002
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30042
-            }
-          }
-        }
-      }
-    },
-    "ControlService": {
-      "cs20-ffaa_1_3-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30254
-            }
-          }
-        }
-      }
-    },
-    "ISD_AS": "20-ffaa:1:3",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4",
-    "SIG": {
-      "sig20-ffaa_1_3-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 31056
-            }
-          }
-        }
-      }
-    }
-  }
-gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/beacon_policy.yaml: |
-  Filter:
-    AllowIsdLoop: false
-gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/certs/ISD17-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "gZb3KXzvSt0UXfzOmsVkSnwRFLT0YcXoFZZvYreWtcYx_vVbhk06OThC002x4OgpK0BjBMJcrL_cn3blsh4UCQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "ePlI06GLjIBr8a28UC8MsdDi3sFZLFb0KYev7mt-aEAd-LEFKUXJcvUM9Dhz_huMkPFMJVFLZ9JffAovOZ5DDA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "G8LhE9WyxIG0N7dLtMtGeGbnGzktTd-ogguIVubgU62K-fi_U-MQRGoDVwc3OHkWEYzs3SzxPOWQy67SzsZdDA"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/certs/ISD19-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "3YGYoxPTR8jgDGadWM5ac03jNC6eIyrYVYJ3IFL_0d6ESO1eDfaWhPpEJPjni_am5DM-BGTC_6dl4IM4i58vDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "mKhwMiacq-3sJOEkkQ_e92622gR6pnFTvrI829vdoC64lkieM-18HGbJANXVmi-Bpl_CcF0uQyMSswapax23BQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "IyAgvp-9ZOHOnnVkUXMqlS22nF-KO2VYP_bXd09AONuJHsWlsGXDjoxOmH6SN2FwPpSDc_hkXuskHCUrk76HCg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "yBo9CKM5LgNk95QcjjK3UMdDVq3z0rsDIvvaWrKeWnbc1ejDpVK4IgM9hcpYLrRSt6y5sncFHw2Q1wTTlhSrDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "S0jmllXbdZL-1HQmT0C_29zIyuGnA03nKv2CiLpoeccWJN9sCoBc9AG9SaZQzasvJvEE7JNAHxrpNjB_j6bQCw"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wV0ZrVAXx88EUvIuk673MJLIAXcqQ-iV4vCCH50LCs0tLx65cI7ps6a31PSgIAnbp3SEg1VerkhUxJTxzyhzAg"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/certs/ISD20-ASffaa_1_3-V1.crt: |-
-  [
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIlh3QjBPcDFrQTFVY0d6UHhVSWNwWDNqVmJ0eVJlNHJZMEM1bGpLK2dpNnc9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIyMC1mZmFhOjA6MTQwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjcml0IjogWyJ0eXBlIiwgInRyY192ZXJzaW9uIl0sICJ0cmNfdmVyc2lvbiI6IDEsICJ0eXBlIjogInRyYyJ9",
-      "signature": "Crzhv-xjoP_I2tka2vP7EvlyFfy8kku9yYTMX94oWxypOrHx_hWmD8hBCDFl81lonL49Z2v-AnCebH42KMZLCQ"
-    },
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImFzIiwgImRlc2NyaXB0aW9uIjogIkFTIGNlcnRpZmljYXRlIiwgImZvcm1hdF92ZXJzaW9uIjogMSwgImlzc3VlciI6IHsiY2VydGlmaWNhdGVfdmVyc2lvbiI6IDEsICJpc2RfYXMiOiAiMjAtZmZhYTowOjE0MDEifSwgImtleXMiOiB7ImVuY3J5cHRpb24iOiB7ImFsZ29yaXRobSI6ICJjdXJ2ZTI1NTE5IiwgImtleSI6ICJlWDAyTGlVNkErdS9vaDVORmx4eTExckMrWlRpQm5yd09XM3pGaUE2MGkwPSIsICJrZXlfdmVyc2lvbiI6IDF9LCAic2lnbmluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogImE3RGR6VlErWGJRSzd6MXE3OURKV3dhUnFwNlVqZEsyRDh3VnJyZ1RhWTA9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIyMC1mZmFhOjE6MyIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYwMTU1MDQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjZXJ0aWZpY2F0ZV92ZXJzaW9uIjogMSwgImNyaXQiOiBbInR5cGUiLCAiY2VydGlmaWNhdGVfdmVyc2lvbiIsICJpc2RfYXMiXSwgImlzZF9hcyI6ICIyMC1mZmFhOjA6MTQwMSIsICJ0eXBlIjogImNlcnRpZmljYXRlIn0",
-      "signature": "RqSJCfje4nMDI4yCSBnzyJLEPnnJAEmQm-f36H1l1xHqmeTmfaXL5QYVWCL3K2h2KkkesuNxkWG5ANRT7y0RCA"
-    }
-  ]
-gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/certs/ISD20-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "lMflSxDL23pPZdxm4kCQrrExtho-3qWjBUGtFR9DCyADGjuhBBvJhUYXKCQgJmZwZKQ6sNvZhQrN650H7pXIAQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "IEQs-UKm_a0azRdYCBKgfytqLPKkC-KicEn8WyGNj_nJEpc6il5SvfUJkfv1TAUu2m5TK3Cwi_06dlKaOuacDQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "5x2TpKF5nJA3Z9gLdD45NZGm7nJZn8ndLaN8groZogAR9jW4y4qICkXuXz9ESYyA0JWVNLv_NsEEcaT33-hHBA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "LdhZ-vIz-I2G2dPJ3genkYhOCFJxsB3fZ_JDkm8w-94n8pAfh4CzdkiVLFJkW5xjIdcH6v-M5SyF-_4vwaXNAg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "CMXlaUloufb05e0myd4-fICnAVzCHrgJ7-mDegDHjMqSi3QuE70Gm-Muf887Rey_OHV9x7woExKQ-NpjSaa8Cg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wdZ-vcrtMLvPFnTTp1367W2i9CNq-kDLtpRJyEp4G2bf5KhdqdW_gtuYFEArtW0oGZ4-tiIErM3ng9Rvv7EjDQ"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/cs.toml: |
+etc/scion/cs-1.toml: |
   [beacon_db]
   backend = "sqlite"
-  connection = "/var/lib/scion/cs20-ffaa_1_3-1.beacon.db"
+  connection = "/var/lib/scion/cs-1.beacon.db"
 
   [beaconing]
   origination_interval = "5s"
@@ -305,8 +120,8 @@ gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/cs.toml: |
   rev_ttl = "20s"
 
   [general]
-  config_dir = "/etc/scion/gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1"
-  id = "cs20-ffaa_1_3-1"
+  config_dir = "/etc/scion"
+  id = "cs-1"
   reconnect_to_dispatcher = true
 
   [metrics]
@@ -314,7 +129,7 @@ gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/cs.toml: |
 
   [path_db]
   backend = "sqlite"
-  connection = "/var/lib/scion/cs20-ffaa_1_3-1.path.db"
+  connection = "/var/lib/scion/cs-1.path.db"
 
   [quic]
   address = "127.0.0.1:30354"
@@ -324,17 +139,17 @@ gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/cs.toml: |
 
   [trust_db]
   backend = "sqlite"
-  connection = "/var/lib/scion/cs20-ffaa_1_3-1.trust.db"
+  connection = "/var/lib/scion/cs-1.trust.db"
 
   [beaconing.policies]
-  Propagation = "/etc/scion/gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/beacon_policy.yaml"
+  Propagation = "/etc/scion/beacon_policy.yaml"
 
   [log.file]
   level = "debug"
   max_age = 3
   max_backups = 1
-  path = "/var/log/scion/cs20-ffaa_1_3-1.log"
-gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/keys/as-decrypt-v1.key: |
+  path = "/var/log/scion/cs-1.log"
+etc/scion/keys/as-decrypt-v1.key: |
   -----BEGIN PRIVATE KEY-----
   algorithm: curve25519xsalsa20poly1305
   ia: 20-ffaa:1:3
@@ -345,7 +160,7 @@ gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/keys/as-decrypt-v1.key: |
 
   wA0y4PVBLbmVU0thogpKjW4IrmlEYLo1WCIhHJxbKgc=
   -----END PRIVATE KEY-----
-gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/keys/as-signing-v1.key: |
+etc/scion/keys/as-signing-v1.key: |
   -----BEGIN PRIVATE KEY-----
   algorithm: ed25519
   ia: 20-ffaa:1:3
@@ -356,173 +171,14 @@ gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/keys/as-signing-v1.key: |
 
   bpNldhOktbWuE8dsi7mNIysnNSo6B4Yi0X5b5uGfvEk=
   -----END PRIVATE KEY-----
-gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/keys/master0.key: |-
+etc/scion/keys/master0.key: |-
   /t1Iw4Ac7l5YJKBbxHmhhA==
-gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/keys/master1.key: |-
+etc/scion/keys/master1.key: |-
   /t1Iw4Ac7l5YJKBbxHmhhA==
-gen/ISD20/ASffaa_1_3/cs20-ffaa_1_3-1/topology.json: |-
-  {
-    "Attributes": [],
-    "BorderRouters": {
-      "br20-ffaa_1_3-1": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30242
-            }
-          }
-        },
-        "Interfaces": {
-          "1": {
-            "Bandwidth": 1000,
-            "ISD_AS": "20-ffaa:0:1404",
-            "LinkTo": "PARENT",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "172.31.0.200",
-              "OverlayPort": 54321
-            },
-            "RemoteOverlay": {
-              "Addr": "192.0.2.44",
-              "OverlayPort": 50002
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30042
-            }
-          }
-        }
-      }
-    },
-    "ControlService": {
-      "cs20-ffaa_1_3-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30254
-            }
-          }
-        }
-      }
-    },
-    "ISD_AS": "20-ffaa:1:3",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4",
-    "SIG": {
-      "sig20-ffaa_1_3-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 31056
-            }
-          }
-        }
-      }
-    }
-  }
-gen/ISD20/ASffaa_1_3/endhost/certs/ISD17-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "gZb3KXzvSt0UXfzOmsVkSnwRFLT0YcXoFZZvYreWtcYx_vVbhk06OThC002x4OgpK0BjBMJcrL_cn3blsh4UCQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "ePlI06GLjIBr8a28UC8MsdDi3sFZLFb0KYev7mt-aEAd-LEFKUXJcvUM9Dhz_huMkPFMJVFLZ9JffAovOZ5DDA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "G8LhE9WyxIG0N7dLtMtGeGbnGzktTd-ogguIVubgU62K-fi_U-MQRGoDVwc3OHkWEYzs3SzxPOWQy67SzsZdDA"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_3/endhost/certs/ISD19-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "3YGYoxPTR8jgDGadWM5ac03jNC6eIyrYVYJ3IFL_0d6ESO1eDfaWhPpEJPjni_am5DM-BGTC_6dl4IM4i58vDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "mKhwMiacq-3sJOEkkQ_e92622gR6pnFTvrI829vdoC64lkieM-18HGbJANXVmi-Bpl_CcF0uQyMSswapax23BQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "IyAgvp-9ZOHOnnVkUXMqlS22nF-KO2VYP_bXd09AONuJHsWlsGXDjoxOmH6SN2FwPpSDc_hkXuskHCUrk76HCg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "yBo9CKM5LgNk95QcjjK3UMdDVq3z0rsDIvvaWrKeWnbc1ejDpVK4IgM9hcpYLrRSt6y5sncFHw2Q1wTTlhSrDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "S0jmllXbdZL-1HQmT0C_29zIyuGnA03nKv2CiLpoeccWJN9sCoBc9AG9SaZQzasvJvEE7JNAHxrpNjB_j6bQCw"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wV0ZrVAXx88EUvIuk673MJLIAXcqQ-iV4vCCH50LCs0tLx65cI7ps6a31PSgIAnbp3SEg1VerkhUxJTxzyhzAg"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_3/endhost/certs/ISD20-ASffaa_1_3-V1.crt: |-
-  [
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIlh3QjBPcDFrQTFVY0d6UHhVSWNwWDNqVmJ0eVJlNHJZMEM1bGpLK2dpNnc9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIyMC1mZmFhOjA6MTQwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjcml0IjogWyJ0eXBlIiwgInRyY192ZXJzaW9uIl0sICJ0cmNfdmVyc2lvbiI6IDEsICJ0eXBlIjogInRyYyJ9",
-      "signature": "Crzhv-xjoP_I2tka2vP7EvlyFfy8kku9yYTMX94oWxypOrHx_hWmD8hBCDFl81lonL49Z2v-AnCebH42KMZLCQ"
-    },
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImFzIiwgImRlc2NyaXB0aW9uIjogIkFTIGNlcnRpZmljYXRlIiwgImZvcm1hdF92ZXJzaW9uIjogMSwgImlzc3VlciI6IHsiY2VydGlmaWNhdGVfdmVyc2lvbiI6IDEsICJpc2RfYXMiOiAiMjAtZmZhYTowOjE0MDEifSwgImtleXMiOiB7ImVuY3J5cHRpb24iOiB7ImFsZ29yaXRobSI6ICJjdXJ2ZTI1NTE5IiwgImtleSI6ICJlWDAyTGlVNkErdS9vaDVORmx4eTExckMrWlRpQm5yd09XM3pGaUE2MGkwPSIsICJrZXlfdmVyc2lvbiI6IDF9LCAic2lnbmluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogImE3RGR6VlErWGJRSzd6MXE3OURKV3dhUnFwNlVqZEsyRDh3VnJyZ1RhWTA9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIyMC1mZmFhOjE6MyIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYwMTU1MDQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjZXJ0aWZpY2F0ZV92ZXJzaW9uIjogMSwgImNyaXQiOiBbInR5cGUiLCAiY2VydGlmaWNhdGVfdmVyc2lvbiIsICJpc2RfYXMiXSwgImlzZF9hcyI6ICIyMC1mZmFhOjA6MTQwMSIsICJ0eXBlIjogImNlcnRpZmljYXRlIn0",
-      "signature": "RqSJCfje4nMDI4yCSBnzyJLEPnnJAEmQm-f36H1l1xHqmeTmfaXL5QYVWCL3K2h2KkkesuNxkWG5ANRT7y0RCA"
-    }
-  ]
-gen/ISD20/ASffaa_1_3/endhost/certs/ISD20-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "lMflSxDL23pPZdxm4kCQrrExtho-3qWjBUGtFR9DCyADGjuhBBvJhUYXKCQgJmZwZKQ6sNvZhQrN650H7pXIAQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "IEQs-UKm_a0azRdYCBKgfytqLPKkC-KicEn8WyGNj_nJEpc6il5SvfUJkfv1TAUu2m5TK3Cwi_06dlKaOuacDQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "5x2TpKF5nJA3Z9gLdD45NZGm7nJZn8ndLaN8groZogAR9jW4y4qICkXuXz9ESYyA0JWVNLv_NsEEcaT33-hHBA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "LdhZ-vIz-I2G2dPJ3genkYhOCFJxsB3fZ_JDkm8w-94n8pAfh4CzdkiVLFJkW5xjIdcH6v-M5SyF-_4vwaXNAg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "CMXlaUloufb05e0myd4-fICnAVzCHrgJ7-mDegDHjMqSi3QuE70Gm-Muf887Rey_OHV9x7woExKQ-NpjSaa8Cg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wdZ-vcrtMLvPFnTTp1367W2i9CNq-kDLtpRJyEp4G2bf5KhdqdW_gtuYFEArtW0oGZ4-tiIErM3ng9Rvv7EjDQ"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_3/endhost/sd.toml: |
+etc/scion/sd.toml: |
   [general]
-  config_dir = "/etc/scion/gen/ISD20/ASffaa_1_3/endhost"
-  id = "sd20-ffaa_1_3"
+  config_dir = "/etc/scion"
+  id = "sd"
   reconnect_to_dispatcher = true
 
   [metrics]
@@ -530,25 +186,25 @@ gen/ISD20/ASffaa_1_3/endhost/sd.toml: |
 
   [path_db]
   backend = "sqlite"
-  connection = "/var/lib/scion/sd20-ffaa_1_3.path.db"
+  connection = "/var/lib/scion/sd.path.db"
 
   [sd]
   address = "127.0.0.1:30255"
 
   [trust_db]
   backend = "sqlite"
-  connection = "/var/lib/scion/sd20-ffaa_1_3.trust.db"
+  connection = "/var/lib/scion/sd.trust.db"
 
   [log.file]
   level = "debug"
   max_age = 3
   max_backups = 1
-  path = "/var/log/scion/sd20-ffaa_1_3.log"
-gen/ISD20/ASffaa_1_3/endhost/topology.json: |-
+  path = "/var/log/scion/sd.log"
+etc/scion/topology.json: |-
   {
     "Attributes": [],
     "BorderRouters": {
-      "br20-ffaa_1_3-1": {
+      "br-1": {
         "CtrlAddr": {
           "IPv4": {
             "Public": {
@@ -585,7 +241,7 @@ gen/ISD20/ASffaa_1_3/endhost/topology.json: |-
       }
     },
     "ControlService": {
-      "cs20-ffaa_1_3-1": {
+      "cs-1": {
         "Addrs": {
           "IPv4": {
             "Public": {
@@ -600,7 +256,7 @@ gen/ISD20/ASffaa_1_3/endhost/topology.json: |-
     "MTU": 1472,
     "Overlay": "UDP/IPv4",
     "SIG": {
-      "sig20-ffaa_1_3-1": {
+      "sig-1": {
         "Addrs": {
           "IPv4": {
             "Public": {
@@ -612,28 +268,31 @@ gen/ISD20/ASffaa_1_3/endhost/topology.json: |-
       }
     }
   }
-gen/dispatcher/disp.toml: |
-  [dispatcher]
-  id = "dispatcher"
-  socket_file_mode = "0777"
-
-  [metrics]
-  prometheus = "127.0.0.1:30441"
-
-  [log.file]
-  level = "debug"
-  max_age = 3
-  max_backups = 1
-  path = "/var/log/scion/dispatcher.log"
-gen/scionlab-config.json: |-
+scionlab-config.json: |-
   {
+    "files": {
+      "etc/scion/beacon_policy.yaml": "90c69ea879ca52546774c3007e7d29104766fc07",
+      "etc/scion/br-1.toml": "2df19de492ec1257d6cf3a244ead625c3fe3e102",
+      "etc/scion/certs/ISD17-V1.trc": "ed4f99c371b544e3bd6b4293e14396fd40b0b657",
+      "etc/scion/certs/ISD19-V1.trc": "087f805b006e0ff52e8f4fbab3dcd63d27498601",
+      "etc/scion/certs/ISD20-ASffaa_1_3-V1.crt": "2af0115f49ac6417b024c4a944877dd005bf5353",
+      "etc/scion/certs/ISD20-V1.trc": "df94e1688f2c88dd9648fa4c003f895b546467ab",
+      "etc/scion/cs-1.toml": "0c31ad123b489e233f616393faad56d4a7e93b5d",
+      "etc/scion/keys/as-decrypt-v1.key": "1b01b21751ac1fea1ba78342a7a42905b2b37415",
+      "etc/scion/keys/as-signing-v1.key": "a1385c0c78e7916d269c085a381a73af1c5c9da6",
+      "etc/scion/keys/master0.key": "dca432f9d6228867e00003bd7380db8ab712ab33",
+      "etc/scion/keys/master1.key": "dca432f9d6228867e00003bd7380db8ab712ab33",
+      "etc/scion/sd.toml": "6094e9c83d36e8ff82a188880b7612d4fb0f5c07",
+      "etc/scion/topology.json": "13667e06d06e2ca11d770d64344055048b3d6f84"
+    },
     "host_id": "b7cb55af1ecd46ea9ad668c5dc43e628",
     "host_secret": "57a080f754884125a960fcbdbe8e4e3c",
+    "systemd_units": [
+      "scion-border-router@br-1.service",
+      "scion-control-service@cs-1.service",
+      "scion-daemon@sd.service",
+      "scion-dispatcher.service"
+    ],
     "url": "http://localhost:8000",
     "version": 4
   }
-scionlab-services.txt: |-
-  scion-border-router@20-ffaa_1_3-1.service
-  scion-control-service@20-ffaa_1_3-1.service
-  scion-daemon@20-ffaa_1_3.service
-  scion-dispatcher.service

--- a/scionlab/tests/data/test_config_tar/user_as_19.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_19.yml
@@ -1,6 +1,6 @@
 README.md: |-
   content_not_checked
-client-scionlab-20-ffaa_0_1405.conf: |
+etc/openvpn/client-scionlab-20-ffaa_0_1405.conf: |
   # Specify that we are a client
   client
 
@@ -123,10 +123,13 @@ client-scionlab-20-ffaa_0_1405.conf: |
   sI7Vy6JwwTziNs9QvB1PWndRZXSWuiamODVFh8F7KYo=
   -----END RSA PRIVATE KEY-----
   </key>
-gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/br.toml: |
+etc/scion/beacon_policy.yaml: |
+  Filter:
+    AllowIsdLoop: false
+etc/scion/br-1.toml: |
   [general]
-  config_dir = "/etc/scion/gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1"
-  id = "br20-ffaa_1_4-1"
+  config_dir = "/etc/scion"
+  id = "br-1"
   reconnect_to_dispatcher = true
 
   [metrics]
@@ -136,8 +139,8 @@ gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/br.toml: |
   level = "debug"
   max_age = 3
   max_backups = 1
-  path = "/var/log/scion/br20-ffaa_1_4-1.log"
-gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/certs/ISD17-V1.trc: |-
+  path = "/var/log/scion/br-1.log"
+etc/scion/certs/ISD17-V1.trc: |-
   {
     "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
     "signatures": [
@@ -155,7 +158,7 @@ gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/certs/ISD17-V1.trc: |-
       }
     ]
   }
-gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/certs/ISD19-V1.trc: |-
+etc/scion/certs/ISD19-V1.trc: |-
   {
     "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
     "signatures": [
@@ -185,7 +188,7 @@ gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/certs/ISD19-V1.trc: |-
       }
     ]
   }
-gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/certs/ISD20-ASffaa_1_4-V1.crt: |-
+etc/scion/certs/ISD20-ASffaa_1_4-V1.crt: |-
   [
     {
       "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIlh3QjBPcDFrQTFVY0d6UHhVSWNwWDNqVmJ0eVJlNHJZMEM1bGpLK2dpNnc9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIyMC1mZmFhOjA6MTQwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
@@ -198,7 +201,7 @@ gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/certs/ISD20-ASffaa_1_4-V1.crt: |-
       "signature": "dqAaZzyA5Tuj19tlvNuc38L5W6WHtfUsH4S1gPmYpnWMonfX9CeU-liMFBuXBHZkwl0nk-hHdArd5qI21_qiDA"
     }
   ]
-gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/certs/ISD20-V1.trc: |-
+etc/scion/certs/ISD20-V1.trc: |-
   {
     "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
     "signatures": [
@@ -228,198 +231,10 @@ gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/certs/ISD20-V1.trc: |-
       }
     ]
   }
-gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/keys/as-decrypt-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: curve25519xsalsa20poly1305
-  ia: 20-ffaa:1:4
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-decrypt
-  version: 1
-
-  rvknJQGVmKK0++/hhBuyx6WyNJikmvuDHESwu50rYBU=
-  -----END PRIVATE KEY-----
-gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/keys/as-signing-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: ed25519
-  ia: 20-ffaa:1:4
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-signing
-  version: 1
-
-  ywkCHeRc0bh7URutc16VskCqfM/GOuwoj43T5RPH24I=
-  -----END PRIVATE KEY-----
-gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/keys/master0.key: |-
-  4er+YFhj8niCTvZo/mjQGQ==
-gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/keys/master1.key: |-
-  4er+YFhj8niCTvZo/mjQGQ==
-gen/ISD20/ASffaa_1_4/br20-ffaa_1_4-1/topology.json: |-
-  {
-    "Attributes": [],
-    "BorderRouters": {
-      "br20-ffaa_1_4-1": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30242
-            }
-          }
-        },
-        "Interfaces": {
-          "1": {
-            "Bandwidth": 1000,
-            "ISD_AS": "20-ffaa:0:1405",
-            "LinkTo": "PARENT",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "10.8.0.2",
-              "OverlayPort": 54321
-            },
-            "RemoteOverlay": {
-              "Addr": "10.8.0.1",
-              "OverlayPort": 50000
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30042
-            }
-          }
-        }
-      }
-    },
-    "ControlService": {
-      "cs20-ffaa_1_4-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30254
-            }
-          }
-        }
-      }
-    },
-    "ISD_AS": "20-ffaa:1:4",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4",
-    "SIG": {
-      "sig20-ffaa_1_4-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 31056
-            }
-          }
-        }
-      }
-    }
-  }
-gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/beacon_policy.yaml: |
-  Filter:
-    AllowIsdLoop: false
-gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/certs/ISD17-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "gZb3KXzvSt0UXfzOmsVkSnwRFLT0YcXoFZZvYreWtcYx_vVbhk06OThC002x4OgpK0BjBMJcrL_cn3blsh4UCQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "ePlI06GLjIBr8a28UC8MsdDi3sFZLFb0KYev7mt-aEAd-LEFKUXJcvUM9Dhz_huMkPFMJVFLZ9JffAovOZ5DDA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "G8LhE9WyxIG0N7dLtMtGeGbnGzktTd-ogguIVubgU62K-fi_U-MQRGoDVwc3OHkWEYzs3SzxPOWQy67SzsZdDA"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/certs/ISD19-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "3YGYoxPTR8jgDGadWM5ac03jNC6eIyrYVYJ3IFL_0d6ESO1eDfaWhPpEJPjni_am5DM-BGTC_6dl4IM4i58vDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "mKhwMiacq-3sJOEkkQ_e92622gR6pnFTvrI829vdoC64lkieM-18HGbJANXVmi-Bpl_CcF0uQyMSswapax23BQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "IyAgvp-9ZOHOnnVkUXMqlS22nF-KO2VYP_bXd09AONuJHsWlsGXDjoxOmH6SN2FwPpSDc_hkXuskHCUrk76HCg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "yBo9CKM5LgNk95QcjjK3UMdDVq3z0rsDIvvaWrKeWnbc1ejDpVK4IgM9hcpYLrRSt6y5sncFHw2Q1wTTlhSrDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "S0jmllXbdZL-1HQmT0C_29zIyuGnA03nKv2CiLpoeccWJN9sCoBc9AG9SaZQzasvJvEE7JNAHxrpNjB_j6bQCw"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wV0ZrVAXx88EUvIuk673MJLIAXcqQ-iV4vCCH50LCs0tLx65cI7ps6a31PSgIAnbp3SEg1VerkhUxJTxzyhzAg"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/certs/ISD20-ASffaa_1_4-V1.crt: |-
-  [
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIlh3QjBPcDFrQTFVY0d6UHhVSWNwWDNqVmJ0eVJlNHJZMEM1bGpLK2dpNnc9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIyMC1mZmFhOjA6MTQwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjcml0IjogWyJ0eXBlIiwgInRyY192ZXJzaW9uIl0sICJ0cmNfdmVyc2lvbiI6IDEsICJ0eXBlIjogInRyYyJ9",
-      "signature": "Crzhv-xjoP_I2tka2vP7EvlyFfy8kku9yYTMX94oWxypOrHx_hWmD8hBCDFl81lonL49Z2v-AnCebH42KMZLCQ"
-    },
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImFzIiwgImRlc2NyaXB0aW9uIjogIkFTIGNlcnRpZmljYXRlIiwgImZvcm1hdF92ZXJzaW9uIjogMSwgImlzc3VlciI6IHsiY2VydGlmaWNhdGVfdmVyc2lvbiI6IDEsICJpc2RfYXMiOiAiMjAtZmZhYTowOjE0MDEifSwgImtleXMiOiB7ImVuY3J5cHRpb24iOiB7ImFsZ29yaXRobSI6ICJjdXJ2ZTI1NTE5IiwgImtleSI6ICJwQk9wU0JMUm1rTVcraTBQSVM5T2R1eEV5alBPb285aTFGdmduNEdyRTBFPSIsICJrZXlfdmVyc2lvbiI6IDF9LCAic2lnbmluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIkJmSWxCUzk0OURzOHdkV3pHRGV4dGVZckVGblRHeUcybm8rL0RVYkN0TGs9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIyMC1mZmFhOjE6NCIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYwMTU1MDQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjZXJ0aWZpY2F0ZV92ZXJzaW9uIjogMSwgImNyaXQiOiBbInR5cGUiLCAiY2VydGlmaWNhdGVfdmVyc2lvbiIsICJpc2RfYXMiXSwgImlzZF9hcyI6ICIyMC1mZmFhOjA6MTQwMSIsICJ0eXBlIjogImNlcnRpZmljYXRlIn0",
-      "signature": "dqAaZzyA5Tuj19tlvNuc38L5W6WHtfUsH4S1gPmYpnWMonfX9CeU-liMFBuXBHZkwl0nk-hHdArd5qI21_qiDA"
-    }
-  ]
-gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/certs/ISD20-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "lMflSxDL23pPZdxm4kCQrrExtho-3qWjBUGtFR9DCyADGjuhBBvJhUYXKCQgJmZwZKQ6sNvZhQrN650H7pXIAQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "IEQs-UKm_a0azRdYCBKgfytqLPKkC-KicEn8WyGNj_nJEpc6il5SvfUJkfv1TAUu2m5TK3Cwi_06dlKaOuacDQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "5x2TpKF5nJA3Z9gLdD45NZGm7nJZn8ndLaN8groZogAR9jW4y4qICkXuXz9ESYyA0JWVNLv_NsEEcaT33-hHBA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "LdhZ-vIz-I2G2dPJ3genkYhOCFJxsB3fZ_JDkm8w-94n8pAfh4CzdkiVLFJkW5xjIdcH6v-M5SyF-_4vwaXNAg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "CMXlaUloufb05e0myd4-fICnAVzCHrgJ7-mDegDHjMqSi3QuE70Gm-Muf887Rey_OHV9x7woExKQ-NpjSaa8Cg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wdZ-vcrtMLvPFnTTp1367W2i9CNq-kDLtpRJyEp4G2bf5KhdqdW_gtuYFEArtW0oGZ4-tiIErM3ng9Rvv7EjDQ"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/cs.toml: |
+etc/scion/cs-1.toml: |
   [beacon_db]
   backend = "sqlite"
-  connection = "/var/lib/scion/cs20-ffaa_1_4-1.beacon.db"
+  connection = "/var/lib/scion/cs-1.beacon.db"
 
   [beaconing]
   origination_interval = "5s"
@@ -428,8 +243,8 @@ gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/cs.toml: |
   rev_ttl = "20s"
 
   [general]
-  config_dir = "/etc/scion/gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1"
-  id = "cs20-ffaa_1_4-1"
+  config_dir = "/etc/scion"
+  id = "cs-1"
   reconnect_to_dispatcher = true
 
   [metrics]
@@ -437,7 +252,7 @@ gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/cs.toml: |
 
   [path_db]
   backend = "sqlite"
-  connection = "/var/lib/scion/cs20-ffaa_1_4-1.path.db"
+  connection = "/var/lib/scion/cs-1.path.db"
 
   [quic]
   address = "127.0.0.1:30354"
@@ -447,17 +262,17 @@ gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/cs.toml: |
 
   [trust_db]
   backend = "sqlite"
-  connection = "/var/lib/scion/cs20-ffaa_1_4-1.trust.db"
+  connection = "/var/lib/scion/cs-1.trust.db"
 
   [beaconing.policies]
-  Propagation = "/etc/scion/gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/beacon_policy.yaml"
+  Propagation = "/etc/scion/beacon_policy.yaml"
 
   [log.file]
   level = "debug"
   max_age = 3
   max_backups = 1
-  path = "/var/log/scion/cs20-ffaa_1_4-1.log"
-gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/keys/as-decrypt-v1.key: |
+  path = "/var/log/scion/cs-1.log"
+etc/scion/keys/as-decrypt-v1.key: |
   -----BEGIN PRIVATE KEY-----
   algorithm: curve25519xsalsa20poly1305
   ia: 20-ffaa:1:4
@@ -468,7 +283,7 @@ gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/keys/as-decrypt-v1.key: |
 
   rvknJQGVmKK0++/hhBuyx6WyNJikmvuDHESwu50rYBU=
   -----END PRIVATE KEY-----
-gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/keys/as-signing-v1.key: |
+etc/scion/keys/as-signing-v1.key: |
   -----BEGIN PRIVATE KEY-----
   algorithm: ed25519
   ia: 20-ffaa:1:4
@@ -479,173 +294,14 @@ gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/keys/as-signing-v1.key: |
 
   ywkCHeRc0bh7URutc16VskCqfM/GOuwoj43T5RPH24I=
   -----END PRIVATE KEY-----
-gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/keys/master0.key: |-
+etc/scion/keys/master0.key: |-
   4er+YFhj8niCTvZo/mjQGQ==
-gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/keys/master1.key: |-
+etc/scion/keys/master1.key: |-
   4er+YFhj8niCTvZo/mjQGQ==
-gen/ISD20/ASffaa_1_4/cs20-ffaa_1_4-1/topology.json: |-
-  {
-    "Attributes": [],
-    "BorderRouters": {
-      "br20-ffaa_1_4-1": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30242
-            }
-          }
-        },
-        "Interfaces": {
-          "1": {
-            "Bandwidth": 1000,
-            "ISD_AS": "20-ffaa:0:1405",
-            "LinkTo": "PARENT",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "10.8.0.2",
-              "OverlayPort": 54321
-            },
-            "RemoteOverlay": {
-              "Addr": "10.8.0.1",
-              "OverlayPort": 50000
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30042
-            }
-          }
-        }
-      }
-    },
-    "ControlService": {
-      "cs20-ffaa_1_4-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30254
-            }
-          }
-        }
-      }
-    },
-    "ISD_AS": "20-ffaa:1:4",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4",
-    "SIG": {
-      "sig20-ffaa_1_4-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 31056
-            }
-          }
-        }
-      }
-    }
-  }
-gen/ISD20/ASffaa_1_4/endhost/certs/ISD17-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "gZb3KXzvSt0UXfzOmsVkSnwRFLT0YcXoFZZvYreWtcYx_vVbhk06OThC002x4OgpK0BjBMJcrL_cn3blsh4UCQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "ePlI06GLjIBr8a28UC8MsdDi3sFZLFb0KYev7mt-aEAd-LEFKUXJcvUM9Dhz_huMkPFMJVFLZ9JffAovOZ5DDA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "G8LhE9WyxIG0N7dLtMtGeGbnGzktTd-ogguIVubgU62K-fi_U-MQRGoDVwc3OHkWEYzs3SzxPOWQy67SzsZdDA"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_4/endhost/certs/ISD19-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "3YGYoxPTR8jgDGadWM5ac03jNC6eIyrYVYJ3IFL_0d6ESO1eDfaWhPpEJPjni_am5DM-BGTC_6dl4IM4i58vDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "mKhwMiacq-3sJOEkkQ_e92622gR6pnFTvrI829vdoC64lkieM-18HGbJANXVmi-Bpl_CcF0uQyMSswapax23BQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "IyAgvp-9ZOHOnnVkUXMqlS22nF-KO2VYP_bXd09AONuJHsWlsGXDjoxOmH6SN2FwPpSDc_hkXuskHCUrk76HCg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "yBo9CKM5LgNk95QcjjK3UMdDVq3z0rsDIvvaWrKeWnbc1ejDpVK4IgM9hcpYLrRSt6y5sncFHw2Q1wTTlhSrDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "S0jmllXbdZL-1HQmT0C_29zIyuGnA03nKv2CiLpoeccWJN9sCoBc9AG9SaZQzasvJvEE7JNAHxrpNjB_j6bQCw"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wV0ZrVAXx88EUvIuk673MJLIAXcqQ-iV4vCCH50LCs0tLx65cI7ps6a31PSgIAnbp3SEg1VerkhUxJTxzyhzAg"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_4/endhost/certs/ISD20-ASffaa_1_4-V1.crt: |-
-  [
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIlh3QjBPcDFrQTFVY0d6UHhVSWNwWDNqVmJ0eVJlNHJZMEM1bGpLK2dpNnc9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIyMC1mZmFhOjA6MTQwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjcml0IjogWyJ0eXBlIiwgInRyY192ZXJzaW9uIl0sICJ0cmNfdmVyc2lvbiI6IDEsICJ0eXBlIjogInRyYyJ9",
-      "signature": "Crzhv-xjoP_I2tka2vP7EvlyFfy8kku9yYTMX94oWxypOrHx_hWmD8hBCDFl81lonL49Z2v-AnCebH42KMZLCQ"
-    },
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImFzIiwgImRlc2NyaXB0aW9uIjogIkFTIGNlcnRpZmljYXRlIiwgImZvcm1hdF92ZXJzaW9uIjogMSwgImlzc3VlciI6IHsiY2VydGlmaWNhdGVfdmVyc2lvbiI6IDEsICJpc2RfYXMiOiAiMjAtZmZhYTowOjE0MDEifSwgImtleXMiOiB7ImVuY3J5cHRpb24iOiB7ImFsZ29yaXRobSI6ICJjdXJ2ZTI1NTE5IiwgImtleSI6ICJwQk9wU0JMUm1rTVcraTBQSVM5T2R1eEV5alBPb285aTFGdmduNEdyRTBFPSIsICJrZXlfdmVyc2lvbiI6IDF9LCAic2lnbmluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIkJmSWxCUzk0OURzOHdkV3pHRGV4dGVZckVGblRHeUcybm8rL0RVYkN0TGs9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIyMC1mZmFhOjE6NCIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYwMTU1MDQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjZXJ0aWZpY2F0ZV92ZXJzaW9uIjogMSwgImNyaXQiOiBbInR5cGUiLCAiY2VydGlmaWNhdGVfdmVyc2lvbiIsICJpc2RfYXMiXSwgImlzZF9hcyI6ICIyMC1mZmFhOjA6MTQwMSIsICJ0eXBlIjogImNlcnRpZmljYXRlIn0",
-      "signature": "dqAaZzyA5Tuj19tlvNuc38L5W6WHtfUsH4S1gPmYpnWMonfX9CeU-liMFBuXBHZkwl0nk-hHdArd5qI21_qiDA"
-    }
-  ]
-gen/ISD20/ASffaa_1_4/endhost/certs/ISD20-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "lMflSxDL23pPZdxm4kCQrrExtho-3qWjBUGtFR9DCyADGjuhBBvJhUYXKCQgJmZwZKQ6sNvZhQrN650H7pXIAQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "IEQs-UKm_a0azRdYCBKgfytqLPKkC-KicEn8WyGNj_nJEpc6il5SvfUJkfv1TAUu2m5TK3Cwi_06dlKaOuacDQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "5x2TpKF5nJA3Z9gLdD45NZGm7nJZn8ndLaN8groZogAR9jW4y4qICkXuXz9ESYyA0JWVNLv_NsEEcaT33-hHBA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "LdhZ-vIz-I2G2dPJ3genkYhOCFJxsB3fZ_JDkm8w-94n8pAfh4CzdkiVLFJkW5xjIdcH6v-M5SyF-_4vwaXNAg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "CMXlaUloufb05e0myd4-fICnAVzCHrgJ7-mDegDHjMqSi3QuE70Gm-Muf887Rey_OHV9x7woExKQ-NpjSaa8Cg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wdZ-vcrtMLvPFnTTp1367W2i9CNq-kDLtpRJyEp4G2bf5KhdqdW_gtuYFEArtW0oGZ4-tiIErM3ng9Rvv7EjDQ"
-      }
-    ]
-  }
-gen/ISD20/ASffaa_1_4/endhost/sd.toml: |
+etc/scion/sd.toml: |
   [general]
-  config_dir = "/etc/scion/gen/ISD20/ASffaa_1_4/endhost"
-  id = "sd20-ffaa_1_4"
+  config_dir = "/etc/scion"
+  id = "sd"
   reconnect_to_dispatcher = true
 
   [metrics]
@@ -653,25 +309,25 @@ gen/ISD20/ASffaa_1_4/endhost/sd.toml: |
 
   [path_db]
   backend = "sqlite"
-  connection = "/var/lib/scion/sd20-ffaa_1_4.path.db"
+  connection = "/var/lib/scion/sd.path.db"
 
   [sd]
   address = "127.0.0.1:30255"
 
   [trust_db]
   backend = "sqlite"
-  connection = "/var/lib/scion/sd20-ffaa_1_4.trust.db"
+  connection = "/var/lib/scion/sd.trust.db"
 
   [log.file]
   level = "debug"
   max_age = 3
   max_backups = 1
-  path = "/var/log/scion/sd20-ffaa_1_4.log"
-gen/ISD20/ASffaa_1_4/endhost/topology.json: |-
+  path = "/var/log/scion/sd.log"
+etc/scion/topology.json: |-
   {
     "Attributes": [],
     "BorderRouters": {
-      "br20-ffaa_1_4-1": {
+      "br-1": {
         "CtrlAddr": {
           "IPv4": {
             "Public": {
@@ -708,7 +364,7 @@ gen/ISD20/ASffaa_1_4/endhost/topology.json: |-
       }
     },
     "ControlService": {
-      "cs20-ffaa_1_4-1": {
+      "cs-1": {
         "Addrs": {
           "IPv4": {
             "Public": {
@@ -723,7 +379,7 @@ gen/ISD20/ASffaa_1_4/endhost/topology.json: |-
     "MTU": 1472,
     "Overlay": "UDP/IPv4",
     "SIG": {
-      "sig20-ffaa_1_4-1": {
+      "sig-1": {
         "Addrs": {
           "IPv4": {
             "Public": {
@@ -735,28 +391,32 @@ gen/ISD20/ASffaa_1_4/endhost/topology.json: |-
       }
     }
   }
-gen/dispatcher/disp.toml: |
-  [dispatcher]
-  id = "dispatcher"
-  socket_file_mode = "0777"
-
-  [metrics]
-  prometheus = "127.0.0.1:30441"
-
-  [log.file]
-  level = "debug"
-  max_age = 3
-  max_backups = 1
-  path = "/var/log/scion/dispatcher.log"
-gen/scionlab-config.json: |-
+scionlab-config.json: |-
   {
+    "files": {
+      "etc/openvpn/client-scionlab-20-ffaa_0_1405.conf": "d9d03ec80b7465bae05a457ec6ff55510e8f4b79",
+      "etc/scion/beacon_policy.yaml": "90c69ea879ca52546774c3007e7d29104766fc07",
+      "etc/scion/br-1.toml": "2df19de492ec1257d6cf3a244ead625c3fe3e102",
+      "etc/scion/certs/ISD17-V1.trc": "ed4f99c371b544e3bd6b4293e14396fd40b0b657",
+      "etc/scion/certs/ISD19-V1.trc": "087f805b006e0ff52e8f4fbab3dcd63d27498601",
+      "etc/scion/certs/ISD20-ASffaa_1_4-V1.crt": "1799bdca88bd6b234ba89d9c36c165723a3d0b44",
+      "etc/scion/certs/ISD20-V1.trc": "df94e1688f2c88dd9648fa4c003f895b546467ab",
+      "etc/scion/cs-1.toml": "0c31ad123b489e233f616393faad56d4a7e93b5d",
+      "etc/scion/keys/as-decrypt-v1.key": "79ecc7ab4432846f70b211b23910d3633fc3a73e",
+      "etc/scion/keys/as-signing-v1.key": "aa1296b528c8d1eed3eadcbf6a1cb9e70f2ede35",
+      "etc/scion/keys/master0.key": "25d839bcbd879e65f9d0f2e8bbd53dcdf80fdba7",
+      "etc/scion/keys/master1.key": "25d839bcbd879e65f9d0f2e8bbd53dcdf80fdba7",
+      "etc/scion/sd.toml": "6094e9c83d36e8ff82a188880b7612d4fb0f5c07",
+      "etc/scion/topology.json": "7e8b3f08c3184337ba9b5b59e4f26ddf67982d62"
+    },
     "host_id": "ebe22b06d3a4492aa0fe84689ba93570",
     "host_secret": "b5af6743059642eba32be270900dea60",
+    "systemd_units": [
+      "scion-border-router@br-1.service",
+      "scion-control-service@cs-1.service",
+      "scion-daemon@sd.service",
+      "scion-dispatcher.service"
+    ],
     "url": "http://localhost:8000",
     "version": 5
   }
-scionlab-services.txt: |-
-  scion-border-router@20-ffaa_1_4-1.service
-  scion-control-service@20-ffaa_1_4-1.service
-  scion-daemon@20-ffaa_1_4.service
-  scion-dispatcher.service

--- a/scionlab/tests/data/test_config_tar/user_as_20.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_20.yml
@@ -1,9 +1,12 @@
 README.md: |-
   content_not_checked
-gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/br.toml: |
+gen/ASffaa_1_5/beacon_policy.yaml: |
+  Filter:
+    AllowIsdLoop: false
+gen/ASffaa_1_5/br-1.toml: |
   [general]
-  config_dir = "gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1"
-  id = "br17-ffaa_1_5-1"
+  config_dir = "gen/ASffaa_1_5"
+  id = "br-1"
   reconnect_to_dispatcher = true
 
   [metrics]
@@ -13,8 +16,8 @@ gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/br.toml: |
   level = "debug"
   max_age = 3
   max_backups = 1
-  path = "logs/br17-ffaa_1_5-1.log"
-gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/certs/ISD17-ASffaa_1_5-V1.crt: |-
+  path = "logs/br-1.log"
+gen/ASffaa_1_5/certs/ISD17-ASffaa_1_5-V1.crt: |-
   [
     {
       "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIklsOGRqbHVkRXEyazRHNGxxY2gwWUZibmk2ZnF1MllId0p1YWUzTmJHN0k9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
@@ -27,7 +30,7 @@ gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/certs/ISD17-ASffaa_1_5-V1.crt: |-
       "signature": "cIeg8fYNYGq_kszOW5fMDaEgiPzJlllmrnG0B7BDSkeS7XOdEnMTQgsK5xlcJ63_FTlBLL2DBJyJw44seI34Bw"
     }
   ]
-gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/certs/ISD17-V1.trc: |-
+gen/ASffaa_1_5/certs/ISD17-V1.trc: |-
   {
     "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
     "signatures": [
@@ -45,7 +48,7 @@ gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/certs/ISD17-V1.trc: |-
       }
     ]
   }
-gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/certs/ISD19-V1.trc: |-
+gen/ASffaa_1_5/certs/ISD19-V1.trc: |-
   {
     "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
     "signatures": [
@@ -75,7 +78,7 @@ gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/certs/ISD19-V1.trc: |-
       }
     ]
   }
-gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/certs/ISD20-V1.trc: |-
+gen/ASffaa_1_5/certs/ISD20-V1.trc: |-
   {
     "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
     "signatures": [
@@ -105,210 +108,10 @@ gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/certs/ISD20-V1.trc: |-
       }
     ]
   }
-gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/keys/as-decrypt-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: curve25519xsalsa20poly1305
-  ia: 17-ffaa:1:5
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-decrypt
-  version: 1
-
-  EfYRemSQ82iOF0N7OtAcSyRczxgjqN0O0qojlo8yAQg=
-  -----END PRIVATE KEY-----
-gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/keys/as-signing-v1.key: |
-  -----BEGIN PRIVATE KEY-----
-  algorithm: ed25519
-  ia: 17-ffaa:1:5
-  not_after: 2019-10-02 11:07:41+0000
-  not_before: 2020-10-01 11:07:41+0000
-  usage: as-signing
-  version: 1
-
-  3GeOs8GafbawG+55j1jfx1ffGK8BPTp/1vtPRjkCflo=
-  -----END PRIVATE KEY-----
-gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/keys/master0.key: |-
-  pWR5Qy46il0oTdqb1OokdA==
-gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/keys/master1.key: |-
-  pWR5Qy46il0oTdqb1OokdA==
-gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/supervisord.conf: |+
-  [program:br17-ffaa_1_5-1]
-  autostart = false
-  autorestart = true
-  environment = TZ=UTC,GODEBUG="cgocheck=0"
-  stdout_logfile = logs/br17-ffaa_1_5-1.OUT
-  stderr_logfile = logs/br17-ffaa_1_5-1.ERR
-  startretries = 0
-  startsecs = 5
-  priority = 100
-  command = bin/border -config gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/br.toml
-
-gen/ISD17/ASffaa_1_5/br17-ffaa_1_5-1/topology.json: |-
-  {
-    "Attributes": [],
-    "BorderRouters": {
-      "br17-ffaa_1_5-1": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30242
-            }
-          }
-        },
-        "Interfaces": {
-          "1": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:0:1107",
-            "LinkTo": "PARENT",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "172.31.0.200",
-              "OverlayPort": 54321
-            },
-            "RemoteOverlay": {
-              "Addr": "192.0.2.17",
-              "OverlayPort": 50001
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30042
-            }
-          }
-        }
-      }
-    },
-    "ControlService": {
-      "cs17-ffaa_1_5-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30254
-            }
-          }
-        }
-      }
-    },
-    "ISD_AS": "17-ffaa:1:5",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4",
-    "SIG": {
-      "sig17-ffaa_1_5-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 31056
-            }
-          }
-        }
-      }
-    }
-  }
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/beacon_policy.yaml: |
-  Filter:
-    AllowIsdLoop: false
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/certs/ISD17-ASffaa_1_5-V1.crt: |-
-  [
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIklsOGRqbHVkRXEyazRHNGxxY2gwWUZibmk2ZnF1MllId0p1YWUzTmJHN0k9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjcml0IjogWyJ0eXBlIiwgInRyY192ZXJzaW9uIl0sICJ0cmNfdmVyc2lvbiI6IDEsICJ0eXBlIjogInRyYyJ9",
-      "signature": "w21oYonO1a92V7P9ypwkuVPBEH6NFCMseMkgYemgeCOvvtYRa_y0PKj7q7PJapJluUyJ35FNhzWmVxsmVrsYDg"
-    },
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImFzIiwgImRlc2NyaXB0aW9uIjogIkFTIGNlcnRpZmljYXRlIiwgImZvcm1hdF92ZXJzaW9uIjogMSwgImlzc3VlciI6IHsiY2VydGlmaWNhdGVfdmVyc2lvbiI6IDEsICJpc2RfYXMiOiAiMTctZmZhYTowOjExMDEifSwgImtleXMiOiB7ImVuY3J5cHRpb24iOiB7ImFsZ29yaXRobSI6ICJjdXJ2ZTI1NTE5IiwgImtleSI6ICI4TGx0Tk1PdVNmRW4ydVE4NjRtM2NqdCtienc0TzZqQ0ZHNE5yRnFpYWdJPSIsICJrZXlfdmVyc2lvbiI6IDF9LCAic2lnbmluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIjhJUXVXeU5pZ3pXWmxJTTZpMnZ1bEdwOGJsS1RuN1IxVEhsTkVBOWFpTE09IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjE6NSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYwMTU1MDQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjZXJ0aWZpY2F0ZV92ZXJzaW9uIjogMSwgImNyaXQiOiBbInR5cGUiLCAiY2VydGlmaWNhdGVfdmVyc2lvbiIsICJpc2RfYXMiXSwgImlzZF9hcyI6ICIxNy1mZmFhOjA6MTEwMSIsICJ0eXBlIjogImNlcnRpZmljYXRlIn0",
-      "signature": "cIeg8fYNYGq_kszOW5fMDaEgiPzJlllmrnG0B7BDSkeS7XOdEnMTQgsK5xlcJ63_FTlBLL2DBJyJw44seI34Bw"
-    }
-  ]
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/certs/ISD17-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "gZb3KXzvSt0UXfzOmsVkSnwRFLT0YcXoFZZvYreWtcYx_vVbhk06OThC002x4OgpK0BjBMJcrL_cn3blsh4UCQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "ePlI06GLjIBr8a28UC8MsdDi3sFZLFb0KYev7mt-aEAd-LEFKUXJcvUM9Dhz_huMkPFMJVFLZ9JffAovOZ5DDA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "G8LhE9WyxIG0N7dLtMtGeGbnGzktTd-ogguIVubgU62K-fi_U-MQRGoDVwc3OHkWEYzs3SzxPOWQy67SzsZdDA"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/certs/ISD19-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "3YGYoxPTR8jgDGadWM5ac03jNC6eIyrYVYJ3IFL_0d6ESO1eDfaWhPpEJPjni_am5DM-BGTC_6dl4IM4i58vDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "mKhwMiacq-3sJOEkkQ_e92622gR6pnFTvrI829vdoC64lkieM-18HGbJANXVmi-Bpl_CcF0uQyMSswapax23BQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "IyAgvp-9ZOHOnnVkUXMqlS22nF-KO2VYP_bXd09AONuJHsWlsGXDjoxOmH6SN2FwPpSDc_hkXuskHCUrk76HCg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "yBo9CKM5LgNk95QcjjK3UMdDVq3z0rsDIvvaWrKeWnbc1ejDpVK4IgM9hcpYLrRSt6y5sncFHw2Q1wTTlhSrDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "S0jmllXbdZL-1HQmT0C_29zIyuGnA03nKv2CiLpoeccWJN9sCoBc9AG9SaZQzasvJvEE7JNAHxrpNjB_j6bQCw"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wV0ZrVAXx88EUvIuk673MJLIAXcqQ-iV4vCCH50LCs0tLx65cI7ps6a31PSgIAnbp3SEg1VerkhUxJTxzyhzAg"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/certs/ISD20-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "lMflSxDL23pPZdxm4kCQrrExtho-3qWjBUGtFR9DCyADGjuhBBvJhUYXKCQgJmZwZKQ6sNvZhQrN650H7pXIAQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "IEQs-UKm_a0azRdYCBKgfytqLPKkC-KicEn8WyGNj_nJEpc6il5SvfUJkfv1TAUu2m5TK3Cwi_06dlKaOuacDQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "5x2TpKF5nJA3Z9gLdD45NZGm7nJZn8ndLaN8groZogAR9jW4y4qICkXuXz9ESYyA0JWVNLv_NsEEcaT33-hHBA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "LdhZ-vIz-I2G2dPJ3genkYhOCFJxsB3fZ_JDkm8w-94n8pAfh4CzdkiVLFJkW5xjIdcH6v-M5SyF-_4vwaXNAg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "CMXlaUloufb05e0myd4-fICnAVzCHrgJ7-mDegDHjMqSi3QuE70Gm-Muf887Rey_OHV9x7woExKQ-NpjSaa8Cg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wdZ-vcrtMLvPFnTTp1367W2i9CNq-kDLtpRJyEp4G2bf5KhdqdW_gtuYFEArtW0oGZ4-tiIErM3ng9Rvv7EjDQ"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/cs.toml: |
+gen/ASffaa_1_5/cs-1.toml: |
   [beacon_db]
   backend = "sqlite"
-  connection = "gen-cache/cs17-ffaa_1_5-1.beacon.db"
+  connection = "gen-cache/cs-1.beacon.db"
 
   [beaconing]
   origination_interval = "5s"
@@ -317,8 +120,8 @@ gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/cs.toml: |
   rev_ttl = "20s"
 
   [general]
-  config_dir = "gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1"
-  id = "cs17-ffaa_1_5-1"
+  config_dir = "gen/ASffaa_1_5"
+  id = "cs-1"
   reconnect_to_dispatcher = true
 
   [metrics]
@@ -326,7 +129,7 @@ gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/cs.toml: |
 
   [path_db]
   backend = "sqlite"
-  connection = "gen-cache/cs17-ffaa_1_5-1.path.db"
+  connection = "gen-cache/cs-1.path.db"
 
   [quic]
   address = "127.0.0.1:30354"
@@ -336,17 +139,17 @@ gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/cs.toml: |
 
   [trust_db]
   backend = "sqlite"
-  connection = "gen-cache/cs17-ffaa_1_5-1.trust.db"
+  connection = "gen-cache/cs-1.trust.db"
 
   [beaconing.policies]
-  Propagation = "gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/beacon_policy.yaml"
+  Propagation = "gen/ASffaa_1_5/beacon_policy.yaml"
 
   [log.file]
   level = "debug"
   max_age = 3
   max_backups = 1
-  path = "logs/cs17-ffaa_1_5-1.log"
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/keys/as-decrypt-v1.key: |
+  path = "logs/cs-1.log"
+gen/ASffaa_1_5/keys/as-decrypt-v1.key: |
   -----BEGIN PRIVATE KEY-----
   algorithm: curve25519xsalsa20poly1305
   ia: 17-ffaa:1:5
@@ -357,7 +160,7 @@ gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/keys/as-decrypt-v1.key: |
 
   EfYRemSQ82iOF0N7OtAcSyRczxgjqN0O0qojlo8yAQg=
   -----END PRIVATE KEY-----
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/keys/as-signing-v1.key: |
+gen/ASffaa_1_5/keys/as-signing-v1.key: |
   -----BEGIN PRIVATE KEY-----
   algorithm: ed25519
   ia: 17-ffaa:1:5
@@ -368,185 +171,14 @@ gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/keys/as-signing-v1.key: |
 
   3GeOs8GafbawG+55j1jfx1ffGK8BPTp/1vtPRjkCflo=
   -----END PRIVATE KEY-----
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/keys/master0.key: |-
+gen/ASffaa_1_5/keys/master0.key: |-
   pWR5Qy46il0oTdqb1OokdA==
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/keys/master1.key: |-
+gen/ASffaa_1_5/keys/master1.key: |-
   pWR5Qy46il0oTdqb1OokdA==
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/supervisord.conf: |+
-  [program:cs17-ffaa_1_5-1]
-  autostart = false
-  autorestart = true
-  environment = TZ=UTC
-  stdout_logfile = logs/cs17-ffaa_1_5-1.OUT
-  stderr_logfile = logs/cs17-ffaa_1_5-1.ERR
-  startretries = 0
-  startsecs = 5
-  priority = 100
-  command = bin/cs -config gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/cs.toml
-
-gen/ISD17/ASffaa_1_5/cs17-ffaa_1_5-1/topology.json: |-
-  {
-    "Attributes": [],
-    "BorderRouters": {
-      "br17-ffaa_1_5-1": {
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30242
-            }
-          }
-        },
-        "Interfaces": {
-          "1": {
-            "Bandwidth": 1000,
-            "ISD_AS": "17-ffaa:0:1107",
-            "LinkTo": "PARENT",
-            "MTU": 1472,
-            "Overlay": "UDP/IPv4",
-            "PublicOverlay": {
-              "Addr": "172.31.0.200",
-              "OverlayPort": 54321
-            },
-            "RemoteOverlay": {
-              "Addr": "192.0.2.17",
-              "OverlayPort": 50001
-            }
-          }
-        },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "Addr": "127.0.0.1",
-              "OverlayPort": 30042
-            }
-          }
-        }
-      }
-    },
-    "ControlService": {
-      "cs17-ffaa_1_5-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 30254
-            }
-          }
-        }
-      }
-    },
-    "ISD_AS": "17-ffaa:1:5",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4",
-    "SIG": {
-      "sig17-ffaa_1_5-1": {
-        "Addrs": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.1",
-              "L4Port": 31056
-            }
-          }
-        }
-      }
-    }
-  }
-gen/ISD17/ASffaa_1_5/endhost/certs/ISD17-ASffaa_1_5-V1.crt: |-
-  [
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImlzc3VlciIsICJkZXNjcmlwdGlvbiI6ICJJc3N1ZXIgY2VydGlmaWNhdGUiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiaXNzdWVyIjogeyJ0cmNfdmVyc2lvbiI6IDF9LCAia2V5cyI6IHsiaXNzdWluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIklsOGRqbHVkRXEyazRHNGxxY2gwWUZibmk2ZnF1MllId0p1YWUzTmJHN0k9IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjA6MTEwMSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYzMzA4NjQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjcml0IjogWyJ0eXBlIiwgInRyY192ZXJzaW9uIl0sICJ0cmNfdmVyc2lvbiI6IDEsICJ0eXBlIjogInRyYyJ9",
-      "signature": "w21oYonO1a92V7P9ypwkuVPBEH6NFCMseMkgYemgeCOvvtYRa_y0PKj7q7PJapJluUyJ35FNhzWmVxsmVrsYDg"
-    },
-    {
-      "payload": "eyJjZXJ0aWZpY2F0ZV90eXBlIjogImFzIiwgImRlc2NyaXB0aW9uIjogIkFTIGNlcnRpZmljYXRlIiwgImZvcm1hdF92ZXJzaW9uIjogMSwgImlzc3VlciI6IHsiY2VydGlmaWNhdGVfdmVyc2lvbiI6IDEsICJpc2RfYXMiOiAiMTctZmZhYTowOjExMDEifSwgImtleXMiOiB7ImVuY3J5cHRpb24iOiB7ImFsZ29yaXRobSI6ICJjdXJ2ZTI1NTE5IiwgImtleSI6ICI4TGx0Tk1PdVNmRW4ydVE4NjRtM2NqdCtienc0TzZqQ0ZHNE5yRnFpYWdJPSIsICJrZXlfdmVyc2lvbiI6IDF9LCAic2lnbmluZyI6IHsiYWxnb3JpdGhtIjogIkVkMjU1MTkiLCAia2V5IjogIjhJUXVXeU5pZ3pXWmxJTTZpMnZ1bEdwOGJsS1RuN1IxVEhsTkVBOWFpTE09IiwgImtleV92ZXJzaW9uIjogMX19LCAib3B0aW9uYWxfZGlzdHJpYnV0aW9uX3BvaW50cyI6IFtdLCAic3ViamVjdCI6ICIxNy1mZmFhOjE6NSIsICJ2YWxpZGl0eSI6IHsibm90X2FmdGVyIjogMTYwMTU1MDQ2MSwgIm5vdF9iZWZvcmUiOiAxNTcwMDE0NDYxfSwgInZlcnNpb24iOiAxfQ",
-      "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJjZXJ0aWZpY2F0ZV92ZXJzaW9uIjogMSwgImNyaXQiOiBbInR5cGUiLCAiY2VydGlmaWNhdGVfdmVyc2lvbiIsICJpc2RfYXMiXSwgImlzZF9hcyI6ICIxNy1mZmFhOjA6MTEwMSIsICJ0eXBlIjogImNlcnRpZmljYXRlIn0",
-      "signature": "cIeg8fYNYGq_kszOW5fMDaEgiPzJlllmrnG0B7BDSkeS7XOdEnMTQgsK5xlcJ63_FTlBLL2DBJyJw44seI34Bw"
-    }
-  ]
-gen/ISD17/ASffaa_1_5/endhost/certs/ISD17-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE3IChTd2l0emVybGFuZCkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE3LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTEwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWHpIUlF3WHJqMm5JNzNJZkhqRlFPeEhadlNNN1N3VG05N1ZuN05pK1ZIdz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiWlorODVGMGtrZTNTRm91Q2VORW1KQWFKUisvL2w0WGRQVGJNKzZBSVM1UT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiMW8rL3RMTmZDMCsyNDlQamppUm9IdWdGRnRnN0hwbmIwQzh0M29HRURjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjExMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAxfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "gZb3KXzvSt0UXfzOmsVkSnwRFLT0YcXoFZZvYreWtcYx_vVbhk06OThC002x4OgpK0BjBMJcrL_cn3blsh4UCQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "ePlI06GLjIBr8a28UC8MsdDi3sFZLFb0KYev7mt-aEAd-LEFKUXJcvUM9Dhz_huMkPFMJVFLZ9JffAovOZ5DDA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTEwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "G8LhE9WyxIG0N7dLtMtGeGbnGzktTd-ogguIVubgU62K-fi_U-MQRGoDVwc3OHkWEYzs3SzxPOWQy67SzsZdDA"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_1_5/endhost/certs/ISD19-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDE5IChFVSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDE5LCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTMwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiTWg2UlpOaXZVREdzQlUvR2RjYkRkUkJjeTh6VmtyMDRUV214OW5zT2NiZz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZmRpbC8yakVScEtacEVvVDgzaEpYdXhpWk94SmpkTzAyd1dFTnpqU0lIST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJuS2VjY0FZTEVaV3FxVlBSN3I1OTdoQjhDWUs1YzRGMXJ1YkliTkxxNzhrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTMwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiMVVJcVFpS0JHTWdVQWEzeS9uVTdDbEhFQURYdFJWZjRMWDd2OXJJeHRMRT0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAidVFDYkZyaHdNQTA2em5MZEVkbGNrMm5JN2NMaHAwZndtMklJemlCekh5az0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJXakIwRzl0RFRlTlVGTXpKNDMzREcrZjR6a3doSlZnNHZXbi9rYmRDODJJPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjEzMDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjEzMDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "3YGYoxPTR8jgDGadWM5ac03jNC6eIyrYVYJ3IFL_0d6ESO1eDfaWhPpEJPjni_am5DM-BGTC_6dl4IM4i58vDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "mKhwMiacq-3sJOEkkQ_e92622gR6pnFTvrI829vdoC64lkieM-18HGbJANXVmi-Bpl_CcF0uQyMSswapax23BQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "IyAgvp-9ZOHOnnVkUXMqlS22nF-KO2VYP_bXd09AONuJHsWlsGXDjoxOmH6SN2FwPpSDc_hkXuskHCUrk76HCg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "yBo9CKM5LgNk95QcjjK3UMdDVq3z0rsDIvvaWrKeWnbc1ejDpVK4IgM9hcpYLrRSt6y5sncFHw2Q1wTTlhSrDg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "S0jmllXbdZL-1HQmT0C_29zIyuGnA03nKv2CiLpoeccWJN9sCoBc9AG9SaZQzasvJvEE7JNAHxrpNjB_j6bQCw"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTMwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wV0ZrVAXx88EUvIuk673MJLIAXcqQ-iV4vCCH50LCs0tLx65cI7ps6a31PSgIAnbp3SEg1VerkhUxJTxzyhzAg"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_1_5/endhost/certs/ISD20-V1.trc: |-
-  {
-    "payload": "eyJiYXNlX3ZlcnNpb24iOiAxLCAiZGVzY3JpcHRpb24iOiAiU0NJT05MYWIgSVNEIDIwIChLb3JlYSkiLCAiZm9ybWF0X3ZlcnNpb24iOiAxLCAiZ3JhY2VfcGVyaW9kIjogMCwgImlzZCI6IDIwLCAicHJpbWFyeV9hc2VzIjogeyJmZmFhOjA6MTQwMSI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiekVia0Z5Mi9JWThxMTVNNXM5UCtIR0tGdzdYU2xVOHJMWDkzaEtYTG5odz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZjREK0pwTXB0OHAweUh2U1RxVzA4clB1a21lUXNSNmhkNmhNV1AxSzljST0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJWMGRSNEpkUE0yMHJFMzdwd1c4UDNFaXNMeWlTS0pidGhUbEVmeTNld2VjPSIsICJrZXlfdmVyc2lvbiI6IDF9fX0sICJmZmFhOjA6MTQwMiI6IHsiYXR0cmlidXRlcyI6IFsiYXV0aG9yaXRhdGl2ZSIsICJjb3JlIiwgImlzc3VpbmciLCAidm90aW5nIl0sICJrZXlzIjogeyJpc3N1aW5nX2dyYW50IjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAieEFCdSszK1NLQ0tXSlBIUklaYUQ4T3owRzMwUXVGRlZ2VXBOR1ZKQjVwcz0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vZmZsaW5lIjogeyJhbGdvcml0aG0iOiAiRWQyNTUxOSIsICJrZXkiOiAiZFhobXBhZnVPdktoZmFsU1F3TXdid0RCTzNydkQwWWk5UVBDRnBkanJyND0iLCAia2V5X3ZlcnNpb24iOiAxfSwgInZvdGluZ19vbmxpbmUiOiB7ImFsZ29yaXRobSI6ICJFZDI1NTE5IiwgImtleSI6ICJiQUNzNXo3SHNhS05RdGxvMG5POWZlNjhiVHh0UjFvUE1UdlBMcjBkSWFrPSIsICJrZXlfdmVyc2lvbiI6IDF9fX19LCAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiI6IHsiZmZhYTowOjE0MDEiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdLCAiZmZhYTowOjE0MDIiOiBbImlzc3VpbmdfZ3JhbnQiLCAidm90aW5nX29ubGluZSIsICJ2b3Rpbmdfb2ZmbGluZSJdfSwgInRyY192ZXJzaW9uIjogMSwgInRydXN0X3Jlc2V0X2FsbG93ZWQiOiBmYWxzZSwgInZhbGlkaXR5IjogeyJub3RfYWZ0ZXIiOiAxNjMzMDg2NDYxLCAibm90X2JlZm9yZSI6IDE1NzAwMTQ0NjF9LCAidm90ZXMiOiB7fSwgInZvdGluZ19xdW9ydW0iOiAyfQ",
-    "signatures": [
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "lMflSxDL23pPZdxm4kCQrrExtho-3qWjBUGtFR9DCyADGjuhBBvJhUYXKCQgJmZwZKQ6sNvZhQrN650H7pXIAQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "IEQs-UKm_a0azRdYCBKgfytqLPKkC-KicEn8WyGNj_nJEpc6il5SvfUJkfv1TAUu2m5TK3Cwi_06dlKaOuacDQ"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMSIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "5x2TpKF5nJA3Z9gLdD45NZGm7nJZn8ndLaN8groZogAR9jW4y4qICkXuXz9ESYyA0JWVNLv_NsEEcaT33-hHBA"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJpc3N1aW5nX2dyYW50IiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "LdhZ-vIz-I2G2dPJ3genkYhOCFJxsB3fZ_JDkm8w-94n8pAfh4CzdkiVLFJkW5xjIdcH6v-M5SyF-_4vwaXNAg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb25saW5lIiwgImtleV92ZXJzaW9uIjogMSwgInR5cGUiOiAicHJvb2Zfb2ZfcG9zc2Vzc2lvbiJ9",
-        "signature": "CMXlaUloufb05e0myd4-fICnAVzCHrgJ7-mDegDHjMqSi3QuE70Gm-Muf887Rey_OHV9x7woExKQ-NpjSaa8Cg"
-      },
-      {
-        "protected": "eyJhbGciOiAiRWQyNTUxOSIsICJhcyI6ICJmZmFhOjA6MTQwMiIsICJjcml0IjogWyJ0eXBlIiwgImtleV90eXBlIiwgImtleV92ZXJzaW9uIiwgImFzIl0sICJrZXlfdHlwZSI6ICJ2b3Rpbmdfb2ZmbGluZSIsICJrZXlfdmVyc2lvbiI6IDEsICJ0eXBlIjogInByb29mX29mX3Bvc3Nlc3Npb24ifQ",
-        "signature": "wdZ-vcrtMLvPFnTTp1367W2i9CNq-kDLtpRJyEp4G2bf5KhdqdW_gtuYFEArtW0oGZ4-tiIErM3ng9Rvv7EjDQ"
-      }
-    ]
-  }
-gen/ISD17/ASffaa_1_5/endhost/sd.toml: |
+gen/ASffaa_1_5/sd.toml: |
   [general]
-  config_dir = "gen/ISD17/ASffaa_1_5/endhost"
-  id = "sd17-ffaa_1_5"
+  config_dir = "gen/ASffaa_1_5"
+  id = "sd"
   reconnect_to_dispatcher = true
 
   [metrics]
@@ -554,37 +186,25 @@ gen/ISD17/ASffaa_1_5/endhost/sd.toml: |
 
   [path_db]
   backend = "sqlite"
-  connection = "gen-cache/sd17-ffaa_1_5.path.db"
+  connection = "gen-cache/sd.path.db"
 
   [sd]
   address = "127.0.0.1:30255"
 
   [trust_db]
   backend = "sqlite"
-  connection = "gen-cache/sd17-ffaa_1_5.trust.db"
+  connection = "gen-cache/sd.trust.db"
 
   [log.file]
   level = "debug"
   max_age = 3
   max_backups = 1
-  path = "logs/sd17-ffaa_1_5.log"
-gen/ISD17/ASffaa_1_5/endhost/supervisord.conf: |+
-  [program:sd17-ffaa_1_5]
-  autostart = false
-  autorestart = true
-  environment = TZ=UTC
-  stdout_logfile = logs/sd17-ffaa_1_5.OUT
-  stderr_logfile = logs/sd17-ffaa_1_5.ERR
-  startretries = 0
-  startsecs = 5
-  priority = 100
-  command = bin/sciond -config gen/ISD17/ASffaa_1_5/endhost/sd.toml
-
-gen/ISD17/ASffaa_1_5/endhost/topology.json: |-
+  path = "logs/sd.log"
+gen/ASffaa_1_5/topology.json: |-
   {
     "Attributes": [],
     "BorderRouters": {
-      "br17-ffaa_1_5-1": {
+      "br-1": {
         "CtrlAddr": {
           "IPv4": {
             "Public": {
@@ -621,7 +241,7 @@ gen/ISD17/ASffaa_1_5/endhost/topology.json: |-
       }
     },
     "ControlService": {
-      "cs17-ffaa_1_5-1": {
+      "cs-1": {
         "Addrs": {
           "IPv4": {
             "Public": {
@@ -636,7 +256,7 @@ gen/ISD17/ASffaa_1_5/endhost/topology.json: |-
     "MTU": 1472,
     "Overlay": "UDP/IPv4",
     "SIG": {
-      "sig17-ffaa_1_5-1": {
+      "sig-1": {
         "Addrs": {
           "IPv4": {
             "Public": {
@@ -648,10 +268,6 @@ gen/ISD17/ASffaa_1_5/endhost/topology.json: |-
       }
     }
   }
-gen/ISD17/ASffaa_1_5/supervisord.conf: |+
-  [group:as17-ffaa_1_5]
-  programs = br17-ffaa_1_5-1,cs17-ffaa_1_5-1,sd17-ffaa_1_5,dispatcher
-
 gen/dispatcher/disp.toml: |
   [dispatcher]
   id = "dispatcher"
@@ -665,22 +281,52 @@ gen/dispatcher/disp.toml: |
   max_age = 3
   max_backups = 1
   path = "logs/dispatcher.log"
-gen/dispatcher/supervisord.conf: |+
+gen/supervisord.conf: |+
+  [program:br-1]
+  autostart = false
+  autorestart = true
+  environment = TZ=UTC,GODEBUG="cgocheck=0"
+  stdout_logfile = logs/br-1.log
+  redirect_stderr = True
+  startretries = 0
+  startsecs = 5
+  priority = 100
+  command = bin/border -config gen/ASffaa_1_5/br-1.toml
+
+  [program:cs-1]
+  autostart = false
+  autorestart = true
+  environment = TZ=UTC
+  stdout_logfile = logs/cs-1.log
+  redirect_stderr = True
+  startretries = 0
+  startsecs = 5
+  priority = 100
+  command = bin/cs -config gen/ASffaa_1_5/cs-1.toml
+
+  [program:sd]
+  autostart = false
+  autorestart = true
+  environment = TZ=UTC
+  stdout_logfile = logs/sd.log
+  redirect_stderr = True
+  startretries = 0
+  startsecs = 5
+  priority = 100
+  command = bin/sciond -config gen/ASffaa_1_5/sd.toml
+
+  [group:as17-ffaa_1_5]
+  programs = br-1,cs-1,sd
+
   [program:dispatcher]
   autostart = false
   autorestart = true
   environment = TZ=UTC
-  stdout_logfile = logs/dispatcher.OUT
-  stderr_logfile = logs/dispatcher.ERR
+  stdout_logfile = logs/dispatcher.log
+  redirect_stderr = True
   startretries = 0
   startsecs = 1
   priority = 50
   command = bin/godispatcher -config gen/dispatcher/disp.toml
 
-gen/scionlab-config.json: |-
-  {
-    "host_id": "f2f482ed5717434e926c39bd5ef661dc",
-    "host_secret": "c2253b49ef334ec6bba8e1c85b48629c",
-    "url": "http://localhost:8000",
-    "version": 4
-  }
+...

--- a/scionlab/tests/test_archive.py
+++ b/scionlab/tests/test_archive.py
@@ -1,0 +1,77 @@
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import configparser
+import hashlib
+import pathlib
+import tempfile
+
+from django.test import TestCase
+
+from scionlab.util.archive import DictWriter, HashedArchiveWriter, FileArchiveWriter
+
+_TEST_DICT = {'foo': 'foo'}
+
+_TEST_CONFIG = configparser.ConfigParser()
+_TEST_CONFIG['foosection'] = {'foo': 'foo'}
+
+
+class HashedArchiveWriterTests(TestCase):
+    def test_undistorted(self):
+        """ Check that base writer receives same content """
+        base = DictWriter()
+        self._add_stuff(base)
+
+        adaptee = DictWriter()
+        adapter = HashedArchiveWriter(adaptee)
+        self._add_stuff(adapter)
+
+        self.assertEqual(base.dict, adaptee.dict)
+
+    def test_hash_set(self):
+        """ Check that there is a hash for each file (excluding directories) """
+        adaptee = DictWriter()
+        hasher = HashedArchiveWriter(adaptee)
+        self._add_stuff(hasher)
+
+        self.assertEqual(sorted(path for path in adaptee.dict.keys() if not path.endswith('/')),
+                         sorted(hasher.hashes.keys()))
+
+    def test_file_hashes(self):
+        """ Check that hashes for files written to disk match computed hashes """
+        adaptee = DictWriter()
+        hasher = HashedArchiveWriter(adaptee)
+        self._add_stuff(hasher)
+
+        with tempfile.TemporaryDirectory("scionlab_tests_test_archive") as tmpdir:
+            filer = FileArchiveWriter(tmpdir)
+            self._add_stuff(filer)
+
+            # Get hashes from files on disk:
+            hashes = {}
+            for f in pathlib.Path(tmpdir).iterdir():
+                if f.is_file():
+                    hashes[f.name] = hashlib.sha1(f.read_bytes()).hexdigest()
+
+            # Should be the same hashes:
+            self.assertEqual(hasher.hashes, hashes)
+
+    def _add_stuff(self, archive):
+        archive.write_text("test.txt", "henlo")
+        archive.write_json("test.json", _TEST_DICT)
+        archive.write_toml("test.toml", _TEST_DICT)
+        archive.write_yaml("test.yaml", _TEST_DICT)
+        archive.write_config("test.ini", _TEST_CONFIG)
+        archive.add("test.py", __file__)
+        archive.add_dir("testdir")

--- a/scionlab/tests/test_config_tar.py
+++ b/scionlab/tests/test_config_tar.py
@@ -14,6 +14,7 @@
 
 import os
 import yaml
+from parameterized import parameterized
 
 from django.test import TestCase
 
@@ -21,7 +22,7 @@ from scionlab.config_tar import generate_host_config_tar, generate_user_as_confi
 from scionlab.fixtures.testuser import get_testuser_exbert
 from scionlab.models.core import Service
 from scionlab.models.user_as import UserAS
-from scionlab.util.archive import DictWriter
+from scionlab.util.archive import DictWriter, FileArchiveWriter
 
 
 _TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -56,11 +57,11 @@ class ConfigTarRegressionTests(TestCase):
         generate_host_config_tar(host, archive)
         self._check_archive('host_%i' % host.id, archive)
 
-    def test_user_as(self):
-        for user_as in UserAS.objects.filter(owner=get_testuser_exbert()).iterator():
-            archive = DictWriter()
-            generate_user_as_config_tar(user_as, archive)
-            self._check_archive('user_as_%i' % user_as.id, archive)
+    @parameterized.expand(list(zip(range(5))))
+    def test_user_as(self, user_as_id):
+        user_as = UserAS.objects.filter(owner=get_testuser_exbert()).order_by('pk')[user_as_id]
+        archive = DictWriter()
+        generate_user_as_config_tar(user_as, archive)
 
     def _check_archive(self, test_id, archive):
 

--- a/scionlab/tests/test_config_tar.py
+++ b/scionlab/tests/test_config_tar.py
@@ -22,7 +22,7 @@ from scionlab.config_tar import generate_host_config_tar, generate_user_as_confi
 from scionlab.fixtures.testuser import get_testuser_exbert
 from scionlab.models.core import Service
 from scionlab.models.user_as import UserAS
-from scionlab.util.archive import DictWriter, FileArchiveWriter
+from scionlab.util.archive import DictWriter
 
 
 _TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -62,6 +62,7 @@ class ConfigTarRegressionTests(TestCase):
         user_as = UserAS.objects.filter(owner=get_testuser_exbert()).order_by('pk')[user_as_id]
         archive = DictWriter()
         generate_user_as_config_tar(user_as, archive)
+        self._check_archive('user_as_%i' % user_as.id, archive)
 
     def _check_archive(self, test_id, archive):
 

--- a/scionlab/tests/test_scionlab-config.py
+++ b/scionlab/tests/test_scionlab-config.py
@@ -1,0 +1,243 @@
+# Copyright 2020 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import importlib.machinery
+import os
+import sys
+import tarfile
+from io import StringIO
+from unittest.mock import patch
+from unittest import TestCase
+
+from django.test import LiveServerTestCase
+
+from scionlab.models.core import Host
+from scionlab.tests import utils
+
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_BASE_DIR = os.path.dirname(os.path.dirname(_TEST_DIR))
+_SCIONLAB_CONFIG_PATH = os.path.join(_BASE_DIR, "scionlab/hostfiles/scionlab-config")
+
+# import "scionlab-config" as a module "scionlab_config"
+# (tiny bit of magic, https://stackoverflow.com/a/43602645/4666991)
+spec = importlib.util.spec_from_loader(
+    "scionlab_config",
+    importlib.machinery.SourceFileLoader("scionlab_config", _SCIONLAB_CONFIG_PATH)
+)
+scionlab_config = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scionlab_config)
+sys.modules['scionlab_config'] = scionlab_config
+
+
+class ScionlabConfigLiveTests(LiveServerTestCase):
+    """
+    Use a "live" test server to test the API client functionality in the scionlab-config script
+    """
+    fixtures = ['testdata']
+
+    def setUp(self):
+        host = Host.objects.last()
+        host.config_version = 1
+        host.config_version_deployed = 1
+        host.save()
+        self.host = host
+        self.fetch_info = scionlab_config.FetchInfo(
+            host_id=host.uid,
+            host_secret=host.secret,
+            url=self.live_server_url,
+            version=1,
+        )
+
+    def test_fetch_config_update(self):
+        self.host.config_version += 1
+        self.host.save()
+        config = scionlab_config.fetch_config(self.fetch_info)
+        self._check_tar(config)
+
+    def test_fetch_config_nop(self):
+        config = scionlab_config.fetch_config(self.fetch_info)
+        self.assertIs(config, scionlab_config._CONFIG_UNCHANGED)
+
+    def test_fetch_config_force(self):
+        config = scionlab_config.fetch_config(self.fetch_info._replace(version=None))
+        self.assertIsInstance(config, tarfile.TarFile)
+        self._check_tar(config)
+
+    def test_fetch_empty(self):
+        self.host.AS.delete()  # Nothing left to do for this host
+        config = scionlab_config.fetch_config(self.fetch_info)
+        self.assertIs(config, scionlab_config._CONFIG_EMPTY)
+
+    def test_confirm_deployed(self):
+        self.host.config_version += 1
+        self.host.save()
+        confirm_info = self.fetch_info._replace(version=self.host.config_version)
+        with patch('scionlab_config._read_fetch_info', return_value=confirm_info):
+            class MockArgs:
+                url = None
+            scionlab_config.confirm_deployed(MockArgs())
+
+        self.host.refresh_from_db()
+        self.assertEqual(self.host.config_version, self.host.config_version_deployed)
+
+    def _check_tar(self, tar):
+        self.assertIsInstance(tar, tarfile.TarFile)
+        utils._check_tarball_etc_scion(self, tar, self.host)
+        utils._check_tarball_info(self, tar, self.host)
+
+
+class ScionlabConfigUnitTests(TestCase):
+
+    def test_sanity_check_file_list(self):
+        good = [
+            "etc/scion/foo.toml",
+            "etc/scion/topology.json",
+            "etc/openvpn/foo.config",
+        ]
+        bad = [
+            "/etc/scion/foo.toml",
+            "etc/../usr/bin/sudo",
+            "etc/scion/",
+            "etc/scion",
+            "usr/bin/sudo",
+            "/usr/bin/sudo",
+        ]
+
+        def _check_good(files):
+            scionlab_config._sanity_check_file_list(files)
+
+        def _check_bad(files):
+            with self.assertRaises(ValueError):
+                scionlab_config._sanity_check_file_list(files)
+
+        _check_good(good)  # all good
+        for f in good:
+            _check_good([f])  # individual good also pass
+
+        _check_bad(bad)  # all bad fail
+        _check_bad(good + bad)  # all bad with all good still fail
+        for f in bad:
+            _check_bad([f])  # individual bad fail
+            _check_bad(good + [f])  # individual bad with good still fail
+
+    def test_check_file_conflicts(self):
+        # Test setup defines some files and their pseudo sha1 hashes:
+        # foo: unchanged
+        # fmo: modified locally, unchanged in update -> skip
+        # bar: modified locally and in config -> prompt
+        # boo: deleted in updated config -> ok
+        # bmo: modified locally, deleted in config -> ok, no prompt
+        # new: new in config -> ok
+        # egg: existst locally, new in config -> prompt
+        old_files = {
+            "etc/scion/foo.toml": "sha1_foo",
+            "etc/scion/fmo.toml": "sha1_fmo",
+            "etc/scion/bar.toml": "sha1_bar_old",
+            "etc/scion/boo.toml": "sha1_boo",
+            "etc/scion/bmo.toml": "sha1_bmo",
+        }
+        new_files = {
+            "etc/scion/foo.toml": "sha1_foo",
+            "etc/scion/fmo.toml": "sha1_fmo",
+            "etc/scion/bar.toml": "sha1_bar_new",
+            "etc/scion/new.toml": "sha1_new",
+            "etc/scion/egg.toml": "sha1_egg_new",
+        }
+        disk_files = {
+            # note absolute path here
+            "/etc/scion/foo.toml": "sha1_foo",
+            "/etc/scion/fmo.toml": "sha1_fmo_local",
+            "/etc/scion/bar.toml": "sha1_bar_local",
+            "/etc/scion/boo.toml": "sha1_boo",
+            "/etc/scion/bmo.toml": "sha1_bmo_local",
+            "/etc/scion/egg.toml": "sha1_egg_local",
+        }
+
+        # define expected result, the list of files to be skipped, depending on
+        # user input on prompt:
+        expected_num_prompts = 2
+        tests = {
+            "skip": ["etc/scion/fmo.toml", "etc/scion/bar.toml", "etc/scion/egg.toml"],
+            "replace": ["etc/scion/fmo.toml"],
+        }
+
+        def _mock_os_path_exists(path):
+            return path in disk_files
+
+        def _mock_sha1(path):
+            return disk_files[path]
+
+        for user_input, expected_skip in tests.items():
+            with patch('scionlab_config._sha1', side_effect=_mock_sha1), \
+                    patch('os.path.exists', side_effect=_mock_os_path_exists), \
+                    patch('scionlab_config._prompt', return_value=user_input) as mock_prompt:
+
+                skip = scionlab_config.check_file_conflicts(old_files, new_files)
+
+                self.assertEqual(mock_prompt.call_count, expected_num_prompts)
+                self.assertEqual(sorted(skip), sorted(expected_skip))
+
+    def test_prompt(self):
+        context = "Darling, you got to let me know."
+        question = "Should I stay or should I go?"
+        options = ["stay", "go", "tease"]
+        default = "tease"
+        expected_prompt = " [s/g/T] "
+
+        tests = [
+            (['s'], 'stay'),
+            (['x', 's'], 'stay'),
+            (['g'], 'go'),
+            (['G'], 'go'),
+            (['go'], 'go'),
+            (['goo', 'go now', 'go'], 'go'),
+            (['tea'], 'tease'),
+            ([''], 'tease'),
+        ]
+        for inputs, expected_result in tests:
+            ret, term, prompts = self._patched_prompt(inputs, context, question,
+                                                      options, default=default)
+
+            self.assertEqual(len(prompts), len(inputs))  # matches expected number of question asked
+            for prompt in prompts:
+                self.assertEqual(prompt, expected_prompt)
+            lines = term.splitlines()
+            self.assertEqual(lines[0], context + " " + question + expected_prompt + inputs[0])
+            for i in range(1, len(inputs)):
+                self.assertEqual(lines[2*i-1], "Please respond with any of s/g/t.")
+                self.assertEqual(lines[2*i], question + expected_prompt + inputs[i])
+            self.assertTrue(ret, expected_result)
+
+    def _patched_prompt(self, inputs, *prompt_args, **prompt_kwargs):
+        """
+        Run scionlab-config._prompt with patched input and sys.stdout
+        Returns the value returned by prompt, the list of prompts given to `input` and the
+        (approximated) view of the terminal (stdout + some).
+        """
+
+        term = StringIO()
+        inputs_iter = iter(inputs)
+        prompts = []
+
+        def patched_input(prompt):
+            prompts.append(prompt)
+            user_input = next(inputs_iter)  # blows up if called too often (~intended)
+            # user hits enter, so looks like a new line (even though not on stdout)
+            term.write(prompt + user_input + "\n")
+            return user_input
+
+        with patch('builtins.input', side_effect=patched_input), patch('sys.stdout', new=term):
+            ret = scionlab_config._prompt(*prompt_args, **prompt_kwargs)
+            return ret, term.getvalue(), prompts

--- a/scionlab/urls.py
+++ b/scionlab/urls.py
@@ -16,6 +16,7 @@ from django.views.generic.base import TemplateView
 from django.contrib import admin
 from django.contrib.auth.decorators import login_required
 from django.urls import include, path, re_path
+from django.views.generic.base import RedirectView
 
 from scionlab.views.user_as_views import (
     UserASesView,
@@ -73,15 +74,18 @@ urlpatterns = [
     path('topology.png', topology_png, name='topology.png'),
 
     # API:
-    path('api/v2/host/<slug:uid>/config',
+    path('api/v3/host/<slug:uid>/config',
          GetHostConfig.as_view(),
          name='api_get_config'),
-    path('api/v2/host/<slug:uid>/deployed_config_version',
+    path('api/v3/host/<slug:uid>/deployed_config_version',
          PostHostDeployedConfigVersion.as_view(),
          name='api_post_deployed_version'),
-    path('api/v2/topology/topology',
+    path('api/v3/topology/topology',
          topology_json,
          name='api_topology'),
     # no longer supported versions of the API
-    re_path(r'^api/host/', gone)
+    re_path(r'^api/host/', gone),
+    re_path(r'^api/v2/host/', gone),
+    path('api/v2/topology/topology',
+         RedirectView.as_view(url='/api/v3/topology/topology', permanent=True)),
 ]

--- a/scionlab/util/archive.py
+++ b/scionlab/util/archive.py
@@ -99,11 +99,19 @@ class BaseArchiveWriter:
         """
         raise NotImplementedError()
 
-    def _normalize_path(self, path):
+    def _normalize_path(self, path) -> str:
+        """
+        The `path` is either
+        - a string
+        - a pathlib.Path
+        - or a tuple consisting of string/pathlib.Path that will be joined
+
+        Spurious slashes and single dots are collapsed (double dots are not).
+        """
         if isinstance(path, tuple):
             return str(pathlib.PurePosixPath(*path))
         else:
-            return str(path)
+            return str(pathlib.PurePosixPath(path))
 
 
 class FileArchiveWriter(BaseArchiveWriter):


### PR DESCRIPTION
* Create flatter configuration directory hierachy (see #307)
  * the root `/etc/scion` contains all `*.toml` service configuration files, the `topology.json` file and the `certs/`, `keys/` (and in the future `crypto/`)
  * the scionlab-config.json file now contains a list of files generated by the coordinator, with checksum. This allows the scionlab-config script to know which files to remove/replace in an update. The checksum allows the scionlab-config script to avoid trampling over files modified by the user. In the configuration tar file, the configuration files are now stored under their full installation path (e.g. `etc/scion/topology.json`).
   * the scionlab-config.json file also contains a list of "managed" services. This allows us and SCIONLab users to enable services outside of the control of the coordinator under the `scionlab.target`.
* Adapt `scionlab-config` to the new config tar. Will now prompt the user before overwriting locally modified files. At the same time, remove some most likely unused functionality (`--config-info` and `--local-version` flags)
* Add unit-tests and linter coverage for `scionlab-config`

This is an API breaking change, i.e. current `scionlab-config` scripts will not be able to properly consume the new `tar`-file.
Thusly, bumping the (global) API version to `v3`. Keeping a redirect for the unaffected `topology` API.

Closes #307

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/308)
<!-- Reviewable:end -->
