### PR TITLE
caddy: fix redirect to www. subdomain

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -14,5 +14,6 @@
 
 # Redirect to www. subdomain
 scionlab.org {
-    redir www.scionlab.org{uri}
+    log
+    redir https://www.scionlab.org{uri} permanent
 }


### PR DESCRIPTION
Add https:// to redirect. Without scheme, the redirect was interpreted
as URI on the same server, leading to a redirect loop.
Note that there is unfortunately no test for this right now, as it would
require faking host names etc. I'm confident this fix works because it's
already running in "production".

Enable logging for the scionlab.org site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/327)
<!-- Reviewable:end -->
