### PR TITLE
Host.get_port_map includes now services' ports

### DIFF
--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -1093,7 +1093,7 @@ class BorderRouterManager(models.Manager):
 class BorderRouter(models.Model):
     """
     A BorderRouter object represents the actual `border`-process executing an Interface.
-    It stores the per-border-router settings (internal addess port and control addess port).
+    It stores the per-border-router settings (internal address port and control address port).
     """
     AS = models.ForeignKey(
         AS,

--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -40,7 +40,6 @@ from scionlab.defines import (
     DEFAULT_PUBLIC_PORT,
     DEFAULT_INTERNAL_PORT,
     DEFAULT_CONTROL_PORT,
-    SD_TCP_PORT,
     CS_PORT,
     BW_PORT,
     PP_PORT,
@@ -590,8 +589,6 @@ class Host(models.Model):
         """
         portmap = PortMap()
         portmap.add(None, DISPATCHER_PORT)
-        # SD_TCP_PORT TCP port doesn't clash with UDP, but anyways excluded
-        portmap.add(self.internal_ip, SD_TCP_PORT)
 
         for internal_port, control_port in \
                 self.border_routers.values_list('internal_port', 'control_port'):

--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -40,6 +40,7 @@ from scionlab.defines import (
     DEFAULT_PUBLIC_PORT,
     DEFAULT_INTERNAL_PORT,
     DEFAULT_CONTROL_PORT,
+    SD_TCP_PORT,
     CS_PORT,
     BW_PORT,
     PP_PORT,
@@ -589,13 +590,15 @@ class Host(models.Model):
         """
         portmap = PortMap()
         portmap.add(None, DISPATCHER_PORT)
+        # SD_TCP_PORT TCP port doesn't clash with UDP, but anyways excluded
+        portmap.add(self.internal_ip, SD_TCP_PORT)
 
         for internal_port, control_port in \
                 self.border_routers.values_list('internal_port', 'control_port'):
             portmap.add(self.internal_ip, internal_port)
             portmap.add(self.internal_ip, control_port)
 
-        for srv in self.services.filter(type=Service.CS):
+        for srv in self.services.iterator():
             portmap.add(self.internal_ip, srv.port())
 
         # Note: could also use values_list for interface ports, but slightly more complicated

--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -595,6 +595,9 @@ class Host(models.Model):
             portmap.add(self.internal_ip, internal_port)
             portmap.add(self.internal_ip, control_port)
 
+        for srv in self.services.filter(type=Service.CS):
+            portmap.add(self.internal_ip, srv.port())
+
         # Note: could also use values_list for interface ports, but slightly more complicated
         for interface in self.interfaces.iterator():
             portmap.add(interface.get_public_ip(), interface.public_port)

--- a/scionlab/tests/test_models.py
+++ b/scionlab/tests/test_models.py
@@ -14,7 +14,6 @@
 
 from unittest.mock import patch
 from django.test import TestCase
-from scionlab.defines import SD_TCP_PORT
 from scionlab.models.core import ISD, AS, Link, Host, Interface, BorderRouter, Service
 from scionlab.models.pki import Certificate
 from scionlab.fixtures import testtopo
@@ -280,7 +279,7 @@ class HostTests(TestCase):
         self.assertEqual(Host.objects.filter(AS=as_1101).count(), 1)
         host = Host.objects.first()
         # check service ports do not clash
-        ports_in_use = {SD_TCP_PORT}
+        ports_in_use = set()
         for srv in host.services.iterator():
             self.assertNotIn(srv.port(), ports_in_use)
             ports_in_use.add(srv.port())

--- a/scionlab/tests/test_models.py
+++ b/scionlab/tests/test_models.py
@@ -14,6 +14,7 @@
 
 from unittest.mock import patch
 from django.test import TestCase
+from scionlab.defines import SD_TCP_PORT
 from scionlab.models.core import ISD, AS, Link, Host, Interface, BorderRouter, Service
 from scionlab.models.pki import Certificate
 from scionlab.fixtures import testtopo
@@ -269,3 +270,24 @@ class DeleteASTests(TestCase):
         ases.delete()
 
         self.assertEqual(self.mock_as_post_delete.call_count, ases_count)
+
+
+class HostTests(TestCase):
+    def test_add_border_routers(self):
+        isd17 = ISD.objects.create(isd_id=17, label='Switzerland')
+        as_1101 = AS.objects.create(isd=isd17, as_id='ff00:0:1101', label='SCMN')
+        as_1101.init_default_services()
+        self.assertEqual(Host.objects.filter(AS=as_1101).count(), 1)
+        host = Host.objects.first()
+        # check service ports do not clash
+        ports_in_use = {SD_TCP_PORT}
+        for srv in host.services.iterator():
+            self.assertNotIn(srv.port(), ports_in_use)
+            ports_in_use.add(srv.port())
+        # create a lot (e.g. 200) border routers. No port clash should occur.
+        for i in range(200):
+            br = BorderRouter.objects.create(host=host)
+            self.assertNotIn(br.internal_port, ports_in_use)
+            ports_in_use.add(br.internal_port)
+            self.assertNotIn(br.control_port, ports_in_use)
+            ports_in_use.add(br.control_port)


### PR DESCRIPTION
The `PortMap` returned by the `Host` now also covers the services this host has.
- [x] Change
- [x] Tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/317)
<!-- Reviewable:end -->
