### PR TITLE
ci: bump cache keys to avoid old venv cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-          - v5-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
+          - v6-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
           # fallback to using the latest cache if no exact match is found
-          - v5-dependencies-
+          - v6-dependencies-
 
       - run:
           name: Install dependencies
@@ -66,7 +66,7 @@ commands:
       - save_cache:
           paths:
             - /tmp/venv
-          key: v5-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
+          key: v6-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
 
 
 jobs:


### PR DESCRIPTION
Cached venv is not compatible with python installation in updated images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/394)
<!-- Reviewable:end -->
