### PR TITLE
Fix .dockerignore comment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-run # mounted as volume
+# run/ mounted as volume
+run
 .circleci
 .git
 .gitignore


### PR DESCRIPTION
The .dockerignore file does not support inline comments, only comment lines.
So the run/ was previously not ignored as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/335)
<!-- Reviewable:end -->
