### PR TITLE
admin: fix ValidationError handling for LinkAdminForm

### DIFF
--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -159,11 +159,14 @@ class _CreateUpdateModelForm(_AlwaysChangedModelForm):
             self._update_errors(e)
 
         # Call more stuff that ModelForm usually does.
+        exclude = self._get_validation_exclusions()
         try:
-            self.instance.full_clean(validate_unique=False)
+            self.instance.full_clean(exclude=exclude, validate_unique=False)
         except ValidationError as e:
             self._update_errors(e)
-        self.validate_unique()
+
+        if self._validate_unique:
+            self.validate_unique()
 
     def save(self, commit=True):
         # We override this hook too, because we have already saved our model at this point.

--- a/scionlab/tests/test_admin.py
+++ b/scionlab/tests/test_admin.py
@@ -83,6 +83,23 @@ class LinkAdminFormTests(TestCase):
         self.assertTrue(edit_form.is_valid(), edit_form.errors)
         self.assertFalse(edit_form.has_changed(), edit_form.changed_data)
 
+    def test_create_link_error(self):
+        # Create an illegal loop-back link
+        as_a = AS.objects.first()
+        form_data = dict(
+            type=Link.PROVIDER,
+            active=True,
+            bandwidth=1234,
+            mtu=2345,
+            from_host=as_a.hosts.first().pk,
+            from_public_port=50000,
+            to_host=as_a.hosts.first().pk,
+            to_public_port=50000,
+        )
+        form = LinkAdminForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('Loop AS-link', str(form.errors['__all__'][0]))
+
     def test_render_edit(self):
         ases = AS.objects.iterator()
         as_a = next(ases)


### PR DESCRIPTION
Add appropriate exclude parameter when invoking full_clean,
analogous to the original ModelForm._post_clean.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/375)
<!-- Reviewable:end -->
