### PR TITLE
Host.get_port_map includes now services' ports

### DIFF
--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -595,6 +595,9 @@ class Host(models.Model):
             portmap.add(self.internal_ip, internal_port)
             portmap.add(self.internal_ip, control_port)
 
+        for srv in self.services.filter(type=Service.CS):
+            portmap.add(self.internal_ip, srv.port())
+
         # Note: could also use values_list for interface ports, but slightly more complicated
         for interface in self.interfaces.iterator():
             portmap.add(interface.get_public_ip(), interface.public_port)

--- a/scionlab/templates/scionlab/home.html
+++ b/scionlab/templates/scionlab/home.html
@@ -20,6 +20,14 @@ Your ASes will actively participate in routing in the SCIONLab network and enabl
   <a class="btn btn-primary btn-lg" href="{% url 'registration_form' %}">Join SCIONLab</a>
   <a class="btn btn-outline-secondary btn-lg" href="{% url 'login' %}">Login</a>
 {% endif %}
+<p class="mt-5">
+  If you are part of an organization committed to do research with SCION, and run the SCION AS uninterruptedly 24/7,
+  then you could join the SCIONLab infrastructure. You could also be eligible to obtain a free <a href="https://www.pcengines.ch/apu2.htm" target="_blank">PC Engines APU2</a> to run the services.
+  Get in contact, by filling in this form:
+</p>
+<a class="btn btn-outline-primary btn-lg" href="https://forms.gle/eZSfKhxnky2bwgFfA" target="_blank" rel="noreferrer">
+  <span class="fa fa-external-link d-none d-sm-inline"></span>
+  Request to Become an Infrastructure Node</a>
 </div>
 
 <div class="col-md">


### PR DESCRIPTION
The `PortMap` returned by the `Host` now also covers the services this host has.
- [x] Change
- [ ] Tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/316)
<!-- Reviewable:end -->
