### PR TITLE
scionlab-config: default to "keep" in prompts, add option to silence prompts

### DIFF
--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -549,7 +549,7 @@ def install_config_files(old_files, new_files, skip, confnew, tar):
     for f in to_extract:
         shutil.chown(_root(f), user='scion', group='scion')
 
-    # Also extract all changed and skipped files for reference with a .confnew suffix
+    # Extract reference files with a .confnew suffix
     suffixing_tar = _SuffixingTarFile(CONFNEW_SUFFIX, tar)
     suffixing_tar.extractall(path=_root(""),
                              members=[tar.getmember(f) for f in confnew])

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -54,6 +54,8 @@ CONFIG_INFO_FILE = 'scionlab-config.json'
 CONFIG_INFO_PATH = os.path.join(SCION_CONFIG_PATH, CONFIG_INFO_FILE)
 FALLBACK_CONFIG_INFO_PATH = os.path.join(SCION_CONFIG_PATH, 'gen', CONFIG_INFO_FILE)
 
+CONFNEW_SUFFIX = '.confnew'
+
 # Names for
 FALLBACK_SYSTEMD_UNIT_PATTERNS = [
     'scion-border-router', 'scion-control-service', 'scion-daemon', 'scionlab-dispatcher'
@@ -413,7 +415,7 @@ def install_config(args, tar):
     new_config_info = _read_config_info_tar_member(tar)
     new_files = new_config_info.files
 
-    skip, backup = resolve_file_conflicts(args.force, args.keep, old_files, new_files)
+    skip, confnew, backup = resolve_file_conflicts(args.force, args.keep, old_files, new_files)
 
     if args.force and backup:  # only warn in --force, otherwise user has already been prompted
         logging.warn("Overwriting files with local modifications, creating backup: %s",
@@ -421,7 +423,7 @@ def install_config(args, tar):
     backup_files(backup)
 
     stop_scion()
-    install_config_files(old_files, new_files, skip, new_config_info.version, tar)
+    install_config_files(old_files, new_files, skip, confnew, tar)
     enable_scionlab_services(old_config_info, new_config_info)
     tar.extract(CONFIG_INFO_FILE, path=SCION_CONFIG_PATH)
     shutil.chown(CONFIG_INFO_PATH, user='scion', group='scion')
@@ -437,27 +439,34 @@ def install_config(args, tar):
 def resolve_file_conflicts(force, keep, old_files, new_files):
     """
     Check for modification conflicts and determines the appropriate action, prompting the user
-    where necessary. Returns the lists of files to be skipped and backed-up
+    where necessary.
+    Returns the lists of conflicting files to skip, install as .confnew, or backup:
+        - skipped: will be ignored and not installed / removed
+        - confnew: will be installed, but with a .confnew suffix, for reference.
+        - backup: will be backed up
 
-    :returns: list of files to be skipped, list of files to backed up
+    :returns: list of files to skip, confnew, backup
     """
     assert not (force and keep)
 
     conflicts = find_file_conflicts(old_files, new_files)
     if force:
         skip = []
+        confnew = []
         backup = conflicts
     else:
-        unchanged = [f for f in new_files if new_files[f] == old_files.get(f, None)]
-        prompts = sorted(set(conflicts) - set(unchanged))
+        unchanged = [f for f in conflicts
+                     if new_files.get(f, None) == old_files.get(f, None)]
         if keep:
-            skip = prompts
+            skip = unchanged
+            confnew = set(conflicts) - set(unchanged)
             backup = []
         else:
-            skip, backup = prompt_conflicts(old_files, new_files, prompts)
-        skip += unchanged
+            prompts = sorted(set(conflicts) - set(unchanged))
+            confnew, backup = prompt_conflicts(old_files, new_files, prompts)
+            skip = unchanged
 
-    return skip, backup
+    return skip, confnew, backup
 
 
 def find_file_conflicts(old_files, new_files):
@@ -480,7 +489,7 @@ def find_file_conflicts(old_files, new_files):
 
 
 def prompt_conflicts(old_files, new_files, conflicts):
-    skip = []
+    keep = []
     backup = []
     for f in conflicts:
         if f in old_files:
@@ -495,11 +504,11 @@ def prompt_conflicts(old_files, new_files, conflicts):
         if reply == "quit":
             sys.exit(1)
         elif reply == "keep":
-            skip.append(f)
+            keep.append(f)
         elif reply == "backup":
             backup.append(f)
 
-    return skip, backup
+    return keep, backup
 
 
 def backup_files(files):
@@ -519,7 +528,7 @@ def backup_file(path, suffix):
     os.rename(path, bkname)
 
 
-def install_config_files(old_files, new_files, skip, new_version, tar):
+def install_config_files(old_files, new_files, skip, confnew, tar):
     """ Install new config files by extracting from tar, and remove old files """
 
     # safely extract files; paths in new_files (file hashes listed in the config info) has already
@@ -535,19 +544,17 @@ def install_config_files(old_files, new_files, skip, new_version, tar):
     for f in to_delete:
         os.remove(_root(f))
 
-    to_extract = set(tar.getnames()) - set(skip) - {CONFIG_INFO_FILE}
+    to_extract = set(tar.getnames()) - set(skip) - set(confnew) - {CONFIG_INFO_FILE}
     tar.extractall(path=_root(""), members=[tar.getmember(f) for f in to_extract])
     for f in to_extract:
         shutil.chown(_root(f), user='scion', group='scion')
 
-    # Also extract all new but skipped files for reference with a .v{version} suffix
-    suffix = '.v%d' % new_version
-    suffixing_tar = _SuffixingTarFile(suffix, tar)
-    to_extract_suffixed = set(suffixing_tar.getnames()).intersection(skip)
+    # Also extract all changed and skipped files for reference with a .v{version} suffix
+    suffixing_tar = _SuffixingTarFile(CONFNEW_SUFFIX, tar)
     suffixing_tar.extractall(path=_root(""),
-                             members=[tar.getmember(f) for f in to_extract_suffixed])
-    for f in to_extract_suffixed:
-        shutil.chown(_root(f+suffix), user='scion', group='scion')
+                             members=[tar.getmember(f) for f in confnew])
+    for f in confnew:
+        shutil.chown(_root(f+CONFNEW_SUFFIX), user='scion', group='scion')
 
 
 class _SuffixingTarFile(tarfile.TarFile):

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -469,10 +469,10 @@ def prompt_conflicts(old_files, new_files, conflicts):
         else:
             explanation = "File '/%s' exists on disk and the updated config would overwrite it." % f
 
-        question = ("Do you want to (b)ackup + replace, (o)verwrite, or (k)eep the file? "
-                    "(default: backup + replace)?")
-        options = ["backup", "overwrite", "keep", "quit"]
-        reply = _prompt(explanation, question, options, default="backup")
+        question = ("Do you want to (k)eep, (b)ackup + replace, or (o)verwrite the file? "
+                    "(default: keep)?")
+        options = ["keep", "backup", "overwrite", "quit"]
+        reply = _prompt(explanation, question, options, default="keep")
         if reply == "quit":
             sys.exit(1)
         elif reply == "keep":

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -91,7 +91,8 @@ FetchInfo = namedtuple('FetchInfo',
 # services installed by this script.
 ConfigInfo = namedtuple('ConfigInfo',
                         ['files',
-                         'systemd_units'])
+                         'systemd_units',
+                         'version'])
 
 
 def main(argv):
@@ -407,7 +408,7 @@ def install_config(args, tar):
     backup_files(backup)
 
     stop_scion()
-    install_config_files(old_files, new_files, skip, tar)
+    install_config_files(old_files, new_files, skip, new_config_info.version, tar)
     enable_scionlab_services(old_config_info, new_config_info)
     tar.extract(CONFIG_INFO_FILE, path=SCION_CONFIG_PATH)
     shutil.chown(CONFIG_INFO_PATH, user='scion', group='scion')
@@ -499,7 +500,7 @@ def backup_file(path, suffix):
     os.rename(path, bkname)
 
 
-def install_config_files(old_files, new_files, skip, tar):
+def install_config_files(old_files, new_files, skip, new_version, tar):
     """ Install new config files by extracting from tar, and remove old files """
 
     # safely extract files; paths in new_files (file hashes listed in the config info) has already
@@ -519,6 +520,32 @@ def install_config_files(old_files, new_files, skip, tar):
     tar.extractall(path=_root(""), members=[tar.getmember(f) for f in to_extract])
     for f in to_extract:
         shutil.chown(_root(f), user='scion', group='scion')
+
+    # Also extract all new but skipped files for reference with a .v{version} suffix
+    suffix = '.v%d' % new_version
+    suffixing_tar = _SuffixingTarFile(suffix, tar)
+    to_extract_suffixed = set(suffixing_tar.getnames()).intersection(skip)
+    suffixing_tar.extractall(path=_root(""),
+                             members=[tar.getmember(f) for f in to_extract_suffixed])
+    for f in to_extract_suffixed:
+        shutil.chown(_root(f+suffix), user='scion', group='scion')
+
+
+class _SuffixingTarFile(tarfile.TarFile):
+    """
+    TarFile with override to append suffix to extracted files.
+    """
+
+    def __init__(self, suffix, wrapped):
+        self.suffix = suffix
+        self.wrapped = wrapped
+
+    def __getattr__(self, attr):
+        return getattr(self.wrapped, attr)
+
+    def makefile(self, tarinfo, targetpath):
+        # see tarfile.py: called in _extract_member, "can be replaced in a subclass"
+        super().makefile(tarinfo, targetpath + self.suffix)
 
 
 def enable_scionlab_services(old_config_info, new_config_info):
@@ -630,7 +657,7 @@ def list_tun_interfaces():
 
 def _read_config_info_file():
     """
-    Load and parse the fetch information from the scionlab-config.json file.
+    Load and parse the config information from the scionlab-config.json file.
     :returns: ConfigInfo or None
     """
     if not os.path.exists(CONFIG_INFO_PATH):
@@ -645,7 +672,7 @@ def _read_config_info_file():
 
 def _read_config_info_tar_member(tar):
     """
-    Load and parse the fetch information from the scionlab-config.json tar member.
+    Load and parse the config information from the scionlab-config.json tar member.
     :returns: ConfigInfo
     """
     try:
@@ -662,8 +689,10 @@ def _read_config_info(f):
     """
     config_info_dict = json.load(f)
     info = ConfigInfo(config_info_dict['files'],
-                      config_info_dict['systemd_units'])
+                      config_info_dict['systemd_units'],
+                      config_info_dict['version'])
     _sanity_check_file_list(info.files)
+    _sanity_check_version(info.version)
     return info
 
 
@@ -685,6 +714,14 @@ def _sanity_check_file_list(files):
                 or not any(os.path.commonpath([os.path.dirname(f), d]) == d
                            for d in acceptable_dirs)):
             raise ValueError("The list of files has a fishy entry ('%s')." % f)
+
+
+def _sanity_check_version(version):
+    """
+    Sanity check that the version is the expected integer value in a sensible range.
+    """
+    if type(version) is not int or version < 0 or version >= 2**64:
+        raise ValueError("The version info looks fishy.")
 
 
 def _root(path):

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -148,7 +148,7 @@ def parse_command_line_args(argv):
         locally and is also changed in the new version of the configuration, the script
         asks for confirmation before overwriting the file.
         If the user decides to keep a modified, conflicting file, the new configuration
-        file version will be installed with a .v{version} suffix for reference.
+        file version will be installed with a .confnew suffix for reference.
         Use --keep to disable prompts and keep all locally modified config files.
         Use --force to overwrite all locally modified config files and disable prompts
         in case of conflicting file modifications.
@@ -549,7 +549,7 @@ def install_config_files(old_files, new_files, skip, confnew, tar):
     for f in to_extract:
         shutil.chown(_root(f), user='scion', group='scion')
 
-    # Also extract all changed and skipped files for reference with a .v{version} suffix
+    # Also extract all changed and skipped files for reference with a .confnew suffix
     suffixing_tar = _SuffixingTarFile(CONFNEW_SUFFIX, tar)
     suffixing_tar.extractall(path=_root(""),
                              members=[tar.getmember(f) for f in confnew])

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -145,6 +145,9 @@ def parse_command_line_args(argv):
         configuration files. If a conflict occurs, e.g. if a file appears to be modified
         locally and is also changed in the new version of the configuration, the script
         asks for confirmation before overwriting the file.
+        If the user decides to keep a modified, conflicting file, the new configuration
+        file version will be installed with a .v{version} suffix for reference.
+        Use --keep to disable prompts and keep all locally modified config files.
         Use --force to overwrite all locally modified config files and disable prompts
         in case of conflicting file modifications.
         """
@@ -165,15 +168,21 @@ def parse_command_line_args(argv):
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
 
     group_config = parser.add_argument_group('Configuration installation options')
-    group_config.add_argument('--force',
-                              action='store_true',
-                              help='Overwrite locally modified configuration files. '
-                                   'Unconditionally fetch latest configuration from SCIONLab API.')
+    force_or_keep = group_config.add_mutually_exclusive_group()
+    force_or_keep.add_argument('--force',
+                               action='store_true',
+                               help='Overwrite locally modified configuration files. '
+                                    'Unconditionally fetch latest configuration from SCIONLab API.')
+    force_or_keep.add_argument('--keep',
+                               action='store_true',
+                               help='Disable interactive prompt and always keep '
+                                    'locally modified configuration files. '
+                                    'This is enabled by default if --force is not set and '
+                                    'the stdin is not a TTY.')
     group_config.add_argument('--tar',
                               type=argparse.FileType('r'),
                               help='Install configuration from a tar-file already obtained from '
                                    'the SCIONLab coordination service')
-
     group_fetch = parser.add_argument_group('SCIONLab API options')
     group_fetch.add_argument('--host-id', help='Host identifier')
     group_fetch.add_argument('--host-secret', help='Authentication for host')
@@ -196,6 +205,10 @@ def parse_command_line_args(argv):
     else:
         if bool(args.host_id) != bool(args.host_secret):
             parser.error("arguments --host-id and --host-secret must be used together\n")
+
+    if not args.force and not args.keep:
+        args.keep = not sys.stdin.isatty()
+
     return args
 
 
@@ -400,7 +413,7 @@ def install_config(args, tar):
     new_config_info = _read_config_info_tar_member(tar)
     new_files = new_config_info.files
 
-    skip, backup = resolve_file_conflicts(args.force, old_files, new_files)
+    skip, backup = resolve_file_conflicts(args.force, args.keep, old_files, new_files)
 
     if args.force and backup:  # only warn in --force, otherwise user has already been prompted
         logging.warn("Overwriting files with local modifications, creating backup: %s",
@@ -421,13 +434,15 @@ def install_config(args, tar):
         shutil.rmtree(os.path.join(SCION_CONFIG_PATH, 'gen'), ignore_errors=True)
 
 
-def resolve_file_conflicts(force, old_files, new_files):
+def resolve_file_conflicts(force, keep, old_files, new_files):
     """
     Check for modification conflicts and determines the appropriate action, prompting the user
     where necessary. Returns the lists of files to be skipped and backed-up
 
     :returns: list of files to be skipped, list of files to backed up
     """
+    assert not (force and keep)
+
     conflicts = find_file_conflicts(old_files, new_files)
     if force:
         skip = []
@@ -435,7 +450,11 @@ def resolve_file_conflicts(force, old_files, new_files):
     else:
         unchanged = [f for f in new_files if new_files[f] == old_files.get(f, None)]
         prompts = sorted(set(conflicts) - set(unchanged))
-        skip, backup = prompt_conflicts(old_files, new_files, prompts)
+        if keep:
+            skip = prompts
+            backup = []
+        else:
+            skip, backup = prompt_conflicts(old_files, new_files, prompts)
         skip += unchanged
 
     return skip, backup

--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -549,7 +549,7 @@ def install_config_files(old_files, new_files, skip, confnew, tar):
     for f in to_extract:
         shutil.chown(_root(f), user='scion', group='scion')
 
-    # Extract reference files with a .confnew suffix
+    # Extract some files with a .confnew suffix (for reference)
     suffixing_tar = _SuffixingTarFile(CONFNEW_SUFFIX, tar)
     suffixing_tar.extractall(path=_root(""),
                              members=[tar.getmember(f) for f in confnew])

--- a/scionlab/tests/test_scionlab-config.py
+++ b/scionlab/tests/test_scionlab-config.py
@@ -249,6 +249,9 @@ class ScionlabConfigUnitTests(TestCase):
 
                 self.assertEqual(mock_prompt.call_count, expected_num_prompts if not c.force else 0,
                                  c)
+                for call in mock_prompt.call_args_list:
+                    self.assertEqual(call[1]["default"], "keep", call)
+
                 self.assertEqual(sorted(skip), sorted(c.expected_skip), c)
                 self.assertEqual(sorted(backup), sorted(c.expected_backup), c)
 

--- a/scionlab/tests/test_scionlab-config.py
+++ b/scionlab/tests/test_scionlab-config.py
@@ -206,34 +206,37 @@ class ScionlabConfigUnitTests(TestCase):
         # user input on prompt:
         expected_num_prompts = 2
         case = namedtuple('case', ['force', 'keep', 'prompt_reply', 'expected_skip',
-                                   'expected_backup'])
-        case.__new__.__defaults__ = (False, False, None, None, None)
+                                   'expected_confnew', 'expected_backup'])
+        case.__new__.__defaults__ = (False, False, None, None, None, None)
         cases = [
             case(
                 force=True,
                 expected_skip=[],
+                expected_confnew=[],
                 expected_backup=["etc/scion/fmo.toml", "etc/scion/bar.toml", "etc/scion/egg.toml"],
             ),
             case(
                 prompt_reply="backup",
-                expected_skip=["etc/scion/foo.toml", "etc/scion/fmo.toml"],
+                expected_skip=["etc/scion/fmo.toml"],
+                expected_confnew=[],
                 expected_backup=["etc/scion/bar.toml", "etc/scion/egg.toml"],
             ),
             case(
                 prompt_reply="keep",
-                expected_skip=["etc/scion/foo.toml", "etc/scion/fmo.toml",
-                               "etc/scion/bar.toml", "etc/scion/egg.toml"],
+                expected_skip=["etc/scion/fmo.toml"],
+                expected_confnew=["etc/scion/bar.toml", "etc/scion/egg.toml"],
                 expected_backup=[],
             ),
             case(
                 keep=True,
-                expected_skip=["etc/scion/foo.toml", "etc/scion/fmo.toml",
-                               "etc/scion/bar.toml", "etc/scion/egg.toml"],
+                expected_skip=["etc/scion/fmo.toml"],
+                expected_confnew=["etc/scion/bar.toml", "etc/scion/egg.toml"],
                 expected_backup=[],
             ),
             case(
                 prompt_reply="overwrite",
-                expected_skip=["etc/scion/foo.toml", "etc/scion/fmo.toml"],
+                expected_skip=["etc/scion/fmo.toml"],
+                expected_confnew=[],
                 expected_backup=[],
             ),
         ]
@@ -249,8 +252,8 @@ class ScionlabConfigUnitTests(TestCase):
                     patch('os.path.exists', side_effect=_mock_os_path_exists), \
                     patch('scionlab_config._prompt', return_value=c.prompt_reply) as mock_prompt:
 
-                skip, backup = scionlab_config.resolve_file_conflicts(c.force, c.keep,
-                                                                      old_files, new_files)
+                skip, confnew, backup = scionlab_config.resolve_file_conflicts(c.force, c.keep,
+                                                                               old_files, new_files)
 
                 doprompt = not c.force and not c.keep
                 self.assertEqual(mock_prompt.call_count, expected_num_prompts if doprompt else 0, c)
@@ -258,6 +261,7 @@ class ScionlabConfigUnitTests(TestCase):
                     self.assertEqual(call[1]["default"], "keep", call)
 
                 self.assertEqual(sorted(skip), sorted(c.expected_skip), c)
+                self.assertEqual(sorted(confnew), sorted(c.expected_confnew), c)
                 self.assertEqual(sorted(backup), sorted(c.expected_backup), c)
 
     def test_prompt(self):
@@ -317,7 +321,7 @@ class ScionlabConfigUnitTests(TestCase):
         # Each testcase consists of a description of the initial file system (and configuration
         # info) state and the new configuration.
         # Each entry represents either a text file or a directory (None value).
-        case = namedtuple('case', ['initial', 'files', 'skip'])
+        case = namedtuple('case', ['initial', 'files', 'skip', 'confnew'])
         cases = [
             case(
                 initial={},
@@ -327,6 +331,7 @@ class ScionlabConfigUnitTests(TestCase):
                     'etc/scion/dir': None,
                 },
                 skip=[],
+                confnew=[],
             ),
             case(
                 initial={
@@ -338,17 +343,21 @@ class ScionlabConfigUnitTests(TestCase):
                     'etc/scion/same': 'same',
                 },
                 skip=[],
+                confnew=[],
             ),
             case(
                 initial={
                     'etc/scion/bar/boo': 'boo',
+                    'etc/scion/bar/hoo': 'hoo',
                     'etc/scion/same': 'same',
                 },
                 files={
                     'etc/scion/bar/boo': 'newboo',
+                    'etc/scion/bar/hoo': 'newhoo',
                     'etc/scion/same': 'same',
                 },
-                skip=['etc/scion/bar/boo']
+                skip=['etc/scion/bar/boo'],
+                confnew=['etc/scion/bar/hoo']
             ),
             case(
                 initial={
@@ -359,6 +368,7 @@ class ScionlabConfigUnitTests(TestCase):
                     'etc/scion/dir/stuff': 'stuff',
                 },
                 skip=[],
+                confnew=[],
             ),
         ]
 
@@ -375,12 +385,15 @@ class ScionlabConfigUnitTests(TestCase):
 
                 with patch('scionlab_config._root', side_effect=_tmproot), \
                         patch('shutil.chown'):
-                    scionlab_config.install_config_files(old_files, new_files, c.skip, 2, tar)
+                    scionlab_config.install_config_files(old_files, new_files,
+                                                         c.skip, c.confnew, tar)
 
                 expected = c.files.copy()
                 for f in c.skip:
                     expected[f] = c.initial[f]
-                    expected[f + '.v2'] = c.files[f]
+                for f in c.confnew:
+                    expected[f] = c.initial[f]
+                    expected[f + '.confnew'] = c.files[f]
 
                 self._check_files(tmp, expected)
 

--- a/scionlab/tests/test_scionlab-config.py
+++ b/scionlab/tests/test_scionlab-config.py
@@ -158,6 +158,17 @@ class ScionlabConfigUnitTests(TestCase):
             _check_bad([f])  # individual bad fail
             _check_bad(good + [f])  # individual bad with good still fail
 
+    def test_sanity_check_version(self):
+        good = [0, 1, 10000]
+        bad = ['foo', {}, '1', '123', 1.0]
+
+        for version in good:
+            scionlab_config._sanity_check_version(version)
+
+        for version in bad:
+            with self.assertRaises(ValueError):
+                scionlab_config._sanity_check_version(version)
+
     def test_resolve_file_conflicts(self):
         # Test setup defines some files and their pseudo sha1 hashes:
         # foo: unchanged
@@ -356,11 +367,13 @@ class ScionlabConfigUnitTests(TestCase):
 
                 with patch('scionlab_config._root', side_effect=_tmproot), \
                         patch('shutil.chown'):
-                    scionlab_config.install_config_files(old_files, new_files, c.skip, tar)
+                    scionlab_config.install_config_files(old_files, new_files, c.skip, 2, tar)
 
-                expected = c.files
+                expected = c.files.copy()
                 for f in c.skip:
                     expected[f] = c.initial[f]
+                    expected[f + '.v2'] = c.files[f]
+
                 self._check_files(tmp, expected)
 
     def _to_tar(self, files):
@@ -403,4 +416,4 @@ class ScionlabConfigUnitTests(TestCase):
             if d not in expected:
                 del actual[d]
 
-        self.assertEqual(actual, expected)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
In the postinst-script of the scionlab.deb debian package, we currently invoke `scionlab-config` with `--force`; the idea was that we want to ensure a clean state during package upgrades. Also, `--force` was previously the only way to silence prompts. However, this hinders tinkering with the configuration files as modifications are frequently overwritten (albeit with a backup) somewhat unexpectedly.
We will remove the `--force` from the invocation in the package postinst script and instead default to "keep" the locally modified files.

Changes:
- install skipped files (i.e. files with conflicting edits for which the user chose to _keep_ the local version) with a `.confnew` suffix for future reference (i.e. to diff).
- make "keep" the more conservative default in prompt
- add option `--keep` to silence prompts and answer keep for all prompts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/361)
<!-- Reviewable:end -->
