### PR TITLE
Fix config generation for hosts without CS

### DIFF
--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -106,8 +106,8 @@ class _ConfigGeneratorBase:
             assert service.type == Service.CS
             self.archive.write_toml((config_dir, f'{service.instance_name}.toml'),
                                     cb.build_cs_conf(service))
+            self._write_beacon_policy(config_dir, cb.build_beacon_policy(service))
 
-        self._write_beacon_policy(config_dir, cb.build_beacon_policy(service))
         self._write_topo(config_dir)
         self._write_trcs(config_dir)
         self._write_certs(config_dir)


### PR DESCRIPTION
Simple, stupid bad indent (and missing tests).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/337)
<!-- Reviewable:end -->
