### PR TITLE
Remove obsolete rev_ttl and rev_overlap options

### DIFF
--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -301,8 +301,6 @@ class _ConfigBuilder:
             'beaconing': {
                 'origination_interval': interval,
                 'propagation_interval': interval,
-                'rev_ttl': '20s',
-                'rev_overlap': '5s',
                 'policies': {
                     'propagation': os.path.join(self.config_dir, 'beacon_policy.yaml')
                 }

--- a/scionlab/tests/data/test_config_tar/host_1.yml
+++ b/scionlab/tests/data/test_config_tar/host_1.yml
@@ -425,8 +425,6 @@ etc/scion/cs-1.toml: |
   [beaconing]
   origination_interval = "60s"
   propagation_interval = "60s"
-  rev_overlap = "5s"
-  rev_ttl = "20s"
 
   [general]
   config_dir = "/etc/scion"
@@ -534,7 +532,7 @@ scionlab-config.json: |-
       "etc/scion/crypto/voting/ISD17-ASffaa_0_1101.sensitive.crt": "bb2628e2081161030858ed029857ec5f1fa16775",
       "etc/scion/crypto/voting/regular-voting.key": "154aac0ce5aeb4730e89636555aecace6e854b7b",
       "etc/scion/crypto/voting/sensitive-voting.key": "7b814e500635ee18eaf9af8f6d7d8b7de5653222",
-      "etc/scion/cs-1.toml": "29acf3f22d998849dda271314af17f3ecfdbc9d8",
+      "etc/scion/cs-1.toml": "3cc5e42e3dc78a28bd0e5c0aae2cc817f2fc42ea",
       "etc/scion/keys/master0.key": "70deed870340082346f2554d163ac20928e0412d",
       "etc/scion/keys/master1.key": "70deed870340082346f2554d163ac20928e0412d",
       "etc/scion/topology.json": "d98ff25307e2eda82b43957ef622e550831dc324"

--- a/scionlab/tests/data/test_config_tar/host_16.yml
+++ b/scionlab/tests/data/test_config_tar/host_16.yml
@@ -453,8 +453,6 @@ etc/scion/cs-1.toml: |
   [beaconing]
   origination_interval = "5s"
   propagation_interval = "5s"
-  rev_overlap = "5s"
-  rev_ttl = "20s"
 
   [general]
   config_dir = "/etc/scion"
@@ -533,7 +531,7 @@ scionlab-config.json: |-
       "etc/scion/certs/ISD20-B1-S1.trc": "66a6da3efd14c19c51c88dacd3de1534caa9b92c",
       "etc/scion/crypto/as/ISD17-ASffaa_1_1.pem": "9ee0ef4b9ba69ce243876c91af6450486cd7ed36",
       "etc/scion/crypto/as/cp-as.key": "9146df68cbb0c8995fedf690b93ea0114665303b",
-      "etc/scion/cs-1.toml": "971405d2fe08e2a2a7f6f7ad259dbd3d8746fd79",
+      "etc/scion/cs-1.toml": "84467cd10682d975caeccba3a7eaaec1bd9ea858",
       "etc/scion/keys/master0.key": "a7482404d0e639c890d1077791061e2d5bd530df",
       "etc/scion/keys/master1.key": "a7482404d0e639c890d1077791061e2d5bd530df",
       "etc/scion/topology.json": "58a289a357e0154a2ee7c4a47c6a2923152424b1"

--- a/scionlab/tests/data/test_config_tar/host_17.yml
+++ b/scionlab/tests/data/test_config_tar/host_17.yml
@@ -330,8 +330,6 @@ etc/scion/cs-1.toml: |
   [beaconing]
   origination_interval = "5s"
   propagation_interval = "5s"
-  rev_overlap = "5s"
-  rev_ttl = "20s"
 
   [general]
   config_dir = "/etc/scion"
@@ -410,7 +408,7 @@ scionlab-config.json: |-
       "etc/scion/certs/ISD20-B1-S1.trc": "66a6da3efd14c19c51c88dacd3de1534caa9b92c",
       "etc/scion/crypto/as/ISD19-ASffaa_1_2.pem": "430b7a1146e18b7696db59e79ee6cdc20fbeed59",
       "etc/scion/crypto/as/cp-as.key": "6c7c05a511790222a8bc666047ea0e1670082c7c",
-      "etc/scion/cs-1.toml": "971405d2fe08e2a2a7f6f7ad259dbd3d8746fd79",
+      "etc/scion/cs-1.toml": "84467cd10682d975caeccba3a7eaaec1bd9ea858",
       "etc/scion/keys/master0.key": "830fe170742ae27e1c8867c09a799815e7ec3dbb",
       "etc/scion/keys/master1.key": "830fe170742ae27e1c8867c09a799815e7ec3dbb",
       "etc/scion/topology.json": "5c061e2995f336aebcb64f06b25da87684e8c2b8"

--- a/scionlab/tests/data/test_config_tar/host_4.yml
+++ b/scionlab/tests/data/test_config_tar/host_4.yml
@@ -470,8 +470,6 @@ etc/scion/cs-1.toml: |
   [beaconing]
   origination_interval = "5s"
   propagation_interval = "5s"
-  rev_overlap = "5s"
-  rev_ttl = "20s"
 
   [general]
   config_dir = "/etc/scion"
@@ -572,7 +570,7 @@ scionlab-config.json: |-
       "etc/scion/certs/ISD20-B1-S1.trc": "66a6da3efd14c19c51c88dacd3de1534caa9b92c",
       "etc/scion/crypto/as/ISD17-ASffaa_0_1107.pem": "98da874b3c5235b7db5c738fc2823688fbc96388",
       "etc/scion/crypto/as/cp-as.key": "a021c811417bf4ce9a0e924fe6083d9a978cf67e",
-      "etc/scion/cs-1.toml": "971405d2fe08e2a2a7f6f7ad259dbd3d8746fd79",
+      "etc/scion/cs-1.toml": "84467cd10682d975caeccba3a7eaaec1bd9ea858",
       "etc/scion/keys/master0.key": "73184546f40ab4bc57870965e4a5896105a8ca2a",
       "etc/scion/keys/master1.key": "73184546f40ab4bc57870965e4a5896105a8ca2a",
       "etc/scion/topology.json": "919e85f60aa61648a1d45d792fda85581c0537f4"

--- a/scionlab/tests/data/test_config_tar/user_as_18.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_18.yml
@@ -332,8 +332,6 @@ etc/scion/cs-1.toml: |
   [beaconing]
   origination_interval = "5s"
   propagation_interval = "5s"
-  rev_overlap = "5s"
-  rev_ttl = "20s"
 
   [general]
   config_dir = "/etc/scion"
@@ -411,7 +409,7 @@ scionlab-config.json: |-
       "etc/scion/certs/ISD20-B1-S1.trc": "66a6da3efd14c19c51c88dacd3de1534caa9b92c",
       "etc/scion/crypto/as/ISD20-ASffaa_1_3.pem": "55fddb15c9266b80cd6a668f6c180ff17f48a3f4",
       "etc/scion/crypto/as/cp-as.key": "dc59568c9fc7e76d94e33987ddcf8d8c98e7e0ea",
-      "etc/scion/cs-1.toml": "971405d2fe08e2a2a7f6f7ad259dbd3d8746fd79",
+      "etc/scion/cs-1.toml": "84467cd10682d975caeccba3a7eaaec1bd9ea858",
       "etc/scion/keys/master0.key": "9f8c82543b3f0e4b2e91fd9e12b99a73d4e48afe",
       "etc/scion/keys/master1.key": "9f8c82543b3f0e4b2e91fd9e12b99a73d4e48afe",
       "etc/scion/topology.json": "8bd681097537472c8e750c0eefd2f6a32413c674"

--- a/scionlab/tests/data/test_config_tar/user_as_19.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_19.yml
@@ -455,8 +455,6 @@ etc/scion/cs-1.toml: |
   [beaconing]
   origination_interval = "5s"
   propagation_interval = "5s"
-  rev_overlap = "5s"
-  rev_ttl = "20s"
 
   [general]
   config_dir = "/etc/scion"
@@ -535,7 +533,7 @@ scionlab-config.json: |-
       "etc/scion/certs/ISD20-B1-S1.trc": "66a6da3efd14c19c51c88dacd3de1534caa9b92c",
       "etc/scion/crypto/as/ISD20-ASffaa_1_4.pem": "9652fc45e8b0f6877c69c15fd80df90441204245",
       "etc/scion/crypto/as/cp-as.key": "bca52213b23b496adcab7c2625e678256edc127c",
-      "etc/scion/cs-1.toml": "971405d2fe08e2a2a7f6f7ad259dbd3d8746fd79",
+      "etc/scion/cs-1.toml": "84467cd10682d975caeccba3a7eaaec1bd9ea858",
       "etc/scion/keys/master0.key": "1369f5f512c33e2f02573f843ccafb42e916d726",
       "etc/scion/keys/master1.key": "1369f5f512c33e2f02573f843ccafb42e916d726",
       "etc/scion/topology.json": "cf3a4aad5cb3a2c2ca1ba7d45a1fb0d91b3239f1"

--- a/scionlab/tests/data/test_config_tar/user_as_20.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_20.yml
@@ -332,8 +332,6 @@ gen/ASffaa_1_5/cs-1.toml: |
   [beaconing]
   origination_interval = "5s"
   propagation_interval = "5s"
-  rev_overlap = "5s"
-  rev_ttl = "20s"
 
   [general]
   config_dir = "gen/ASffaa_1_5"


### PR DESCRIPTION
Remove obsolete rev_ttl and rev_overlap options from the generated CS config file.
These options are still accepted but ignored by the current version of
the CS. This was cleaned up in the SCION upstream and will no longer be
recognised in the configuration file (https://github.com/scionproto/scion/commit/4234a5869fdde41abe0e007d29aadc37d2af6b2f).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/360)
<!-- Reviewable:end -->
