### PR TITLE
add a link to our ICNP2020 infra node registration form

### DIFF
--- a/scionlab/templates/scionlab/home.html
+++ b/scionlab/templates/scionlab/home.html
@@ -21,8 +21,8 @@ Your ASes will actively participate in routing in the SCIONLab network and enabl
   <a class="btn btn-outline-secondary btn-lg" href="{% url 'login' %}">Login</a>
   <br>
   <br>
-  If you arrived here from ICNP 2020, and would like to join the SCIONLab infrastructure, please sign up using this form:
-  <br>
+  <p>If you arrived here from ICNP 2020, and would like to join the SCIONLab infrastructure, please sign up using this form:
+  </p>
   <a class="btn btn-outline-primary btn-lg" href="https://forms.gle/eZSfKhxnky2bwgFfA" target="_blank">ICNP 2020 Form</a>
 {% endif %}
 </div>

--- a/scionlab/templates/scionlab/home.html
+++ b/scionlab/templates/scionlab/home.html
@@ -19,6 +19,11 @@ Your ASes will actively participate in routing in the SCIONLab network and enabl
 {% else %}
   <a class="btn btn-primary btn-lg" href="{% url 'registration_form' %}">Join SCIONLab</a>
   <a class="btn btn-outline-secondary btn-lg" href="{% url 'login' %}">Login</a>
+  <br>
+  <br>
+  If you arrived here from ICNP 2020, and would like to join the SCIONLab infrastructure, please sign up using this form:
+  <br>
+  <a class="btn btn-outline-primary btn-lg" href="https://forms.gle/eZSfKhxnky2bwgFfA" target="_blank">ICNP 2020 Form</a>
 {% endif %}
 </div>
 

--- a/scionlab/templates/scionlab/home.html
+++ b/scionlab/templates/scionlab/home.html
@@ -19,14 +19,14 @@ Your ASes will actively participate in routing in the SCIONLab network and enabl
 {% else %}
   <a class="btn btn-primary btn-lg" href="{% url 'registration_form' %}">Join SCIONLab</a>
   <a class="btn btn-outline-secondary btn-lg" href="{% url 'login' %}">Login</a>
-  <br>
-  <br>
-  <p>
+  <p class="mt-5">
     If you are part of an organization committed to do research with SCION, and run the SCION AS uninterruptedly 24/7,
     then you could join the SCIONLab infrastructure. You could also be eligible to obtain a free <a href="https://www.pcengines.ch/apu2.htm" target="_blank">PC Engines APU2</a> to run the services.
     Get in contact, by filling in this form:
   </p>
-  <a class="btn btn-outline-primary btn-lg" href="https://forms.gle/eZSfKhxnky2bwgFfA" target="_blank">Request to Become an Infrastructure Node</a>
+  <a class="btn btn-outline-primary btn-lg" href="https://forms.gle/eZSfKhxnky2bwgFfA" target="_blank">
+    <span class="fa fa-external-link d-none d-sm-inline"></span>
+    Request to Become an Infrastructure Node</a>
 {% endif %}
 </div>
 

--- a/scionlab/templates/scionlab/home.html
+++ b/scionlab/templates/scionlab/home.html
@@ -19,15 +19,15 @@ Your ASes will actively participate in routing in the SCIONLab network and enabl
 {% else %}
   <a class="btn btn-primary btn-lg" href="{% url 'registration_form' %}">Join SCIONLab</a>
   <a class="btn btn-outline-secondary btn-lg" href="{% url 'login' %}">Login</a>
-  <p class="mt-5">
-    If you are part of an organization committed to do research with SCION, and run the SCION AS uninterruptedly 24/7,
-    then you could join the SCIONLab infrastructure. You could also be eligible to obtain a free <a href="https://www.pcengines.ch/apu2.htm" target="_blank">PC Engines APU2</a> to run the services.
-    Get in contact, by filling in this form:
-  </p>
-  <a class="btn btn-outline-primary btn-lg" href="https://forms.gle/eZSfKhxnky2bwgFfA" target="_blank">
-    <span class="fa fa-external-link d-none d-sm-inline"></span>
-    Request to Become an Infrastructure Node</a>
 {% endif %}
+<p class="mt-5">
+  If you are part of an organization committed to do research with SCION, and run the SCION AS uninterruptedly 24/7,
+  then you could join the SCIONLab infrastructure. You could also be eligible to obtain a free <a href="https://www.pcengines.ch/apu2.htm" target="_blank">PC Engines APU2</a> to run the services.
+  Get in contact, by filling in this form:
+</p>
+<a class="btn btn-outline-primary btn-lg" href="https://forms.gle/eZSfKhxnky2bwgFfA" target="_blank" rel="noreferrer">
+  <span class="fa fa-external-link d-none d-sm-inline"></span>
+  Request to Become an Infrastructure Node</a>
 </div>
 
 <div class="col-md">

--- a/scionlab/templates/scionlab/home.html
+++ b/scionlab/templates/scionlab/home.html
@@ -21,9 +21,12 @@ Your ASes will actively participate in routing in the SCIONLab network and enabl
   <a class="btn btn-outline-secondary btn-lg" href="{% url 'login' %}">Login</a>
   <br>
   <br>
-  <p>If you arrived here from ICNP 2020, and would like to join the SCIONLab infrastructure, please sign up using this form:
+  <p>
+    If you are part of an organization committed to do research with SCION, and run the SCION AS uninterruptedly 24/7,
+    then you could join the SCIONLab infrastructure. You could also be eligible to obtain a free <a href="https://www.pcengines.ch/apu2.htm" target="_blank">PC Engines APU2</a> to run the services.
+    Get in contact, by filling in this form:
   </p>
-  <a class="btn btn-outline-primary btn-lg" href="https://forms.gle/eZSfKhxnky2bwgFfA" target="_blank">ICNP 2020 Form</a>
+  <a class="btn btn-outline-primary btn-lg" href="https://forms.gle/eZSfKhxnky2bwgFfA" target="_blank">Request to Become an Infrastructure Node</a>
 {% endif %}
 </div>
 


### PR DESCRIPTION
On the occasion of the ICNP2020, adding a link to the registration form to join our infrastructure.
~~This change should be temporary, and removed after the ending of ICNP2020.~~

This change is no longer temporary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/311)
<!-- Reviewable:end -->
