### PR TITLE
the scion daemon binary is called now "daemon"

### DIFF
--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -55,7 +55,7 @@ CMDS = {
     Service.CS: 'cs',
     Service.CO: 'co',
     TYPE_BR: 'posix-router',
-    TYPE_SD: 'sciond',
+    TYPE_SD: 'daemon',
 }
 CMD_DISPATCHER = 'dispatcher'
 

--- a/scionlab/tests/data/test_config_tar/user_as_20.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_20.yml
@@ -490,7 +490,7 @@ gen/supervisord.conf: |+
   startretries = 0
   startsecs = 5
   priority = 100
-  command = bin/sciond --config gen/ASffaa_1_5/sd.toml
+  command = bin/daemon --config gen/ASffaa_1_5/sd.toml
 
   [group:as17-ffaa_1_5]
   programs = br-1,cs-1,co-1,sd


### PR DESCRIPTION
Only the supervisor configuration is affected, as the systemd files come from packaging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/400)
<!-- Reviewable:end -->
