### PR TITLE
Add redirect for topology

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,7 @@ jobs:
             grep --quiet "^Server: Caddy" /tmp/headers.txt
             grep --quiet "^Server: gunicorn" /tmp/headers.txt
             curl --fail --silent "http://localhost/login/" > /dev/null
+            curl --fail --silent "http://localhost/topology" > /dev/null
             curl --fail --silent "http://localhost/topology.png" > /dev/null
             curl --fail --silent "http://localhost/api/v2/topology/topology" > /dev/null
 

--- a/scionlab/settings/common.py
+++ b/scionlab/settings/common.py
@@ -98,6 +98,7 @@ CRISPY_TEMPLATE_PACK = 'bootstrap4'
 MAINTENANCE_MODE_IGNORE_ADMIN_SITE = True
 MAINTENANCE_MODE_IGNORE_URLS = (
     r'^/$',               # home
+    r'^/topology$',   # topology map on home page
     r'^/topology.png$',   # topology map on home page
     r'^/api/',            # get config, set deployed version
 )

--- a/scionlab/urls.py
+++ b/scionlab/urls.py
@@ -72,6 +72,8 @@ urlpatterns = [
          name='user_as_detail'),
 
     path('topology.png', topology_png, name='topology.png'),
+    path('topology',
+         RedirectView.as_view(url='/topology.png')),
 
     # API:
     path('api/v3/host/<slug:uid>/config',


### PR DESCRIPTION
Add general and permanent URL for topology in case we replace the PNG image with something else in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/376)
<!-- Reviewable:end -->
