### PR TITLE
Add minimal SIG topology entry support

### DIFF
--- a/scionlab/fixtures/testdata.yaml
+++ b/scionlab/fixtures/testdata.yaml
@@ -3640,7 +3640,7 @@
     ssh_host: 172.31.0.110
     uid: 9b2eedd0a1bd41d59a6c3a37a0317024
     secret: e563ae76441a44b3b225cb26e569dc72
-    config_version: 9
+    config_version: 10
     config_version_deployed: 0
     config_queried_at: null
 - model: scionlab.host
@@ -4772,6 +4772,12 @@
     AS: 20
     host: 20
     type: CS
+- model: scionlab.service
+  pk: 23
+  fields:
+    AS: 5
+    host: 5
+    type: SIG
 - model: scionlab.vpn
   pk: 1
   fields:

--- a/scionlab/fixtures/testtopo.py
+++ b/scionlab/fixtures/testtopo.py
@@ -107,6 +107,7 @@ links = [
 extra_services = [
     (_expand_as_id(0x1107), Service.BW),
     (_expand_as_id(0x1406), Service.BW),
+    (_expand_as_id(0x1301), Service.SIG),
 ]
 
 # VPNs for APs, except 1303

--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -43,6 +43,7 @@ from scionlab.defines import (
     BR_METRICS_PORT_BASE,
     CS_PORT,
     CS_METRICS_PORT,
+    SIG_CTRL_PORT,
     BW_PORT,
     PP_PORT,
     DEFAULT_HOST_INTERNAL_IP,
@@ -1071,10 +1072,12 @@ class Service(models.Model):
     and for any other service that communicates using SCION.
     """
     CS = 'CS'
+    SIG = 'SIG'
     BW = 'BW'
     PP = 'PP'
     SERVICE_TYPES = (
         (CS, 'Control Service'),  # monolithic control plane service
+        (SIG, 'SCION IP Gateway'),
         (BW, 'Bandwidth tester server'),
         (PP, 'Pingpong server'),
     )
@@ -1087,6 +1090,7 @@ class Service(models.Model):
     )
     SERVICE_PORTS = {
         CS: CS_PORT,
+        SIG: SIG_CTRL_PORT,
         BW: BW_PORT,
         PP: PP_PORT,
     }


### PR DESCRIPTION
Previously we've had even more minimal support for SIG topology entries
only in User ASes.
Add support for an explicit SIG Service object, to allow configuring the
same thing in the SCIONLab infrastructure ASes.
As before, this is only concerned with adding a topology entry so that
the routers are able to resolve the SIG service address -- actually
configuring the SIG itself is still out of scope and is done manually on
each host.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/374)
<!-- Reviewable:end -->
