### PR TITLE
instance_id property on BorderRouter/Service

### DIFF
--- a/scionlab/scion/topology.py
+++ b/scionlab/scion/topology.py
@@ -36,9 +36,7 @@ class TopologyInfo:
     TopologyInfo creates the router/service-IDs and the topology.json-dict for an AS.
 
     The routers/services in `self.routers` and `self.services` are
-    scionlab.models.core.BorderRouter/Service objects, marked up with the additional attributes
-        `instance_name`
-        `instance_id`
+    scionlab.models.core.BorderRouter/Service objects, with instance_id pre-populated.
     """
 
     def __init__(self, as_, with_sig_dummy_entry=False):
@@ -65,9 +63,8 @@ class TopologyInfo:
 def _fetch_routers(as_):
     routers = []
     for id, router in enumerate(as_.border_routers.order_by('pk').iterator(), start=1):
+        router.__dict__['instance_id'] = id
         if router.interfaces.active().exists():  # skip empty BRs
-            router.instance_id = id
-            router.instance_name = f"br-{id}"
             routers.append(router)
     return routers
 
@@ -76,8 +73,7 @@ def _fetch_services(as_):
     services = []
     for stype, _ in Service.SERVICE_TYPES:
         for id, service in enumerate(as_.services.filter(type=stype).order_by('pk'), start=1):
-            service.instance_id = id
-            service.instance_name = f"{stype.lower()}-{id}"
+            service.__dict__['instance_id'] = id
             services.append(service)
     return services
 

--- a/scionlab/tests/utils.py
+++ b/scionlab/tests/utils.py
@@ -434,11 +434,11 @@ def _check_tarball_etc_scion(testcase, tar, host):
         'topology.json',
     ]
     expected += [
-        "%s-%i.toml" % (s.type.lower(), s._service_idx()) for s in host.services.all()
+        "%s-%i.toml" % (s.type.lower(), s.instance_id) for s in host.services.all()
         if s.type in Service.CONTROL_SERVICE_TYPES
     ]
     expected += [
-        "br-%i.toml" % r._br_idx() for r in host.border_routers.all()
+        "br-%i.toml" % r.instance_id for r in host.border_routers.all()
     ]
     testcase.assertEqual(sorted(expected), tar_ls(tar, 'etc/scion'))
 
@@ -462,9 +462,9 @@ def _check_tarball_info(testcase, tar, host):
     testcase.assertEqual(config_info['version'], host.config_version)
     testcase.assertIn('url', config_info)
 
-    br = ["scion-border-router@br-%i.service" % br._br_idx()
+    br = ["scion-border-router@br-%i.service" % br.instance_id
           for br in host.border_routers.all()]
-    cs = ["scion-control-service@cs-%i.service" % s._service_idx()
+    cs = ["scion-control-service@cs-%i.service" % s.instance_id
           for s in host.services.filter(type=Service.CS)]
     bw = ["scion-bwtestserver.service"
           for _ in host.services.filter(type=Service.BW)]


### PR DESCRIPTION
In order to get rid of the `control_port` and `internal_port` fields
for the routers, we will want to determine these ports based on the
routers `instance_id`.

The `instance_id` had previously been treated specially and was only
added when fetching the objects to generate the AS topology; this was
done because determining the id based on the PK order is normally
expensive, but we can cheaply annotate the objects when we load all
BorderRouter/Services of an AS anyway.

This change turns the `instance_id` into a "normal" `cached_property` on
BorderRouter/Service, so it is always available. We still do the
annotation optimisation when fetching the objects while generating the
AS topology, by simply overriding the `instance_id` entry in the
object's `__dict__` -- this is exactly how the `cached_property`
operates internally too, so fair game.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/346)
<!-- Reviewable:end -->
