### PR TITLE
Fixup for old version in scionlab-config

### DIFF
--- a/scionlab/hostfiles/scionlab-config
+++ b/scionlab/hostfiles/scionlab-config
@@ -36,7 +36,6 @@ import os
 import pathlib
 import shlex
 import shutil
-import string
 import subprocess
 import sys
 import tarfile
@@ -95,8 +94,7 @@ FetchInfo = namedtuple('FetchInfo',
 # services installed by this script.
 ConfigInfo = namedtuple('ConfigInfo',
                         ['files',
-                         'systemd_units',
-                         'version'])
+                         'systemd_units'])
 
 
 def main(argv):
@@ -755,10 +753,8 @@ def _read_config_info(f):
     """
     config_info_dict = json.load(f)
     info = ConfigInfo(config_info_dict['files'],
-                      config_info_dict['systemd_units'],
-                      config_info_dict['version'])
+                      config_info_dict['systemd_units'])
     _sanity_check_file_list(info.files)
-    _sanity_check_version(info.version)
     return info
 
 
@@ -780,18 +776,6 @@ def _sanity_check_file_list(files):
                 or not any(os.path.commonpath([os.path.dirname(f), d]) == d
                            for d in acceptable_dirs)):
             raise ValueError("The list of files has a fishy entry ('%s')." % f)
-
-
-def _sanity_check_version(version):
-    """
-    Sanity check that the version is the expected integer value in a sensible range.
-    """
-    if type(version) is not str \
-            or len(version) < 3 \
-            or len(version) > 40 \
-            or version.count(".") != 1 \
-            or any(c not in "." + string.digits for c in version):
-        raise ValueError("The version info looks fishy.")
 
 
 def _root(path):

--- a/scionlab/tests/test_scionlab-config.py
+++ b/scionlab/tests/test_scionlab-config.py
@@ -188,17 +188,6 @@ class ScionlabConfigUnitTests(TestCase):
             _check_bad([f])  # individual bad fail
             _check_bad(good + [f])  # individual bad with good still fail
 
-    def test_sanity_check_version(self):
-        good = ['0.0', '1.1', '13.10000']
-        bad = [0, 1, 'foo', {}, '1', '123', 1.0, '123.123.13']
-
-        for version in good:
-            scionlab_config._sanity_check_version(version)
-
-        for version in bad:
-            with self.assertRaises(ValueError):
-                scionlab_config._sanity_check_version(version)
-
     def test_resolve_file_conflicts(self):
         # Test setup defines some files and their pseudo sha1 hashes:
         # foo: unchanged


### PR DESCRIPTION
The version sanity for the config info fails for manifest files with the
old versions, so this fails during the upgrade. I had mistakenly assumed
that this sanity check was only applied to the new manifest file. It
turns out that the ConfigInfo does not need the version anyway, so we
can just drop the sanity check altogether.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/398)
<!-- Reviewable:end -->
