### PR TITLE
Fixup broken tests after #309

### DIFF
--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -27,7 +27,6 @@ from scionlab.defines import (
     DISPATCHER_PROM_PORT,
     CS_QUIC_PORT,
     CS_PROM_PORT,
-    SD_TCP_PORT,
     SD_PROM_PORT,
     SCION_CONFIG_DIR,
     SCION_VAR_DIR,

--- a/scionlab/tests/utils.py
+++ b/scionlab/tests/utils.py
@@ -503,7 +503,6 @@ def _check_tarball_etc_scion(testcase, tar, host):
         'beacon_policy.yaml',
         'certs',
         'keys',
-        'sd.toml',
         'topology.json',
     ]
     expected += [
@@ -544,7 +543,7 @@ def _check_tarball_info(testcase, tar, host):
           for _ in host.services.filter(type=Service.BW)]
 
     expected_services = br + cs + bw + [
-        "scion-daemon@sd.service",
+        "scion-daemon.service",
         "scion-dispatcher.service",
     ]
 


### PR DESCRIPTION
Small fixes for flake and unittests after merging #309 prematurely.

Note: as I was expecting the integration tests to be failing after #309,
I merged despite the big red cross warning of failing tests -- I whould
of course have checked that the basic tests _are_ passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/330)
<!-- Reviewable:end -->
