### PR TITLE
Enable DRKey everywhere

### DIFF
--- a/scionlab/config_tar.py
+++ b/scionlab/config_tar.py
@@ -34,7 +34,7 @@ _HOSTFILES_DIR = os.path.join(settings.BASE_DIR, "scionlab", "hostfiles")
 # the scionlab-config.json manifest file in the configuration tar ball.
 # This version number should be incremented whenever code changes globally affect the generated
 # configuration of hosts.
-CONFIG_GEN_VERSION = 15
+CONFIG_GEN_VERSION = 16
 
 
 def generate_user_as_config_tar(user_as, archive):

--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -17,6 +17,7 @@ import os
 from collections import OrderedDict
 
 from scionlab.models.core import Service
+from scionlab.models.pki import Key
 from scionlab.models.trc import TRC
 from scionlab.scion.topology import TopologyInfo
 
@@ -315,6 +316,20 @@ class _ConfigBuilder:
             'quic': {
                 'address': _join_host_port(service.host.internal_ip, CS_QUIC_PORT),
             },
+            'drkey': {
+                'drkey_db': {
+                    'connection': '%s.drkey.db' % os.path.join(self.var_dir, service.instance_name),
+                },
+                'cert_file': os.path.join(self.config_dir, 'crypto', 'as', service.AS
+                                          .certificates_latest().get(key__usage=Key.CP_AS)
+                                          .filename()),
+                'key_file': os.path.join(self.config_dir, 'crypto', 'as', 'cp-as.key'),
+                'delegation': {
+                    # the internal IP of all CO services has rights to derive DS "colibri":
+                    'colibri': [str(s.host.internal_ip) for s in service.AS.services
+                                .filter(type=Service.CO).select_related('host')],
+                },
+            },
         })
         if service.AS.is_core:
             conf.update({
@@ -357,6 +372,9 @@ class _ConfigBuilder:
             },
             'trust_db': {
                 'connection': '%s.trust.db' % os.path.join(self.var_dir, instance_name),
+            },
+            'drkey_db': {
+                'connection': '%s.drkey.db' % os.path.join(self.var_dir, instance_name),
             },
         })
         return conf

--- a/scionlab/tests/data/test_config_tar/host_1.yml
+++ b/scionlab/tests/data/test_config_tar/host_1.yml
@@ -498,6 +498,10 @@ etc/scion/cs-1.toml: |
   [ca]
   mode = "in-process"
 
+  [drkey]
+  cert_file = "/etc/scion/crypto/as/ISD17-ASffaa_0_1101.pem"
+  key_file = "/etc/scion/crypto/as/cp-as.key"
+
   [general]
   config_dir = "/etc/scion"
   id = "cs-1"
@@ -517,6 +521,12 @@ etc/scion/cs-1.toml: |
 
   [beaconing.policies]
   propagation = "/etc/scion/beacon_policy.yaml"
+
+  [drkey.delegation]
+  colibri = [ "127.0.0.1",]
+
+  [drkey.drkey_db]
+  connection = "/var/lib/scion/cs-1.drkey.db"
 
   [log.console]
   level = "info"
@@ -603,7 +613,7 @@ scionlab-config.json: |-
       "etc/scion/crypto/voting/ISD17-ASffaa_0_1101.sensitive.crt": "131ec8597fbf56d7f65c9bba48874c5cd64c157a",
       "etc/scion/crypto/voting/regular-voting.key": "48fd836d8c4f7a3cb2bec2045d03a46c2ca99337",
       "etc/scion/crypto/voting/sensitive-voting.key": "0ca15a73e4d864f32228f4687f29505ac093dbfc",
-      "etc/scion/cs-1.toml": "9aa4d5460b518ac50caac845f9e70f1b7918f589",
+      "etc/scion/cs-1.toml": "dce4c4f6293a5cb2d799fa15305eae1df86400a9",
       "etc/scion/keys/master0.key": "9a91ea3b0c0121326d29224de5d444a31c74ef20",
       "etc/scion/keys/master1.key": "9a91ea3b0c0121326d29224de5d444a31c74ef20",
       "etc/scion/topology.json": "c1afb4da9e309ca7a1c697cb0238e41fc84ae96b"
@@ -618,5 +628,5 @@ scionlab-config.json: |-
       "scion-dispatcher.service"
     ],
     "url": "http://localhost:8000",
-    "version": "15.8"
+    "version": "16.8"
   }

--- a/scionlab/tests/data/test_config_tar/host_16.yml
+++ b/scionlab/tests/data/test_config_tar/host_16.yml
@@ -524,6 +524,10 @@ etc/scion/cs-1.toml: |
   origination_interval = "5s"
   propagation_interval = "5s"
 
+  [drkey]
+  cert_file = "/etc/scion/crypto/as/ISD17-ASffaa_1_1.pem"
+  key_file = "/etc/scion/crypto/as/cp-as.key"
+
   [general]
   config_dir = "/etc/scion"
   id = "cs-1"
@@ -543,6 +547,12 @@ etc/scion/cs-1.toml: |
 
   [beaconing.policies]
   propagation = "/etc/scion/beacon_policy.yaml"
+
+  [drkey.delegation]
+  colibri = [ "127.0.0.1",]
+
+  [drkey.drkey_db]
+  connection = "/var/lib/scion/cs-1.drkey.db"
 
   [log.console]
   level = "info"
@@ -605,7 +615,7 @@ scionlab-config.json: |-
       "etc/scion/co-1.toml": "5f44683ff73c2f105908e20476b8a6f9a17caf26",
       "etc/scion/crypto/as/ISD17-ASffaa_1_1.pem": "d7c2c86acea31bb986430baf5994d8ed5ac6d5df",
       "etc/scion/crypto/as/cp-as.key": "5fac5f3c239a6f9b7bac858977e806e2003d8f52",
-      "etc/scion/cs-1.toml": "84467cd10682d975caeccba3a7eaaec1bd9ea858",
+      "etc/scion/cs-1.toml": "184cd6d33fe54808104a3a73e7f82f3c4823f308",
       "etc/scion/keys/master0.key": "5b95d59a993b11fe65e3ca747ed6c3ea7293a70d",
       "etc/scion/keys/master1.key": "5b95d59a993b11fe65e3ca747ed6c3ea7293a70d",
       "etc/scion/topology.json": "2b3ad3b6e2e899c60cb128c45d5adb862ecda9e4"
@@ -620,5 +630,5 @@ scionlab-config.json: |-
       "scion-dispatcher.service"
     ],
     "url": "http://localhost:8000",
-    "version": "15.6"
+    "version": "16.6"
   }

--- a/scionlab/tests/data/test_config_tar/host_17.yml
+++ b/scionlab/tests/data/test_config_tar/host_17.yml
@@ -401,6 +401,10 @@ etc/scion/cs-1.toml: |
   origination_interval = "5s"
   propagation_interval = "5s"
 
+  [drkey]
+  cert_file = "/etc/scion/crypto/as/ISD19-ASffaa_1_2.pem"
+  key_file = "/etc/scion/crypto/as/cp-as.key"
+
   [general]
   config_dir = "/etc/scion"
   id = "cs-1"
@@ -420,6 +424,12 @@ etc/scion/cs-1.toml: |
 
   [beaconing.policies]
   propagation = "/etc/scion/beacon_policy.yaml"
+
+  [drkey.delegation]
+  colibri = [ "127.0.0.1",]
+
+  [drkey.drkey_db]
+  connection = "/var/lib/scion/cs-1.drkey.db"
 
   [log.console]
   level = "info"
@@ -482,7 +492,7 @@ scionlab-config.json: |-
       "etc/scion/co-1.toml": "5f44683ff73c2f105908e20476b8a6f9a17caf26",
       "etc/scion/crypto/as/ISD19-ASffaa_1_2.pem": "7e8a1969e90d904cb13266ea0141b52b9f42cf24",
       "etc/scion/crypto/as/cp-as.key": "c4f2edd92dc88ddfc81c1515500b24f1038da1c3",
-      "etc/scion/cs-1.toml": "84467cd10682d975caeccba3a7eaaec1bd9ea858",
+      "etc/scion/cs-1.toml": "c9a497ae0a7310205b4ab78afaf0a1a6f3a7dbeb",
       "etc/scion/keys/master0.key": "f1f0ecf7545ffa2035579bfaa0f4b4921df250ec",
       "etc/scion/keys/master1.key": "f1f0ecf7545ffa2035579bfaa0f4b4921df250ec",
       "etc/scion/topology.json": "d4e69284d31d71a05528cb99855899ad63f85695"
@@ -497,5 +507,5 @@ scionlab-config.json: |-
       "scion-dispatcher.service"
     ],
     "url": "http://localhost:8000",
-    "version": "15.5"
+    "version": "16.5"
   }

--- a/scionlab/tests/data/test_config_tar/host_4.yml
+++ b/scionlab/tests/data/test_config_tar/host_4.yml
@@ -530,6 +530,10 @@ etc/scion/cs-1.toml: |
   origination_interval = "5s"
   propagation_interval = "5s"
 
+  [drkey]
+  cert_file = "/etc/scion/crypto/as/ISD17-ASffaa_0_1107.pem"
+  key_file = "/etc/scion/crypto/as/cp-as.key"
+
   [general]
   config_dir = "/etc/scion"
   id = "cs-1"
@@ -549,6 +553,12 @@ etc/scion/cs-1.toml: |
 
   [beaconing.policies]
   propagation = "/etc/scion/beacon_policy.yaml"
+
+  [drkey.delegation]
+  colibri = [ "127.0.0.1",]
+
+  [drkey.drkey_db]
+  connection = "/var/lib/scion/cs-1.drkey.db"
 
   [log.console]
   level = "info"
@@ -624,7 +634,7 @@ scionlab-config.json: |-
       "etc/scion/co-1.toml": "5f44683ff73c2f105908e20476b8a6f9a17caf26",
       "etc/scion/crypto/as/ISD17-ASffaa_0_1107.pem": "e4239e470a5b169d71c135b66bed25ebd4902129",
       "etc/scion/crypto/as/cp-as.key": "106b5e0c2b178641c9fdc99bc1d7a99e712c7197",
-      "etc/scion/cs-1.toml": "84467cd10682d975caeccba3a7eaaec1bd9ea858",
+      "etc/scion/cs-1.toml": "7922708831c71fb9b0c185e3690586e3b94171a4",
       "etc/scion/keys/master0.key": "7b87dcf6b8fda0f0facd3efb3e3b84c1c5c58cb1",
       "etc/scion/keys/master1.key": "7b87dcf6b8fda0f0facd3efb3e3b84c1c5c58cb1",
       "etc/scion/topology.json": "8cc26714431b5044f160f28ef10d22a6d1a81c0d"
@@ -640,5 +650,5 @@ scionlab-config.json: |-
       "scion-dispatcher.service"
     ],
     "url": "http://localhost:8000",
-    "version": "15.10"
+    "version": "16.10"
   }

--- a/scionlab/tests/data/test_config_tar/user_as_18.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_18.yml
@@ -403,6 +403,10 @@ etc/scion/cs-1.toml: |
   origination_interval = "5s"
   propagation_interval = "5s"
 
+  [drkey]
+  cert_file = "/etc/scion/crypto/as/ISD20-ASffaa_1_3.pem"
+  key_file = "/etc/scion/crypto/as/cp-as.key"
+
   [general]
   config_dir = "/etc/scion"
   id = "cs-1"
@@ -422,6 +426,12 @@ etc/scion/cs-1.toml: |
 
   [beaconing.policies]
   propagation = "/etc/scion/beacon_policy.yaml"
+
+  [drkey.delegation]
+  colibri = [ "127.0.0.1",]
+
+  [drkey.drkey_db]
+  connection = "/var/lib/scion/cs-1.drkey.db"
 
   [log.console]
   level = "info"
@@ -483,7 +493,7 @@ scionlab-config.json: |-
       "etc/scion/co-1.toml": "5f44683ff73c2f105908e20476b8a6f9a17caf26",
       "etc/scion/crypto/as/ISD20-ASffaa_1_3.pem": "ba1b681c70af686558bec871e519f396a14019e9",
       "etc/scion/crypto/as/cp-as.key": "0fc4fdc2abf7d5aa5d5029b9bd0700977b3da85f",
-      "etc/scion/cs-1.toml": "84467cd10682d975caeccba3a7eaaec1bd9ea858",
+      "etc/scion/cs-1.toml": "7b22a10f14b2fcfb6b22133d64e1a7c99d7a6651",
       "etc/scion/keys/master0.key": "d36156acb222984eb19866acf01f80b14326b310",
       "etc/scion/keys/master1.key": "d36156acb222984eb19866acf01f80b14326b310",
       "etc/scion/topology.json": "c4c65f6f792007d668b06c42819940cc74a717de"
@@ -498,5 +508,5 @@ scionlab-config.json: |-
       "scion-dispatcher.service"
     ],
     "url": "http://localhost:8000",
-    "version": "15.5"
+    "version": "16.5"
   }

--- a/scionlab/tests/data/test_config_tar/user_as_19.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_19.yml
@@ -526,6 +526,10 @@ etc/scion/cs-1.toml: |
   origination_interval = "5s"
   propagation_interval = "5s"
 
+  [drkey]
+  cert_file = "/etc/scion/crypto/as/ISD20-ASffaa_1_4.pem"
+  key_file = "/etc/scion/crypto/as/cp-as.key"
+
   [general]
   config_dir = "/etc/scion"
   id = "cs-1"
@@ -545,6 +549,12 @@ etc/scion/cs-1.toml: |
 
   [beaconing.policies]
   propagation = "/etc/scion/beacon_policy.yaml"
+
+  [drkey.delegation]
+  colibri = [ "127.0.0.1",]
+
+  [drkey.drkey_db]
+  connection = "/var/lib/scion/cs-1.drkey.db"
 
   [log.console]
   level = "info"
@@ -607,7 +617,7 @@ scionlab-config.json: |-
       "etc/scion/co-1.toml": "5f44683ff73c2f105908e20476b8a6f9a17caf26",
       "etc/scion/crypto/as/ISD20-ASffaa_1_4.pem": "328dc2230dc2354f84c54955f3c27b062f3156f9",
       "etc/scion/crypto/as/cp-as.key": "5b108e8bcb9ae6dddaef910bace302e143b0f5a9",
-      "etc/scion/cs-1.toml": "84467cd10682d975caeccba3a7eaaec1bd9ea858",
+      "etc/scion/cs-1.toml": "c92e12f965614db9300f4f2b77cd98e8f986b5e8",
       "etc/scion/keys/master0.key": "df4e0ab5188491c3993e5718deae6c7bf9f653b1",
       "etc/scion/keys/master1.key": "df4e0ab5188491c3993e5718deae6c7bf9f653b1",
       "etc/scion/topology.json": "e71204be12f25cba1a3bd34c71af1e1cc47875b3"
@@ -622,5 +632,5 @@ scionlab-config.json: |-
       "scion-dispatcher.service"
     ],
     "url": "http://localhost:8000",
-    "version": "15.6"
+    "version": "16.6"
   }

--- a/scionlab/tests/data/test_config_tar/user_as_20.yml
+++ b/scionlab/tests/data/test_config_tar/user_as_20.yml
@@ -403,6 +403,10 @@ gen/ASffaa_1_5/cs-1.toml: |
   origination_interval = "5s"
   propagation_interval = "5s"
 
+  [drkey]
+  cert_file = "gen/ASffaa_1_5/crypto/as/ISD17-ASffaa_1_5.pem"
+  key_file = "gen/ASffaa_1_5/crypto/as/cp-as.key"
+
   [general]
   config_dir = "gen/ASffaa_1_5"
   id = "cs-1"
@@ -423,6 +427,12 @@ gen/ASffaa_1_5/cs-1.toml: |
   [beaconing.policies]
   propagation = "gen/ASffaa_1_5/beacon_policy.yaml"
 
+  [drkey.delegation]
+  colibri = [ "127.0.0.1",]
+
+  [drkey.drkey_db]
+  connection = "gen-cache/cs-1.drkey.db"
+
   [log.console]
   level = "info"
 gen/ASffaa_1_5/keys/master0.key: |-
@@ -430,6 +440,9 @@ gen/ASffaa_1_5/keys/master0.key: |-
 gen/ASffaa_1_5/keys/master1.key: |-
   yXRsWitUgTwm/BQ1jl/zgw==
 gen/ASffaa_1_5/sd.toml: |
+  [drkey_db]
+  connection = "gen-cache/sd.drkey.db"
+
   [general]
   config_dir = "gen/ASffaa_1_5"
   id = "sd"


### PR DESCRIPTION
Enable DRKey in all CSs.
Because of PR https://github.com/netsec-ethz/scion/pull/104 that adds DRKey usage to COLIBRI, the configuration of DRKey is no longer optional.
Make the Coordinator write configuration for the SD and CS:

- SD must configure a drkey DB
- CS configures a drkey DB, a certificate file, a key file and a delegation list (for the "colibri" protocol)

Still TODO:
- [x] Do we need to bump `CONFIG_GEN_VERSION`? (all hosts must get a new configuration; looks like the answer is yes)
- [x] Merge https://github.com/netsec-ethz/scion/pull/104

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/403)
<!-- Reviewable:end -->
