### PR TITLE
Fix prometheus port clashes BR vs SD

### DIFF
--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -44,6 +44,7 @@ from scionlab.defines import (
     BW_PORT,
     PP_PORT,
     DISPATCHER_PORT,
+    SD_TCP_PORT,
     DEFAULT_HOST_INTERNAL_IP,
     DEFAULT_LINK_MTU,
     DEFAULT_LINK_BANDWIDTH,
@@ -589,6 +590,9 @@ class Host(models.Model):
         """
         portmap = PortMap()
         portmap.add(None, DISPATCHER_PORT)
+        # SD_TCP_PORT TCP port doesn't clash with UDP, but anyways excluded
+        # to ensure that the related prometheus ports do not clash either.
+        portmap.add(None, SD_TCP_PORT)
 
         for internal_port, control_port in \
                 self.border_routers.values_list('internal_port', 'control_port'):

--- a/scionlab/tests/test_models.py
+++ b/scionlab/tests/test_models.py
@@ -14,7 +14,15 @@
 
 from unittest.mock import patch
 from django.test import TestCase
-from scionlab.defines import CS_PORT
+from scionlab.defines import (
+    BR_PROM_PORT_OFFSET,
+    CS_PORT,
+    CS_PROM_PORT,
+    DISPATCHER_PORT,
+    DISPATCHER_PROM_PORT,
+    SD_PROM_PORT,
+    SD_TCP_PORT,
+)
 from scionlab.models.core import ISD, AS, Link, Host, Interface, BorderRouter, Service
 from scionlab.models.pki import Certificate
 from scionlab.fixtures import testtopo
@@ -282,17 +290,26 @@ class HostTests(TestCase):
 
     def test_add_border_routers(self):
         # check service ports do not clash
-        ports_in_use = set()
+        ports_in_use = {SD_TCP_PORT, SD_PROM_PORT, DISPATCHER_PORT, DISPATCHER_PROM_PORT}
         for srv in self.host.services.iterator():
             self.assertNotIn(srv.port(), ports_in_use)
             ports_in_use.add(srv.port())
-        # create a lot (e.g. 200) border routers. No port clash should occur.
-        for i in range(200):
+            if srv.type == Service.CS:
+                self.assertNotIn(CS_PROM_PORT, ports_in_use)
+                ports_in_use.add(CS_PROM_PORT)
+
+        # create a lot border routers. No port clash should occur.
+        # Note that with the currently defined port ranges, we _will_ have clashes with more
+        # routers.
+        for i in range(196):
+            print(i)
             br = BorderRouter.objects.create(host=self.host)
             self.assertNotIn(br.internal_port, ports_in_use)
             ports_in_use.add(br.internal_port)
             self.assertNotIn(br.control_port, ports_in_use)
             ports_in_use.add(br.control_port)
+            self.assertNotIn(br.control_port + BR_PROM_PORT_OFFSET, ports_in_use)
+            ports_in_use.add(br.control_port + BR_PROM_PORT_OFFSET)
 
     def test_host_port_map(self):
         pm = self.host.get_port_map()

--- a/scionlab/tests/test_models.py
+++ b/scionlab/tests/test_models.py
@@ -302,7 +302,6 @@ class HostTests(TestCase):
         # Note that with the currently defined port ranges, we _will_ have clashes with more
         # routers.
         for i in range(196):
-            print(i)
             br = BorderRouter.objects.create(host=self.host)
             self.assertNotIn(br.internal_port, ports_in_use)
             ports_in_use.add(br.internal_port)


### PR DESCRIPTION
Similar to previous fix in #321; as the BR's control port could clash
with the sciond port (UDP vs TCP so no problem), the corresponding
prometheus ports would also clash.
So we just avoid the SD port when assigning BR control ports.

This time, actually extend the tests to verify that this works as expected, like I should have done half an hour ago.
Again, this is a hopefully temporary fix (and hence the clunky test code).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/322)
<!-- Reviewable:end -->
