### PR TITLE
test runner is no longer nose, change silent argument to -v0

### DIFF
--- a/scripts/recreate-test-results.sh
+++ b/scripts/recreate-test-results.sh
@@ -15,4 +15,4 @@
 
 
 # recreate expected output in scionlab/tests/data/test_config_tar/
-RECREATE_TEST_RESULTS=1 python manage.py test -s scionlab.tests.test_config_tar
+RECREATE_TEST_RESULTS=1 python manage.py test -v0 scionlab.tests.test_config_tar


### PR DESCRIPTION
`manage.py test -s` does not work

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/415)
<!-- Reviewable:end -->
