### PR TITLE
Fix issue when updating TRC, deleting or adding core AS

### DIFF
--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -271,8 +271,10 @@ class AS(TimestampedModel):
         """ returns a queryset of all the latest certificates of this AS """
         certs = Certificate.objects.none()
         for key_usage in Key.USAGES:
-            latest_version = self.keys.filter(usage=key_usage).aggregate(models.Max('version'))['version__max'] or 1
-            certs = certs | Certificate.objects.filter(key__AS=self, key__usage=key_usage, key__version__gte=latest_version)
+            latest_version = self.keys.filter(usage=key_usage).aggregate(models.Max('version'))[
+                                 'version__max'] or 1
+            certs = certs | Certificate.objects.filter(key__AS=self, key__usage=key_usage,
+                                                       key__version__gte=latest_version)
         return certs
 
     def generate_keys(self, not_before=None):
@@ -602,15 +604,15 @@ class InterfaceManager(models.Manager):
         """
         return list of Interfaces from active links
         """
-        return self.filter(link_as_interfaceA__active=True) |\
-            self.filter(link_as_interfaceB__active=True)
+        return self.filter(link_as_interfaceA__active=True) | \
+               self.filter(link_as_interfaceB__active=True)
 
     def inactive(self):
         """
         return list of Interfaces from inactive links
         """
-        return self.filter(link_as_interfaceA__active=False) |\
-            self.filter(link_as_interfaceB__active=False)
+        return self.filter(link_as_interfaceA__active=False) | \
+               self.filter(link_as_interfaceB__active=False)
 
 
 class Interface(models.Model):

--- a/scionlab/models/core.py
+++ b/scionlab/models/core.py
@@ -605,14 +605,14 @@ class InterfaceManager(models.Manager):
         return list of Interfaces from active links
         """
         return self.filter(link_as_interfaceA__active=True) | \
-               self.filter(link_as_interfaceB__active=True)
+            self.filter(link_as_interfaceB__active=True)
 
     def inactive(self):
         """
         return list of Interfaces from inactive links
         """
         return self.filter(link_as_interfaceA__active=False) | \
-               self.filter(link_as_interfaceB__active=False)
+            self.filter(link_as_interfaceB__active=False)
 
 
 class Interface(models.Model):

--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -125,7 +125,7 @@ class _ConfigGeneratorBase:
             self.archive.write_bytes((dir, CERT_DIR, trc.filename()), trc.format_trcfile())
 
     def _write_certs(self, dir):
-        for cert in self.AS.certificates().all():
+        for cert in self.AS.certificates_latest().all():
             self.archive.write_text((dir, CRYPTO_DIR, cert.subdir(), cert.filename()),
                                     cert.format_certfile())
 

--- a/scionlab/tests/test_trc.py
+++ b/scionlab/tests/test_trc.py
@@ -16,13 +16,10 @@ from datetime import datetime, timedelta
 from django.db import transaction
 from django.test import TestCase
 
-from scionlab.scion import as_ids, trcs, certs
+from scionlab.scion import as_ids, trcs
 from scionlab.models.core import ISD, AS
 from scionlab.models.pki import Key, Certificate
 from scionlab.models.trc import TRC, _coreas_certificates
-
-import base64
-from cryptography.hazmat.primitives import serialization
 
 _ASID_1 = 'ff00:0:1'
 _ASID_2 = 'ff00:0:2'
@@ -282,7 +279,8 @@ class TRCCreationTests(TestCase):
         trcs.verify_certificate(loaded_certs, trcs.decode_trc(trc.trc))
 
     def test_broken_delete_one_core_as(self):
-        # Check that validating an invalid / old certificate against an updated TRC fails (regression test)
+        # [regression test] Check that validating an invalid / old certificate fails
+        # against an updated TRC
         self._create_ases()
         prev = TRC.objects.create(self.isd1)
         # remove one core AS
@@ -302,17 +300,20 @@ class TRCCreationTests(TestCase):
         # Check invalid CP AS certificates when selecting old certificate, core
         with self.assertRaises(trcs._CalledProcessErrorWithOutput):
             some_core = AS.objects.filter(is_core=True, isd=self.isd1).first()
-            cert_cp_as = Certificate.objects.filter(key__AS=some_core, key__usage=Key.CP_AS, key__version=1).get()
+            cert_cp_as = Certificate.objects.filter(key__AS=some_core, key__usage=Key.CP_AS,
+                                                    key__version=1).get()
             loaded_certs = bytes(cert_cp_as.format_certfile(), 'ascii')
             trcs.verify_certificate(loaded_certs, trcs.decode_trc(trc.trc))
 
         # Check invalid CP AS certificates when randomly selecting, non-core
         with self.assertRaises(AttributeError):
             any_none_core = AS.objects.filter(is_core=False, isd=self.isd1).first()
-            cert_cp_as = Certificate.objects.filter(key__AS=any_none_core, key__usage=Key.CP_AS, key__version=1).get()
+            cert_cp_as = Certificate.objects.filter(key__AS=any_none_core, key__usage=Key.CP_AS,
+                                                    key__version=1).get()
             certfile = cert_cp_as.format_certfile()
-            # Unreachable code
-            # We should never get there, since the first core AS was deleted and the version 1 cert was referring to it
+            # We should never get further, Unreachable code
+            # The first core AS was deleted and the non-core v1 CP AS cert was referring to
+            # that core AS CA cert
             loaded_certs = bytes(certfile, 'ascii')
             trcs.verify_certificate(loaded_certs, trcs.decode_trc(trc.trc))
 


### PR DESCRIPTION
Fix issue with overwritting certificate with random version of certificate when updating TRC, after changes to the set of core ASes
Add regression test and unit test checking the new behavior of bundling the latest cert version and not some cert version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/387)
<!-- Reviewable:end -->
