### PR TITLE
admin: remove left-over reference to obsolete action

### DIFF
--- a/scionlab/admin.py
+++ b/scionlab/admin.py
@@ -442,7 +442,7 @@ class ASAdmin(admin.ModelAdmin):
             return queryset
 
     inlines = [InterfaceInline, BorderRouterInline, ServiceInline, HostInline]
-    actions = ['update_keys', 'update_core_keys', 'trigger_config_deployment']
+    actions = ['update_keys', 'update_core_keys']
     list_display = ('isd', 'as_id', 'owner', 'label', 'is_core', 'is_ap', 'is_userAS')
     list_display_links = ('as_id', 'label')
     list_filter = ('isd', 'is_core', InfrastructureASFilter)
@@ -744,7 +744,6 @@ class LinkAdmin(admin.ModelAdmin):
 class HostAdmin(HostAdminMixin, admin.ModelAdmin):
     form = HostAdminForm
     readonly_fields = ['uid', 'get_scionlab_config_cmd']
-    actions = ['trigger_config_deployment']
     list_display = ('__str__', 'AS',
                     'internal_ip', 'public_ip', 'bind_ip', 'ssh_host',
                     'latest_config_deployed', 'get_scionlab_config_cmd', 'get_config_link')


### PR DESCRIPTION
Remove left-over registration for trigger_config_deployment action,
which was removed in #313.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/405)
<!-- Reviewable:end -->
