### PR TITLE
Use absolute path in scionlab-config.service

### DIFF
--- a/scionlab/hostfiles/scionlab-config.service
+++ b/scionlab/hostfiles/scionlab-config.service
@@ -4,7 +4,7 @@ Description=scionlab-config daemon mode
 
 [Service]
 Type=simple
-ExecStart=scionlab-config --daemon
+ExecStart=/usr/bin/scionlab-config --daemon
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Use absolute path to scionlab-config executable in scionlab-config.service.
This is enforced by systemd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/351)
<!-- Reviewable:end -->
