### PR TITLE
Set DEFAULT_AUTO_FIELD to AutoField

### DIFF
--- a/scionlab/settings/common.py
+++ b/scionlab/settings/common.py
@@ -67,6 +67,9 @@ TEMPLATES = [
     },
 ]
 
+# Use the default primary key field type AutoField (rather than the 64-bit BigAutoField)
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 # ##### DJANGO RUNNING CONFIGURATION ######################
 
 # the URL for static files


### PR DESCRIPTION
This setting is new in django 3.2. Setting it to the default AutoField
does not change the schema, but is required to silence a warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/385)
<!-- Reviewable:end -->
