### PR TITLE
ci: fix python setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,21 +50,22 @@ commands:
     steps:
       - restore_cache:
           keys:
-          - v4-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
+          - v5-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
           # fallback to using the latest cache if no exact match is found
-          - v4-dependencies-
+          - v5-dependencies-
 
       - run:
           name: Install dependencies
           command: |
             python3 -m venv /tmp/venv 2>&1
             . /tmp/venv/bin/activate
+            pip install -U pip  # need pip >= 19.0 to install cryptography
             pip install --require-hashes -r requirements.txt -r dev-requirements.txt
 
       - save_cache:
           paths:
             - /tmp/venv
-          key: v4-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
+          key: v5-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
 
 
 jobs:


### PR DESCRIPTION
Crpytography wheel cannot be easily installed with an old version of pip
(does not support the required wheel tag and whatever that entails).
Update pip before installation to fix this, bump cache key version to
force running this.
Accidentally broken in #366 -- this pip update was there initially but I
removed it later because I thought it was not needed in the newer python
docker image. Due to the cache, the later CI runs did not encounter the
problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/370)
<!-- Reviewable:end -->
