### PR TITLE
Renew slack link (30 days only).

### DIFF
--- a/scionlab/templates/scionlab/base.html
+++ b/scionlab/templates/scionlab/base.html
@@ -83,7 +83,7 @@
     <div class="container text-muted mt-4">
       <ul class="list-inline">
         <li class="list-inline-item mr-4"><a href="mailto:scionlab-admins@sympa.ethz.ch"><span class="fa fa-envelope"></span> Contact</a></li>
-        <li class="list-inline-item mr-4"><a href="https://join.slack.com/t/scionproto/shared_invite/zt-2smf6rnhh-aVs5MfXkdrrhtT2XzP_YLA"><span class="fa fa-slack"></span> SLACK</a></li>
+        <li class="list-inline-item mr-4"><a href="https://join.slack.com/t/scionproto/shared_invite/zt-2mhzmqe84-cWs~UuTYT7kwtlU7_2X3lg"><span class="fa fa-slack"></span> SLACK</a></li>
         <li class="list-inline-item mr-4"><a href="https://lists.inf.ethz.ch/mailman/listinfo/scion"><span class="fa fa-users"></span> SCION community mailing list</a></li>
         <li class="list-inline-item mr-4"><a href="https://docs.scionlab.org/">Documentation</a></li>
         <li class="list-inline-item"><a href="https://docs.scionlab.org/content/faq/">FAQ</a></li>

--- a/scionlab/templates/scionlab/base.html
+++ b/scionlab/templates/scionlab/base.html
@@ -83,7 +83,7 @@
     <div class="container text-muted mt-4">
       <ul class="list-inline">
         <li class="list-inline-item mr-4"><a href="mailto:scionlab-admins@sympa.ethz.ch"><span class="fa fa-envelope"></span> Contact</a></li>
-        <li class="list-inline-item mr-4"><a href="https://join.slack.com/t/scionproto/shared_invite/zt-1gtgkuvk3-vQzq3gPOWOL6T58yu45vXg"><span class="fa fa-slack"></span> SLACK</a></li>
+        <li class="list-inline-item mr-4"><a href="https://join.slack.com/t/scionproto/shared_invite/zt-2smf6rnhh-aVs5MfXkdrrhtT2XzP_YLA"><span class="fa fa-slack"></span> SLACK</a></li>
         <li class="list-inline-item mr-4"><a href="https://lists.inf.ethz.ch/mailman/listinfo/scion"><span class="fa fa-users"></span> SCION community mailing list</a></li>
         <li class="list-inline-item mr-4"><a href="https://docs.scionlab.org/">Documentation</a></li>
         <li class="list-inline-item"><a href="https://docs.scionlab.org/content/faq/">FAQ</a></li>


### PR DESCRIPTION
The Slack link shown in the webpage is expired. The new one is valid for 30 days only.

- [x] Additionally, it would be nice to find out how to automate this renewal process, and not have us remember / be notified of the expired one.
- [x] Double check that the link does not expire anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scionlab/478)
<!-- Reviewable:end -->
