### PR TITLE
Fix extract empty directories in scionlab-config

### DIFF
--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -465,7 +465,7 @@ def install_config_files(old_files, new_files, skip, tar):
     # safely extract files; paths in new_files (file hashes listed in the config info) has already
     # been sanity checked. Because we also want to extract any possibly empty directories that may
     # be in the tar, we sanity check the remaining items too. These should only be dirs.
-    to_check = set(tar.getnames()) - set(CONFIG_INFO_FILE) - set(new_files)
+    to_check = set(tar.getnames()) - {CONFIG_INFO_FILE} - set(new_files)
     _sanity_check_file_list(to_check)
     for f in to_check:
         if not tar.getmember(f).isdir():
@@ -475,7 +475,7 @@ def install_config_files(old_files, new_files, skip, tar):
     for f in to_delete:
         os.remove(_root(f))
 
-    to_extract = set(tar.getnames()) - set(skip) - set(CONFIG_INFO_FILE)
+    to_extract = set(tar.getnames()) - set(skip) - {CONFIG_INFO_FILE}
     tar.extractall(path=_root(""), members=[tar.getmember(f) for f in to_extract])
     for f in to_extract:
         shutil.chown(_root(f), user='scion', group='scion')

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -38,7 +38,6 @@ import shutil
 import subprocess
 import sys
 import tarfile
-import tempfile
 import textwrap
 import time
 import urllib.request
@@ -367,20 +366,14 @@ def install_config(args, tar):
                      ", ".join(_root(f) for f in backup))
     backup_files(backup)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # safely extract files; new_files list has been checked
-        # (c.f. warning on tarfile.TarFile.extractall)
-        to_extract = list(new_files) + [CONFIG_INFO_FILE]
-        tar.extractall(path=tmpdir, members=[tar.getmember(f) for f in to_extract])
+    stop_scion()
+    install_config_files(old_files, new_files, skip, tar)
+    enable_scionlab_services(old_config_info, new_config_info)
+    tar.extract(tar.getmember(CONFIG_INFO_FILE), path=SCION_CONFIG_PATH)
+    shutil.chown(CONFIG_INFO_FILE, user='scion', group='scion')
 
-        stop_scion()
-
-        install_config_files(old_files, new_files, skip, tmpdir)
-        enable_scionlab_services(old_config_info, new_config_info)
-        os.replace(os.path.join(tmpdir, CONFIG_INFO_FILE), CONFIG_INFO_PATH)
-
-        run_vpn_tunnels(old_files, new_files)
-        run_scion()
+    run_vpn_tunnels(old_files, new_files)
+    run_scion()
 
     # Cleanup configuration in gen/ directory (old style)
     if os.path.exists(FALLBACK_CONFIG_INFO_PATH):
@@ -466,18 +459,26 @@ def backup_file(path, suffix):
     os.rename(path, bkname)
 
 
-def install_config_files(old_files, new_files, skip, tmpdir):
-    """ Install new config files by copying from tmpdir, and remove old files """
+def install_config_files(old_files, new_files, skip, tar):
+    """ Install new config files by extracting from tar, and remove old files """
+
+    # safely extract files; paths in new_files (file hashes listed in the config info) has already
+    # been sanity checked. Because we also want to extract any possibly empty directories that may
+    # be in the tar, we sanity check the remaining items too. These should only be dirs.
+    to_check = set(tar.getnames()) - set(CONFIG_INFO_FILE) - set(new_files)
+    _sanity_check_file_list(to_check)
+    for f in to_check:
+        if not tar.getmember(f).isdir():
+            raise ValueError("The tar has a fishy member ('%s'), was expected to be a dir." % f)
 
     to_delete = set(old_files) - set(new_files) - set(skip)
     for f in to_delete:
         os.remove(_root(f))
 
-    to_install = set(new_files) - set(skip)
-    for f in to_install:
-        os.makedirs(os.path.dirname(_root(f)), exist_ok=True)
-        os.replace(os.path.join(tmpdir, f), _root(f))
-        subprocess.run(['chown', 'scion:scion', _root(f)])
+    to_extract = set(tar.getnames()) - set(skip) - set(CONFIG_INFO_FILE)
+    tar.extractall(path=_root(""), members=[tar.getmember(f) for f in to_extract])
+    for f in to_extract:
+        shutil.chown(_root(f), user='scion', group='scion')
 
 
 def enable_scionlab_services(old_config_info, new_config_info):

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -369,8 +369,8 @@ def install_config(args, tar):
     stop_scion()
     install_config_files(old_files, new_files, skip, tar)
     enable_scionlab_services(old_config_info, new_config_info)
-    tar.extract(tar.getmember(CONFIG_INFO_FILE), path=SCION_CONFIG_PATH)
-    shutil.chown(CONFIG_INFO_FILE, user='scion', group='scion')
+    tar.extract(CONFIG_INFO_FILE, path=SCION_CONFIG_PATH)
+    shutil.chown(CONFIG_INFO_PATH, user='scion', group='scion')
 
     run_vpn_tunnels(old_files, new_files)
     run_scion()

--- a/scionlab/tests/test_scionlab-config.py
+++ b/scionlab/tests/test_scionlab-config.py
@@ -352,6 +352,8 @@ class ScionlabConfigUnitTests(TestCase):
                     archive.add_dir(f)
                 else:
                     archive.write_text(f, content)
+            # Add config info file, to ensure this is ignored correctly
+            archive.write_json('scionlab-config.json', {})
 
         buf.seek(0)
         return tarfile.open(mode='r:gz', fileobj=buf)

--- a/scionlab/tests/test_scionlab-config.py
+++ b/scionlab/tests/test_scionlab-config.py
@@ -14,10 +14,14 @@
 
 import importlib.util
 import importlib.machinery
+import io
 import os
+import pathlib
 import sys
 import tarfile
+import tempfile
 from collections import namedtuple
+from contextlib import closing
 from io import StringIO
 from unittest import TestCase
 from unittest.mock import patch
@@ -25,6 +29,7 @@ from unittest.mock import patch
 from django.test import LiveServerTestCase
 
 from scionlab.models.core import Host
+from scionlab.util.archive import TarWriter
 from scionlab.tests import utils
 
 _TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -268,3 +273,112 @@ class ScionlabConfigUnitTests(TestCase):
         with patch('builtins.input', side_effect=patched_input), patch('sys.stdout', new=term):
             ret = scionlab_config._prompt(*prompt_args, **prompt_kwargs)
             return ret, term.getvalue(), prompts
+
+    def test_install_config_files(self):
+        # Each testcase consists of a description of the initial file system (and configuration
+        # info) state and the new configuration.
+        # Each entry represents either a text file or a directory (None value).
+        case = namedtuple('case', ['initial', 'files', 'skip'])
+        cases = [
+            case(
+                initial={},
+                files={
+                    'etc/scion/bar/boo': 'boo',
+                    'etc/scion/foo': 'foo',
+                    'etc/scion/dir': None,
+                },
+                skip=[],
+            ),
+            case(
+                initial={
+                    'etc/scion/bar/boo': 'boo',
+                    'etc/scion/same': 'same',
+                },
+                files={
+                    'etc/scion/bar/boo': 'newboo',
+                    'etc/scion/same': 'same',
+                },
+                skip=[],
+            ),
+            case(
+                initial={
+                    'etc/scion/bar/boo': 'boo',
+                    'etc/scion/same': 'same',
+                },
+                files={
+                    'etc/scion/bar/boo': 'newboo',
+                    'etc/scion/same': 'same',
+                },
+                skip=['etc/scion/bar/boo']
+            ),
+            case(
+                initial={
+                    'etc/scion/dir': None,
+                },
+                files={
+                    'etc/scion/dir': None,
+                    'etc/scion/dir/stuff': 'stuff',
+                },
+                skip=[],
+            ),
+        ]
+
+        for c in cases:
+            with tempfile.TemporaryDirectory() as tmp:
+                self._setup_initial_files(tmp, c.initial)
+
+                def _tmproot(path):
+                    return os.path.join(tmp, path)
+
+                tar = self._to_tar(c.files)
+                new_files = [f for f, content in c.files.items() if content is not None]
+                old_files = [f for f, content in c.initial.items() if content is not None]
+
+                with patch('scionlab_config._root', side_effect=_tmproot), \
+                        patch('shutil.chown'):
+                    scionlab_config.install_config_files(old_files, new_files, c.skip, tar)
+
+                expected = c.files
+                for f in c.skip:
+                    expected[f] = c.initial[f]
+                self._check_files(tmp, expected)
+
+    def _to_tar(self, files):
+        buf = io.BytesIO()
+        with closing(tarfile.open(mode='w:gz', fileobj=buf)) as tar:
+            archive = TarWriter(tar)
+            for f, content in files.items():
+                if content is None:
+                    archive.add_dir(f)
+                else:
+                    archive.write_text(f, content)
+
+        buf.seek(0)
+        return tarfile.open(mode='r:gz', fileobj=buf)
+
+    def _setup_initial_files(self, tmp, files):
+        for f, content in files.items():
+            filepath = pathlib.Path(tmp, f)
+            if content is None:
+                filepath.mkdir(parents=True, exist_ok=True)
+            else:
+                filepath.parent.mkdir(parents=True, exist_ok=True)
+                filepath.write_text(content)
+
+    def _check_files(self, tmp, expected):
+        actual = {}
+        for root, dirs, files in os.walk(tmp):
+            for d in dirs:
+                filepath = pathlib.Path(root, d)
+                actual[str(filepath.relative_to(tmp))] = None
+            for f in files:
+                filepath = pathlib.Path(root, f)
+                actual[str(filepath.relative_to(tmp))] = filepath.read_text()
+
+        # ok for some of the directories not to be listed in expected:
+        dirs = [f for f, content in actual.items() if content is None]
+        for d in dirs:
+            if d not in expected:
+                del actual[d]
+
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
We explicitly create empty directories in the configuration archive in
two places:
- openvpn ccd/ must exist, otherwise the server refuses to start
  (this usually doesn't make any difference as no client can connect if
  there is nothing in the ccd/)
- crypto/ca/clients/ must exist, otherwise the CS refuses to start
  (new CPPKI). As we don't put anything into this directory, we have to
  ensure it is created.

The scionlab-config script was previously explicitly only extracting
specific files listed in the configuration info "manifest" from the
archive. Now it extracts everything, after checking that the archive
only contains the expected files plus possibly some directory entries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/332)
<!-- Reviewable:end -->
