### PR TITLE
update circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
 jobs:
   style-check:
     docker:
-      - image: circleci/python:3.6.13
+      - image: cimg/python:3.6.13
     steps:
       - install_git_lfs
       - cached_checkout
@@ -91,7 +91,7 @@ jobs:
 
   unit-tests:
     docker:
-      - image: circleci/python:3.6.13
+      - image: cimg/python:3.6.13
     steps:
       - install_git_lfs
       - cached_checkout


### PR DESCRIPTION
The former image will be deprecated on the 31st Dec. 2021

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/392)
<!-- Reviewable:end -->
