### PR TITLE
checkout master tracking it CI upgrade test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,8 +198,7 @@ jobs:
       - run:
           name: OLD -- Checkout
           command: |
-            git checkout master
-            git pull --ff-only  # may be stale
+            git checkout --force -B master --track origin/master
       - run:
           name: OLD -- Build and start containers for coordinator and ASes
           command: |


### PR DESCRIPTION
CI runs the upgrade test by building `master`. To do so, it runs
```shell
git checkout master
git pull --ff-only  # may be stale
```
But it could happen that `master` was already checked out in `.git` and recover by the cache, and thus the branch will be local only (or whatever the cache had) and `git pull` will fail.

Instead run
```shell
git checkout --force -B master --track origin/master
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/422)
<!-- Reviewable:end -->
