### PR TITLE
Fix prometheus port clashes BR vs CS

### DIFF
--- a/scionlab/defines.py
+++ b/scionlab/defines.py
@@ -26,7 +26,7 @@ USER_AS_ID_END = 0xffaa0001ffff  # 'ffaa:1:ffff'
 DEFAULT_PUBLIC_PORT = 50000    # 30042-30051 (suggested by scion/wiki/default-port-ranges)
 DEFAULT_INTERNAL_PORT = 30042  # 30042-30051
 DEFAULT_CONTROL_PORT = 30242   # 30242-30251
-BR_PROM_PORT_OFFSET = 400  # offset from BR internal (data plane) port. E.g. 30042 + 400 = 30442
+BR_PROM_PORT_OFFSET = 200  # offset from BR control port. E.g. 30242 + 200 = 30442
 
 CS_PORT = 30254  # This is both a SCION/UDP (inter-AS) and TCP (intra-AS)
 CS_QUIC_PORT = 30354  # SCION/UDP/QUIC port for inter-AS

--- a/scionlab/scion_config.py
+++ b/scionlab/scion_config.py
@@ -265,7 +265,7 @@ class _ConfigBuilder:
     def build_br_conf(self, router):
         general_conf = self._build_general_conf(router.instance_name)
         logging_conf = self._build_logging_conf(router.instance_name)
-        metrics_conf = self._build_metrics_conf(router.internal_port + BR_PROM_PORT_OFFSET)
+        metrics_conf = self._build_metrics_conf(router.control_port + BR_PROM_PORT_OFFSET)
         conf = _chain_dicts(general_conf, logging_conf, metrics_conf)
         return conf
 

--- a/scionlab/views/topology.py
+++ b/scionlab/views/topology.py
@@ -137,7 +137,7 @@ def topology_json(request):
         if service_type == 'BW':
             return None  # does not expose
         if service_type == 'BR':
-            return s.internal_port + BR_PROM_PORT_OFFSET
+            return s.control_port + BR_PROM_PORT_OFFSET
 
     def json_service(s):
         service_type = 'BR' if isinstance(s, BorderRouter) else s.type


### PR DESCRIPTION
The prometheus port of BR and CS could clash.
The BR's prometheus port is set to internal port + 400. Now if the BR's
internal port is 30054, the prometheus port will be 30454 wich is also
the CS's fixed prometheus port.
Using the BR's control port as basis of the prometheus port calculation
fixes this problem (temporarily, I hope), because the range of the
control port overlaps with the CS's service (30254) port and so avoids it.

This leaves all other prometheus port assignments unchanged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/321)
<!-- Reviewable:end -->
