### PR TITLE
vpn: add --local to server config 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,12 @@ jobs:
             docker-compose build
 
       - run:
+          name: Set date so certificates in test data are valid
+          command: |
+            # Certificates are valid between 2019-10-02 and 2020-10-01.
+            sudo date -s "2020-04-01"  # haha
+
+      - run:
           name: Start coordinator
           working_directory: ~/project/.circleci
           <<: *start_coordinator

--- a/scionlab/hostfiles/server.conf.tmpl
+++ b/scionlab/hostfiles/server.conf.tmpl
@@ -2,6 +2,7 @@ mode server
 tls-server
 
 dev tun
+local ${ServerPublicIP}
 port ${ServerPort}
 proto udp
 
@@ -12,9 +13,9 @@ ncp-ciphers AES-256-GCM:AES-256-CBC:BF-CBC
 
 topology subnet
 push "topology subnet"
-ifconfig ${ServerIP} ${Netmask}
+ifconfig ${ServerVPNIP} ${Netmask}
 route ${Subnet} ${Netmask}
-push "route ${ServerIP}"
+push "route ${ServerVPNIP}"
 
 client-config-dir ccd
 ccd-exclusive

--- a/scionlab/openvpn_config.py
+++ b/scionlab/openvpn_config.py
@@ -212,15 +212,12 @@ def generate_vpn_server_config(vpn):
     ca_cert = load_ca_cert().public_bytes(
         encoding=serialization.Encoding.PEM).decode()
     server_config_tmpl = pathlib.Path(SERVER_CONFIG_TEMPLATE_PATH).read_text(encoding='utf-8')
-    server_vpn_as = vpn.server.AS.as_path_str()
-    server_vpn_ip = vpn.server_vpn_ip
-    server_vpn_port = vpn.server_port
     server_vpn_subnet = vpn.vpn_subnet()
 
     server_config = string.Template(server_config_tmpl).substitute(
-        AS=server_vpn_as,
-        ServerIP=server_vpn_ip,
-        ServerPort=server_vpn_port,
+        ServerPublicIP=vpn.server.public_ip,
+        ServerPort=vpn.server_port,
+        ServerVPNIP=vpn.server_vpn_ip,
         Netmask=server_vpn_subnet.netmask,
         Subnet=server_vpn_subnet,
         CACert=ca_cert,

--- a/scionlab/tests/data/test_config_tar/host_4.yml
+++ b/scionlab/tests/data/test_config_tar/host_4.yml
@@ -996,6 +996,7 @@ server.conf: |
   tls-server
 
   dev tun
+  local 192.0.2.17
   port 1194
   proto udp
 


### PR DESCRIPTION
Add --local to openvpn server config to ensure that the server binds to
a specific address and always responds from the correct local address;
when binding to all interfaces, the source address depends on routing
which might not be what we want.

Closes #319

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/320)
<!-- Reviewable:end -->
