### PR TITLE
Dispatcherless SCION

### DIFF
--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -324,9 +324,6 @@ class _ConfigBuilder:
             'trust_db': {
                 'connection': '%s.trust.db' % os.path.join(self.var_dir, service.instance_name),
             },
-            'quic': {
-                'address': _join_host_port(service.host.internal_ip, CS_QUIC_PORT),
-            },
         })
         if service.AS.is_core:
             conf.update({

--- a/scionlab/scion/config.py
+++ b/scionlab/scion/config.py
@@ -370,7 +370,6 @@ class _ConfigBuilder:
                 'id': instance_name,
                 'config_dir': self.config_dir,
                 # Note: this has performance impacts (for BR, only control plane)
-                'reconnect_to_dispatcher': True,
             },
             # XXX: enable header v2 in features? or better flip the default in our builds?
         }

--- a/scionlab/scion/topology.py
+++ b/scionlab/scion/topology.py
@@ -61,6 +61,8 @@ class TopologyInfo:
         self.topo["isd_as"] = self.AS.isd_as_str()
         self.topo["mtu"] = self.AS.mtu
         self.topo["attributes"] = CORE_ATTRIBUTES if self.AS.is_core else []
+        self.topo["test_dispatcher"] = True
+        self.topo["dispatched_ports"] = "31000-32767"
 
         _topo_add_routers(self.topo, self.routers)
         _topo_add_control_services(self.topo, self.services)


### PR DESCRIPTION
Update from `scionproto` that includes the dispatcher-less version of SCION clients and border routers.
Affects configuration and API.
Breaking change.