### PR TITLE
dockerignore: add .circleci back

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # run/ mounted as volume
 run
+.circleci
 .git
 .gitignore
 


### PR DESCRIPTION
Accidentally removed in #355. The .circleci subdirectory is unnecessary
for the production docker image builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/357)
<!-- Reviewable:end -->
